### PR TITLE
feat(ui/qol): add copy button to message items

### DIFF
--- a/packages/ui/src/components/message-item.tsx
+++ b/packages/ui/src/components/message-item.tsx
@@ -16,7 +16,7 @@ interface MessageItemProps {
   showAgentMeta?: boolean
   onContentRendered?: () => void
  }
- 
+
  export default function MessageItem(props: MessageItemProps) {
   const [copied, setCopied] = createSignal(false)
 
@@ -37,7 +37,7 @@ interface MessageItemProps {
   }
 
   const messageParts = () => props.parts
- 
+
   const fileAttachments = () =>
     messageParts().filter((part): part is FilePart => part?.type === "file" && typeof (part as FilePart).url === "string")
 
@@ -146,7 +146,7 @@ interface MessageItemProps {
 
   const getRawContent = () => {
     return props.parts
-      .filter(part => part.type === "text" || part.type === "reasoning")
+      .filter(part => part.type === "text")
       .map(part => (part as { text?: string }).text || "")
       .filter(text => text.trim().length > 0)
       .join("\n\n")


### PR DESCRIPTION
Add a Copy button that allows users to copy raw message contents (text and reasoning parts) to clipboard. The button appears on all messages - alongside Revert/Fork for user messages, and standalone for assistant messages. Shows "Copied!" feedback for 2 seconds after clicking.

Tested on electron and tauri on dev builds, both work as expected. 

<img width="274" height="377" alt="image" src="https://github.com/user-attachments/assets/e946a25e-69ff-43ef-8714-eb52d426663d" />
