### PR TITLE
Update tool call state when permissions are rejected

### DIFF
--- a/src/stores/instances.ts
+++ b/src/stores/instances.ts
@@ -544,9 +544,6 @@ async function sendPermissionResponse(
       path: { id: sessionId, permissionID: permissionId },
       body: { response }
     })
-
-    // Remove from queue after successful response
-    removePermissionFromQueue(instanceId, permissionId)
   } catch (error) {
     console.error("Failed to send permission response:", error)
     throw error


### PR DESCRIPTION
## Summary

Implements proper handling of permission rejections by updating tool call state in the message history when the server confirms a rejection, preventing the agent from thinking the tool call is still pending. I was getting annoyed by this, because I'd reject a proposed edit based on the diff, and then when I suggested how to make a new diff that's up to my standards, the agent would assume the previous diff had been accepted and try to edit non-existent code. This resolves that issue.

## What Changed

- **Permission Queue "Double-Free" Fix**: Removed premature queue clearing in `sendPermissionResponse()` that was causing permissions to be removed before the SSE `permission.replied` event arrived, which was not only redundant (afaict) but meant that we don't have enough information to update the client's state (especially message history, but also theoretically the UI) based on server confirmation
- **Tool Call State Management**: Added `updateToolCallToErrorState()` function called in `handlePermissionReplied`, to manually update tool call state to "error" when permissions are rejected (this matches what happens with other tools, and with the OpenCode TUI, as far as I can tell)

## Technical Details

### Why Manual Updates Are Needed for Rejections

The architecture has an important distinction:
- **For "once"/"always" (approved)**: Server executes the tool and sends `message.part.updated` events as the tool transitions through states (pending → running → completed/error)
- **For "reject"**: Server doesn't execute the tool at all, so there's no execution to report via `message.part.updated`
- The server only sends `permission.replied` event, which doesn't include updated tool state
- Therefore, the client must manually update the UI to reflect the rejected state