### PR TITLE
feat(ui): add MCP, provider settings, and model defaults panels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
         "7zip-bin": "^5.2.0",
         "google-auth-library": "^10.5.0"
       },
+      "devDependencies": {
+        "@rollup/rollup-darwin-arm64": "^4.53.3"
+      },
       "workspaces": {
         "packages": [
           "packages/*"
@@ -1306,6 +1309,47 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.5.tgz",
+      "integrity": "sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.5.tgz",
+      "integrity": "sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
+      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "os": [
+        "darwin"
+      ]
+    },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.52.5",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.5.tgz",
@@ -1318,6 +1362,258 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.5.tgz",
+      "integrity": "sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.5.tgz",
+      "integrity": "sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.5.tgz",
+      "integrity": "sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.5.tgz",
+      "integrity": "sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.5.tgz",
+      "integrity": "sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.5.tgz",
+      "integrity": "sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.5.tgz",
+      "integrity": "sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.5.tgz",
+      "integrity": "sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.5.tgz",
+      "integrity": "sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.5.tgz",
+      "integrity": "sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.5.tgz",
+      "integrity": "sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.5.tgz",
+      "integrity": "sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.5.tgz",
+      "integrity": "sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.5.tgz",
+      "integrity": "sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.5.tgz",
+      "integrity": "sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.5.tgz",
+      "integrity": "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@shikijs/core": {
@@ -7400,6 +7696,20 @@
         "@rollup/rollup-win32-x64-msvc": "4.52.5",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.5.tgz",
+      "integrity": "sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "dependencies": {
     "7zip-bin": "^5.2.0",
     "google-auth-library": "^10.5.0"
+  },
+  "devDependencies": {
+    "@rollup/rollup-darwin-arm64": "^4.53.3"
   }
 }

--- a/packages/server/src/api-types.ts
+++ b/packages/server/src/api-types.ts
@@ -213,6 +213,8 @@ export interface ServerMeta {
   hostLabel: string
   /** Absolute path of the filesystem root exposed to clients. */
   workspaceRoot: string
+  /** True when the server allows browsing the full filesystem. */
+  unrestrictedRoot?: boolean
   /** Reachable addresses for this server, external first. */
   addresses: NetworkAddress[]
   /** Optional metadata about the most recent public release. */

--- a/packages/server/src/config/schema.ts
+++ b/packages/server/src/config/schema.ts
@@ -8,6 +8,25 @@ const ModelPreferenceSchema = z.object({
 const AgentModelSelectionSchema = z.record(z.string(), ModelPreferenceSchema)
 const AgentModelSelectionsSchema = z.record(z.string(), AgentModelSelectionSchema)
 
+const McpLocalServerConfigSchema = z.object({
+  type: z.literal("local"),
+  command: z.array(z.string()).min(1),
+  environment: z.record(z.string()).optional(),
+  enabled: z.boolean().optional(),
+  timeout: z.number().int().positive().optional(),
+})
+
+const McpRemoteServerConfigSchema = z.object({
+  type: z.literal("remote"),
+  url: z.string(),
+  headers: z.record(z.string()).optional(),
+  oauth: z.union([z.boolean(), z.record(z.unknown())]).optional(),
+  enabled: z.boolean().optional(),
+  timeout: z.number().int().positive().optional(),
+})
+
+const McpServerConfigSchema = z.union([McpLocalServerConfigSchema, McpRemoteServerConfigSchema])
+
 const PreferencesSchema = z.object({
   showThinkingBlocks: z.boolean().default(false),
   thinkingBlocksExpansion: z.enum(["expanded", "collapsed"]).default("expanded"),
@@ -21,6 +40,12 @@ const PreferencesSchema = z.object({
   showUsageMetrics: z.boolean().default(true),
   autoCleanupBlankSessions: z.boolean().default(true),
   listeningMode: z.enum(["local", "all"]).default("local"),
+
+  modelDefaultsByAgent: z.record(ModelPreferenceSchema).default({}),
+
+  mcpRegistry: z.record(McpServerConfigSchema).default({}),
+  mcpDesiredState: z.record(z.boolean()).default({}),
+  mcpAutoApply: z.boolean().default(true),
 })
 
 const RecentFolderSchema = z.object({
@@ -48,6 +73,9 @@ export {
   ModelPreferenceSchema,
   AgentModelSelectionSchema,
   AgentModelSelectionsSchema,
+  McpLocalServerConfigSchema,
+  McpRemoteServerConfigSchema,
+  McpServerConfigSchema,
   PreferencesSchema,
   RecentFolderSchema,
   OpenCodeBinarySchema,
@@ -58,6 +86,9 @@ export {
 export type ModelPreference = z.infer<typeof ModelPreferenceSchema>
 export type AgentModelSelection = z.infer<typeof AgentModelSelectionSchema>
 export type AgentModelSelections = z.infer<typeof AgentModelSelectionsSchema>
+export type McpLocalServerConfig = z.infer<typeof McpLocalServerConfigSchema>
+export type McpRemoteServerConfig = z.infer<typeof McpRemoteServerConfigSchema>
+export type McpServerConfig = z.infer<typeof McpServerConfigSchema>
 export type Preferences = z.infer<typeof PreferencesSchema>
 export type RecentFolder = z.infer<typeof RecentFolderSchema>
 export type OpenCodeBinary = z.infer<typeof OpenCodeBinarySchema>

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -147,6 +147,7 @@ async function main() {
     port: options.port,
     hostLabel: options.host,
     workspaceRoot: options.rootDir,
+    unrestrictedRoot: options.unrestrictedRoot,
     addresses: [],
   }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -43,9 +43,11 @@ import {
   setActiveParentSession,
   clearActiveParentSession,
   createSession,
+  forkSession,
   fetchSessions,
   updateSessionAgent,
   updateSessionModel,
+  getActiveSession,
 } from "./stores/sessions"
 
 const log = getLogger("actions")

--- a/packages/ui/src/components/advanced-settings-modal.tsx
+++ b/packages/ui/src/components/advanced-settings-modal.tsx
@@ -1,7 +1,11 @@
 import { Component } from "solid-js"
 import { Dialog } from "@kobalte/core/dialog"
+import { Terminal, Settings2, Plug, Variable } from "lucide-solid"
 import OpenCodeBinarySelector from "./opencode-binary-selector"
 import EnvironmentVariablesEditor from "./environment-variables-editor"
+import ModelDefaultsPanel from "./model-defaults-panel"
+import ProviderSettingsPanel from "./provider-settings-panel"
+import McpSettingsPanel from "./mcp-settings-panel"
 
 interface AdvancedSettingsModalProps {
   open: boolean
@@ -17,34 +21,52 @@ const AdvancedSettingsModal: Component<AdvancedSettingsModalProps> = (props) => 
       <Dialog.Portal>
         <Dialog.Overlay class="modal-overlay" />
         <div class="fixed inset-0 z-50 flex items-center justify-center p-4">
-          <Dialog.Content class="modal-surface w-full max-w-5xl max-h-[90vh] flex flex-col overflow-hidden">
-            <header class="px-6 py-4 border-b" style={{ "border-color": "var(--border-base)" }}>
+          <Dialog.Content class="modal-surface w-full max-w-4xl max-h-[90vh] flex flex-col overflow-hidden">
+            <header class="modal-header">
               <Dialog.Title class="text-xl font-semibold text-primary">Advanced Settings</Dialog.Title>
+              <p class="text-sm text-secondary mt-1">Configure OpenCode instances, providers, and environment</p>
             </header>
 
-            <div class="flex-1 overflow-y-auto p-6 space-y-6">
-              <OpenCodeBinarySelector
-                selectedBinary={props.selectedBinary}
-                onBinaryChange={props.onBinaryChange}
-                disabled={Boolean(props.isLoading)}
-                isVisible={props.open}
-              />
+            <div class="modal-body">
+              {/* Session Configuration Group */}
+              <div class="modal-section">
+                <div class="modal-section-header">
+                  <Terminal />
+                  <span>Session Configuration</span>
+                </div>
+                <OpenCodeBinarySelector
+                  selectedBinary={props.selectedBinary}
+                  onBinaryChange={props.onBinaryChange}
+                  disabled={Boolean(props.isLoading)}
+                  isVisible={props.open}
+                />
+                <ModelDefaultsPanel />
+              </div>
 
-              <div class="panel">
-                <div class="panel-header">
-                  <h3 class="panel-title">Environment Variables</h3>
-                  <p class="panel-subtitle">Applied whenever a new OpenCode instance starts</p>
+              {/* Connections Group */}
+              <div class="modal-section">
+                <div class="modal-section-header">
+                  <Plug />
+                  <span>Connections</span>
                 </div>
-                <div class="panel-body">
-                  <EnvironmentVariablesEditor disabled={Boolean(props.isLoading)} />
+                <ProviderSettingsPanel />
+                <McpSettingsPanel />
+              </div>
+
+              {/* Environment Group */}
+              <div class="modal-section">
+                <div class="modal-section-header">
+                  <Variable />
+                  <span>Environment</span>
                 </div>
+                <EnvironmentVariablesEditor disabled={Boolean(props.isLoading)} />
               </div>
             </div>
 
-            <div class="px-6 py-4 border-t flex justify-end" style={{ "border-color": "var(--border-base)" }}>
+            <div class="modal-footer">
               <button
                 type="button"
-                class="selector-button selector-button-secondary"
+                class="modal-button modal-button--ghost"
                 onClick={props.onClose}
               >
                 Close

--- a/packages/ui/src/components/environment-variables-editor.tsx
+++ b/packages/ui/src/components/environment-variables-editor.tsx
@@ -51,95 +51,96 @@ const EnvironmentVariablesEditor: Component<EnvironmentVariablesEditorProps> = (
   }
 
   return (
-    <div class="space-y-3">
-      <div class="flex items-center gap-2 mb-3">
-        <Globe class="w-4 h-4 icon-muted" />
-        <span class="text-sm font-medium text-secondary">Environment Variables</span>
-        <span class="text-xs text-muted">
-          ({entries().length} variable{entries().length !== 1 ? "s" : ""})
-        </span>
+    <div class="panel">
+      <div class="panel-header">
+        <h3 class="panel-title">Environment Variables</h3>
+        <p class="panel-subtitle">
+          Applied whenever a new OpenCode instance starts ({entries().length} variable{entries().length !== 1 ? "s" : ""})
+        </p>
       </div>
 
-      {/* Existing variables */}
-      <Show when={entries().length > 0}>
-        <div class="space-y-2">
-          <For each={entries()}>
-            {([key, value]) => (
-              <div class="flex items-center gap-2">
-                <div class="flex-1 flex items-center gap-2">
-                  <Key class="w-3.5 h-3.5 icon-muted flex-shrink-0" />
-                  <input
-                    type="text"
-                    value={key}
+      <div class="panel-body" style={{ gap: "var(--space-md)" }}>
+        {/* Existing variables */}
+        <Show when={entries().length > 0}>
+          <div class="flex flex-col" style={{ gap: "var(--space-sm)" }}>
+            <For each={entries()}>
+              {([key, value]) => (
+                <div class="flex items-center" style={{ gap: "var(--space-sm)" }}>
+                  <div class="flex-1 flex items-center" style={{ gap: "var(--space-sm)" }}>
+                    <Key class="w-3.5 h-3.5 icon-muted flex-shrink-0" />
+                    <input
+                      type="text"
+                      value={key}
+                      disabled
+                      class="modal-input flex-1 min-w-[160px] opacity-70 cursor-not-allowed"
+                      placeholder="Variable name"
+                      title="Variable name (read-only)"
+                    />
+                    <input
+                      type="text"
+                      value={value}
+                      disabled={props.disabled}
+                      onInput={(e) => handleUpdateVariable(key, e.currentTarget.value)}
+                      class="modal-input flex-1 min-w-[200px]"
+                      placeholder="Variable value"
+                    />
+                  </div>
+                  <button
+                    onClick={() => handleRemoveVariable(key)}
                     disabled={props.disabled}
-                    class="flex-1 px-2.5 py-1.5 text-sm bg-surface-secondary border border-base rounded text-muted cursor-not-allowed"
-                    placeholder="Variable name"
-                    title="Variable name (read-only)"
-                  />
-                  <input
-                    type="text"
-                    value={value}
-                    disabled={props.disabled}
-                    onInput={(e) => handleUpdateVariable(key, e.currentTarget.value)}
-                    class="flex-1 px-2.5 py-1.5 text-sm bg-surface-base border border-base rounded text-primary focus-ring-accent disabled:opacity-50 disabled:cursor-not-allowed"
-                    placeholder="Variable value"
-                  />
+                    class="modal-button modal-button--danger p-2"
+                    title="Remove variable"
+                  >
+                    <Trash2 class="w-3.5 h-3.5" />
+                  </button>
                 </div>
-                <button
-                  onClick={() => handleRemoveVariable(key)}
-                  disabled={props.disabled}
-                  class="p-1.5 icon-muted icon-danger-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                  title="Remove variable"
-                >
-                  <Trash2 class="w-3.5 h-3.5" />
-                </button>
-              </div>
-            )}
-          </For>
-        </div>
-      </Show>
+              )}
+            </For>
+          </div>
+        </Show>
 
-      {/* Add new variable */}
-      <div class="flex items-center gap-2 pt-2 border-t border-base">
-        <div class="flex-1 flex items-center gap-2">
-          <Key class="w-3.5 h-3.5 icon-muted flex-shrink-0" />
-          <input
-            type="text"
-            value={newKey()}
-            onInput={(e) => setNewKey(e.currentTarget.value)}
-            onKeyPress={handleKeyPress}
-            disabled={props.disabled}
-            class="flex-1 px-2.5 py-1.5 text-sm bg-surface-base border border-base rounded text-primary focus-ring-accent disabled:opacity-50 disabled:cursor-not-allowed"
-            placeholder="Variable name"
-          />
-          <input
-            type="text"
-            value={newValue()}
-            onInput={(e) => setNewValue(e.currentTarget.value)}
-            onKeyPress={handleKeyPress}
-            disabled={props.disabled}
-            class="flex-1 px-2.5 py-1.5 text-sm bg-surface-base border border-base rounded text-primary focus-ring-accent disabled:opacity-50 disabled:cursor-not-allowed"
-            placeholder="Variable value"
-          />
+        {/* Add new variable */}
+        <div class="flex items-center pt-3 border-t border-base" style={{ gap: "var(--space-sm)" }}>
+          <div class="flex-1 flex items-center" style={{ gap: "var(--space-sm)" }}>
+            <Key class="w-3.5 h-3.5 icon-muted flex-shrink-0" />
+            <input
+              type="text"
+              value={newKey()}
+              onInput={(e) => setNewKey(e.currentTarget.value)}
+              onKeyPress={handleKeyPress}
+              disabled={props.disabled}
+              class="modal-input flex-1 min-w-[160px]"
+              placeholder="Variable name"
+            />
+            <input
+              type="text"
+              value={newValue()}
+              onInput={(e) => setNewValue(e.currentTarget.value)}
+              onKeyPress={handleKeyPress}
+              disabled={props.disabled}
+              class="modal-input flex-1 min-w-[200px]"
+              placeholder="Variable value"
+            />
+          </div>
+          <button
+            onClick={handleAddVariable}
+            disabled={props.disabled || !newKey().trim()}
+            class="modal-button modal-button--primary p-2"
+            title="Add variable"
+          >
+            <Plus class="w-3.5 h-3.5" />
+          </button>
         </div>
-        <button
-          onClick={handleAddVariable}
-          disabled={props.disabled || !newKey().trim()}
-          class="p-1.5 icon-muted icon-accent-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          title="Add variable"
-        >
-          <Plus class="w-3.5 h-3.5" />
-        </button>
-      </div>
 
-      <Show when={entries().length === 0}>
-        <div class="text-xs text-muted text-center py-2">
-          No environment variables configured. Add variables above to customize the OpenCode environment.
-        </div>
-      </Show>
+        <Show when={entries().length === 0}>
+          <p class="text-xs text-secondary italic text-center py-2">
+            No environment variables configured. Add variables above to customize the OpenCode environment.
+          </p>
+        </Show>
 
-      <div class="text-xs text-muted mt-2">
-        These variables will be available in the OpenCode environment when starting instances.
+        <p class="text-xs text-secondary">
+          These variables will be available in the OpenCode environment when starting instances.
+        </p>
       </div>
     </div>
   )

--- a/packages/ui/src/components/instance-mcp-control.tsx
+++ b/packages/ui/src/components/instance-mcp-control.tsx
@@ -1,0 +1,302 @@
+import Switch from "@suid/material/Switch"
+import { Dialog } from "@kobalte/core/dialog"
+import { Plus } from "lucide-solid"
+import { For, Show, createMemo, createSignal, type Component } from "solid-js"
+import type { Instance, RawMcpStatus } from "../types/instance"
+import type { McpServerConfig } from "../stores/preferences"
+import { instances } from "../stores/instances"
+import { useConfig } from "../stores/preferences"
+import { instanceApi } from "../lib/instance-api"
+import { loadInstanceMetadata } from "../lib/hooks/use-instance-metadata"
+import { getLogger } from "../lib/logger"
+
+const log = getLogger("session")
+
+type McpRow = {
+  name: string
+  desiredEnabled: boolean
+  runtime?: { status?: string; error?: string }
+  hasRegistryEntry: boolean
+}
+
+interface InstanceMcpControlProps {
+  instance: Instance
+  onManage?: () => void
+  class?: string
+}
+
+const InstanceMcpControl: Component<InstanceMcpControlProps> = (props) => {
+  const { preferences, updatePreferences } = useConfig()
+  const [pending, setPending] = createSignal<Record<string, boolean>>({})
+
+  const [addModalOpen, setAddModalOpen] = createSignal(false)
+  const [newName, setNewName] = createSignal("")
+  const [newType, setNewType] = createSignal<McpServerConfig["type"]>("local")
+  const [newCommand, setNewCommand] = createSignal("npx -y @modelcontextprotocol/server-playwright")
+  const [newUrl, setNewUrl] = createSignal("")
+
+  const instance = createMemo(() => instances().get(props.instance.id) ?? props.instance)
+
+  const statusMap = createMemo<RawMcpStatus>(() => instance().metadata?.mcpStatus ?? {})
+
+  const rows = createMemo<McpRow[]>(() => {
+    const registry = preferences().mcpRegistry ?? {}
+    const desired = preferences().mcpDesiredState ?? {}
+
+    const names = new Set<string>([...Object.keys(registry), ...Object.keys(statusMap())])
+
+    return Array.from(names)
+      .filter(Boolean)
+      .sort((a, b) => a.localeCompare(b))
+      .map((name) => {
+        const registryEntry = registry[name]
+        const desiredEnabled = desired[name] ?? (registryEntry?.enabled ?? true)
+        return {
+          name,
+          desiredEnabled,
+          runtime: statusMap()[name],
+          hasRegistryEntry: Boolean(registryEntry),
+        }
+      })
+  })
+
+  const applyToInstance = async (name: string, desiredEnabled: boolean) => {
+    const currentInstance = instance()
+    const client = currentInstance.client
+    if (!client) {
+      return
+    }
+
+    setPending((prev) => ({ ...prev, [name]: true }))
+
+    try {
+      const registryEntry = preferences().mcpRegistry?.[name]
+      if (registryEntry) {
+        await instanceApi.upsertMcp(currentInstance, name, { ...registryEntry, enabled: desiredEnabled })
+      }
+
+      if (desiredEnabled) {
+        await instanceApi.connectMcp(currentInstance, name)
+      } else {
+        await instanceApi.disconnectMcp(currentInstance, name)
+      }
+
+      await loadInstanceMetadata(currentInstance, { force: true })
+    } catch (error) {
+      log.error("Failed to apply MCP server toggle", { instanceId: currentInstance.id, name, desiredEnabled, error })
+    } finally {
+      setPending((prev) => ({ ...prev, [name]: false }))
+    }
+  }
+
+  const toggleGlobalDesired = (name: string, enabled: boolean) => {
+    updatePreferences({
+      mcpDesiredState: {
+        ...(preferences().mcpDesiredState ?? {}),
+        [name]: enabled,
+      },
+    })
+
+    void applyToInstance(name, enabled)
+  }
+
+  const addMcpServer = async () => {
+    const name = newName().trim()
+    if (!name) return
+
+    let config: McpServerConfig
+    if (newType() === "local") {
+      const command = newCommand()
+        .split(" ")
+        .map((segment) => segment.trim())
+        .filter(Boolean)
+      if (command.length === 0) return
+      config = { type: "local", command, enabled: true }
+    } else {
+      const url = newUrl().trim()
+      if (!url) return
+      config = { type: "remote", url, enabled: true }
+    }
+
+    // Persist to global registry so it shows up everywhere.
+    updatePreferences({
+      mcpRegistry: { ...(preferences().mcpRegistry ?? {}), [name]: config },
+      mcpDesiredState: { ...(preferences().mcpDesiredState ?? {}), [name]: true },
+    })
+
+    try {
+      const currentInstance = instance()
+      if (currentInstance.client) {
+        await instanceApi.upsertMcp(currentInstance, name, { ...config, enabled: true })
+        await instanceApi.connectMcp(currentInstance, name)
+        await loadInstanceMetadata(currentInstance, { force: true })
+      }
+    } catch (error) {
+      log.error("Failed to add MCP server", { instanceId: instance().id, name, error })
+    }
+
+    setNewName("")
+    setNewUrl("")
+    setAddModalOpen(false)
+  }
+
+  const renderStatusDotClass = (row: McpRow) => {
+    if (pending()[row.name]) return "status-dot animate-pulse"
+
+    const status = row.runtime?.status
+    if (status === "connected") return "status-dot ready animate-pulse"
+    if (status === "failed" || status === "needs_auth" || status === "needs_client_registration") return "status-dot error"
+    if (status === "disabled") return "status-dot stopped"
+
+    // Runtime status unknown/not reported.
+    return row.desiredEnabled ? "status-dot" : "status-dot stopped"
+  }
+
+  const renderStatusLabel = (row: McpRow) => {
+    const status = row.runtime?.status
+    if (pending()[row.name]) return "Applying..."
+    if (!status) return row.desiredEnabled ? "Enabled (status unknown)" : "Disabled"
+    if (status === "connected") return "Connected"
+    if (status === "disabled") return "Disabled"
+    if (status === "failed") return "Failed"
+    if (status === "needs_auth") return "Needs auth"
+    if (status === "needs_client_registration") return "Needs registration"
+    return status
+  }
+
+  return (
+    <div class={props.class}>
+      <div class="flex items-center justify-between gap-2 mb-2">
+        <div class="text-[11px] font-semibold uppercase tracking-wide text-secondary">Servers</div>
+        <div class="flex items-center gap-2">
+          <button type="button" class="control-panel-inline-button" onClick={() => setAddModalOpen(true)}>
+            <Plus class="w-3.5 h-3.5" />
+            Add
+          </button>
+          <Show when={props.onManage}>
+            <button type="button" class="control-panel-inline-button" onClick={() => props.onManage?.()}>
+              Settings
+            </button>
+          </Show>
+        </div>
+      </div>
+
+      <Dialog open={addModalOpen()} onOpenChange={(open) => setAddModalOpen(open)}>
+        <Dialog.Portal>
+          <Dialog.Overlay class="modal-overlay" />
+          <div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+            <Dialog.Content class="modal-surface w-full max-w-xl">
+              <header class="px-6 py-4 border-b" style={{ "border-color": "var(--border-base)" }}>
+                <Dialog.Title class="text-lg font-semibold text-primary">Add MCP Server</Dialog.Title>
+                <div class="text-[11px] text-secondary mt-1">Adds to the global registry and connects this instance.</div>
+              </header>
+
+              <div class="p-6 space-y-4">
+                <div class="flex flex-col gap-1">
+                  <label class="text-xs text-secondary">Name</label>
+                  <input
+                    class="selector-search-input"
+                    value={newName()}
+                    onInput={(event) => setNewName(event.currentTarget.value)}
+                    placeholder="e.g. playwright-mcp"
+                  />
+                </div>
+
+                <div class="flex flex-col gap-1">
+                  <label class="text-xs text-secondary">Type</label>
+                  <select
+                    class="selector-search-input"
+                    value={newType()}
+                    onChange={(event) => setNewType(event.currentTarget.value as McpServerConfig["type"])}
+                  >
+                    <option value="local">local</option>
+                    <option value="remote">remote</option>
+                  </select>
+                </div>
+
+                <Show when={newType() === "local"}>
+                  <div class="flex flex-col gap-1">
+                    <label class="text-xs text-secondary">Command</label>
+                    <input
+                      class="selector-search-input"
+                      value={newCommand()}
+                      onInput={(event) => setNewCommand(event.currentTarget.value)}
+                      placeholder="npx -y @modelcontextprotocol/server-playwright"
+                    />
+                    <div class="text-[11px] text-secondary">Tip: use full command + args.</div>
+                  </div>
+                </Show>
+
+                <Show when={newType() === "remote"}>
+                  <div class="flex flex-col gap-1">
+                    <label class="text-xs text-secondary">URL</label>
+                    <input
+                      class="selector-search-input"
+                      value={newUrl()}
+                      onInput={(event) => setNewUrl(event.currentTarget.value)}
+                      placeholder="https://mcp.example.com/mcp"
+                    />
+                  </div>
+                </Show>
+              </div>
+
+              <div class="px-6 py-4 border-t flex items-center justify-end gap-2" style={{ "border-color": "var(--border-base)" }}>
+                <button type="button" class="selector-button selector-button-secondary" onClick={() => setAddModalOpen(false)}>
+                  Cancel
+                </button>
+                <button type="button" class="selector-button" onClick={() => void addMcpServer()}>
+                  Add & Connect
+                </button>
+              </div>
+            </Dialog.Content>
+          </div>
+        </Dialog.Portal>
+      </Dialog>
+
+      <Show when={rows().length > 0} fallback={<p class="control-panel-empty">No MCP servers configured yet.</p>}>
+        <div class="space-y-1.5">
+          <For each={rows()}>
+            {(row) => (
+              <div class="px-2 py-2 rounded-lg border bg-surface-secondary border-base">
+                <div class="flex items-center justify-between gap-2">
+                  <div class="flex flex-col min-w-0">
+                    <div class="text-xs text-primary font-medium truncate">
+                      {row.name}
+                      <Show when={!row.hasRegistryEntry}>
+                        <span class="text-[11px] text-secondary"> (instance-only)</span>
+                      </Show>
+                    </div>
+                    <div class="flex items-center gap-2 text-[11px] text-secondary">
+                      <div class={renderStatusDotClass(row)} />
+                      <span>{renderStatusLabel(row)}</span>
+                    </div>
+                  </div>
+
+                  <Switch
+                    checked={row.desiredEnabled}
+                    disabled={!instance().client || Boolean(pending()[row.name])}
+                    color="success"
+                    size="small"
+                    inputProps={{ "aria-label": `Toggle ${row.name} MCP server` }}
+                    onChange={(_, checked) => toggleGlobalDesired(row.name, Boolean(checked))}
+                  />
+                </div>
+
+                <Show when={row.runtime?.error}>
+                  {(error) => (
+                    <div class="text-[11px] mt-1 break-words" style={{ color: "var(--status-error)" }}>
+                      {error()}
+                    </div>
+                  )}
+                </Show>
+              </div>
+            )}
+          </For>
+        </div>
+      </Show>
+
+    </div>
+  )
+}
+
+export default InstanceMcpControl

--- a/packages/ui/src/components/mcp-settings-panel.tsx
+++ b/packages/ui/src/components/mcp-settings-panel.tsx
@@ -1,0 +1,232 @@
+import { For, Show, createMemo, createSignal, type Component } from "solid-js"
+import { useConfig } from "../stores/preferences"
+import type { McpServerConfig } from "../stores/preferences"
+import { instances } from "../stores/instances"
+import { getLogger } from "../lib/logger"
+import { instanceApi } from "../lib/instance-api"
+import { loadInstanceMetadata } from "../lib/hooks/use-instance-metadata"
+
+const log = getLogger("actions")
+
+type McpEntry = {
+  name: string
+  config: McpServerConfig
+  desiredEnabled: boolean
+}
+
+const McpSettingsPanel: Component = () => {
+  const { preferences, updatePreferences } = useConfig()
+  const [newName, setNewName] = createSignal("")
+  const [newType, setNewType] = createSignal<McpServerConfig["type"]>("local")
+  const [newCommand, setNewCommand] = createSignal("npx -y @modelcontextprotocol/server-everything")
+  const [newUrl, setNewUrl] = createSignal("")
+
+  const entries = createMemo<McpEntry[]>(() => {
+    const registry = preferences().mcpRegistry ?? {}
+    const desiredState = preferences().mcpDesiredState ?? {}
+    return Object.entries(registry)
+      .map(([name, config]) => ({
+        name,
+        config,
+        desiredEnabled: desiredState[name] ?? (config.enabled ?? true),
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name))
+  })
+
+  const saveEntry = (name: string, config: McpServerConfig, desiredEnabled: boolean) => {
+    updatePreferences({
+      mcpRegistry: { ...(preferences().mcpRegistry ?? {}), [name]: config },
+      mcpDesiredState: { ...(preferences().mcpDesiredState ?? {}), [name]: desiredEnabled },
+    })
+  }
+
+  const removeEntry = (name: string) => {
+    const nextRegistry = { ...(preferences().mcpRegistry ?? {}) }
+    const nextDesired = { ...(preferences().mcpDesiredState ?? {}) }
+    delete nextRegistry[name]
+    delete nextDesired[name]
+    updatePreferences({ mcpRegistry: nextRegistry, mcpDesiredState: nextDesired })
+
+    const activeInstances = Array.from(instances().values()).filter((instance) => instance.status === "ready" && instance.client)
+    void Promise.all(
+      activeInstances.map(async (instance) => {
+        try {
+          await instanceApi.disconnectMcp(instance, name)
+          await loadInstanceMetadata(instance, { force: true })
+        } catch {
+          // ignore
+        }
+      }),
+    )
+  }
+
+  const applyAll = async () => {
+    const currentEntries = entries()
+    const activeInstances = Array.from(instances().values()).filter((instance) => instance.status === "ready" && instance.client)
+
+    await Promise.all(
+      activeInstances.map(async (instance) => {
+        for (const entry of currentEntries) {
+          try {
+            await instanceApi.upsertMcp(instance, entry.name, { ...entry.config, enabled: entry.desiredEnabled })
+            if (entry.desiredEnabled) {
+              await instanceApi.connectMcp(instance, entry.name)
+            } else {
+              await instanceApi.disconnectMcp(instance, entry.name)
+            }
+          } catch (error) {
+            log.error("Failed to apply MCP registry entry", { instanceId: instance.id, name: entry.name, error })
+          }
+        }
+
+        try {
+          await loadInstanceMetadata(instance, { force: true })
+        } catch (error) {
+          log.error("Failed to refresh instance MCP metadata", { instanceId: instance.id, error })
+        }
+      }),
+    )
+  }
+
+  const createNewServer = () => {
+    const name = newName().trim()
+    if (!name) return
+
+    let config: McpServerConfig
+    if (newType() === "local") {
+      const command = newCommand()
+        .split(" ")
+        .map((segment) => segment.trim())
+        .filter(Boolean)
+      if (command.length === 0) return
+      config = { type: "local", command, enabled: true }
+    } else {
+      const url = newUrl().trim()
+      if (!url) return
+      config = { type: "remote", url, enabled: true }
+    }
+
+    saveEntry(name, config, true)
+    setNewName("")
+    setNewUrl("")
+
+    void applyAll()
+  }
+
+  return (
+    <div class="panel">
+      <div class="panel-header">
+        <h3 class="panel-title">MCP Servers</h3>
+        <p class="panel-subtitle">Registry stored in CodeNomad and applied to all instances</p>
+      </div>
+
+      <div class="panel-body" style={{ gap: "var(--space-md)" }}>
+        <label class="text-xs text-secondary flex items-center" style={{ gap: "var(--space-sm)" }}>
+          <input
+            type="checkbox"
+            checked={preferences().mcpAutoApply}
+            onChange={(event) => updatePreferences({ mcpAutoApply: event.currentTarget.checked })}
+          />
+          Auto-apply MCP registry on instance start
+        </label>
+
+        <div class="flex items-end flex-wrap" style={{ gap: "var(--space-sm)" }}>
+          <div class="flex flex-col" style={{ gap: "var(--space-xs)" }}>
+            <label class="text-xs text-secondary">Name</label>
+            <input
+              class="modal-input min-w-[180px]"
+              value={newName()}
+              onInput={(event) => setNewName(event.currentTarget.value)}
+              placeholder="e.g. context7"
+            />
+          </div>
+
+          <div class="flex flex-col" style={{ gap: "var(--space-xs)" }}>
+            <label class="text-xs text-secondary">Type</label>
+            <select
+              class="modal-input min-w-[120px]"
+              value={newType()}
+              onChange={(event) => setNewType(event.currentTarget.value as McpServerConfig["type"])}
+            >
+              <option value="local">local</option>
+              <option value="remote">remote</option>
+            </select>
+          </div>
+
+          <Show when={newType() === "local"}>
+            <div class="flex flex-col flex-1 min-w-[280px]" style={{ gap: "var(--space-xs)" }}>
+              <label class="text-xs text-secondary">Command</label>
+              <input
+                class="modal-input"
+                value={newCommand()}
+                onInput={(event) => setNewCommand(event.currentTarget.value)}
+                placeholder='npx -y @modelcontextprotocol/server-everything'
+              />
+            </div>
+          </Show>
+
+          <Show when={newType() === "remote"}>
+            <div class="flex flex-col flex-1 min-w-[280px]" style={{ gap: "var(--space-xs)" }}>
+              <label class="text-xs text-secondary">URL</label>
+              <input
+                class="modal-input"
+                value={newUrl()}
+                onInput={(event) => setNewUrl(event.currentTarget.value)}
+                placeholder="https://mcp.example.com/mcp"
+              />
+            </div>
+          </Show>
+
+          <button type="button" class="modal-button modal-button--primary" onClick={createNewServer}>
+            Add
+          </button>
+
+          <button type="button" class="modal-button modal-button--secondary" onClick={() => void applyAll()}>
+            Apply to Running Instances
+          </button>
+        </div>
+
+        <Show when={entries().length > 0} fallback={<p class="text-xs text-secondary italic">No MCP servers configured yet.</p>}>
+          <div class="flex flex-col" style={{ gap: "var(--space-sm)" }}>
+            <For each={entries()}>
+              {(entry) => (
+                <div class="px-3 py-2 rounded-md border bg-surface-secondary border-base">
+                  <div class="flex items-center justify-between" style={{ gap: "var(--space-sm)" }}>
+                    <div class="flex flex-col min-w-0">
+                      <div class="text-sm text-primary font-medium truncate">{entry.name}</div>
+                      <div class="text-xs text-secondary truncate">
+                        {entry.config.type === "local" ? entry.config.command.join(" ") : entry.config.url}
+                      </div>
+                    </div>
+                    <div class="flex items-center" style={{ gap: "var(--space-sm)" }}>
+                      <label class="text-xs text-secondary flex items-center" style={{ gap: "var(--space-xs)" }}>
+                        <input
+                          type="checkbox"
+                          checked={entry.desiredEnabled}
+                          onChange={(event) => {
+                            saveEntry(entry.name, entry.config, event.currentTarget.checked)
+                            void applyAll()
+                          }}
+                        />
+                        Enabled
+                      </label>
+                      <button
+                        type="button"
+                        class="modal-button modal-button--danger"
+                        onClick={() => removeEntry(entry.name)}
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </For>
+          </div>
+        </Show>
+      </div>
+    </div>
+  )
+}
+
+export default McpSettingsPanel

--- a/packages/ui/src/components/message-list-header.tsx
+++ b/packages/ui/src/components/message-list-header.tsx
@@ -1,12 +1,9 @@
 import { Show } from "solid-js"
 import Kbd from "./kbd"
-
-const METRIC_CHIP_CLASS = "inline-flex items-center gap-1 rounded-full border border-base px-2 py-0.5 text-xs text-primary"
-const METRIC_LABEL_CLASS = "uppercase text-[10px] tracking-wide text-primary/70"
+import ContextProgressBar from "./context-progress-bar"
 
 interface MessageListHeaderProps {
   usedTokens: number
-
   availableTokens?: number | null
   connectionStatus: "connected" | "connecting" | "error" | "disconnected" | "unknown" | null
   onCommandPalette: () => void
@@ -17,10 +14,6 @@ interface MessageListHeaderProps {
 }
 
 export default function MessageListHeader(props: MessageListHeaderProps) {
-
-  const hasAvailableTokens = () => typeof props.availableTokens === "number"
-  const availableDisplay = () => (hasAvailableTokens() ? props.formatTokens(props.availableTokens as number) : "--")
-
   return (
     <div class={props.forceCompactStatusLayout ? "connection-status connection-status--compact" : "connection-status"}>
       <Show when={props.showSidebarToggle}>
@@ -38,14 +31,12 @@ export default function MessageListHeader(props: MessageListHeaderProps) {
 
       <div class="connection-status-text connection-status-info">
         <div class="connection-status-usage">
-          <div class={METRIC_CHIP_CLASS}>
-            <span class={METRIC_LABEL_CLASS}>Used</span>
-            <span class="font-semibold text-primary">{props.formatTokens(props.usedTokens)}</span>
-          </div>
-          <div class={METRIC_CHIP_CLASS}>
-            <span class={METRIC_LABEL_CLASS}>Avail</span>
-            <span class="font-semibold text-primary">{hasAvailableTokens() ? availableDisplay() : "--"}</span>
-          </div>
+          <ContextProgressBar
+            usedTokens={props.usedTokens}
+            availableTokens={props.availableTokens}
+            formatTokens={props.formatTokens}
+            compact={props.forceCompactStatusLayout}
+          />
         </div>
       </div>
 

--- a/packages/ui/src/components/model-defaults-panel.tsx
+++ b/packages/ui/src/components/model-defaults-panel.tsx
@@ -1,0 +1,211 @@
+import { Combobox } from "@kobalte/core/combobox"
+import { For, Show, createEffect, createMemo, createSignal, type Component } from "solid-js"
+import { ChevronDown } from "lucide-solid"
+import { useConfig, type ModelPreference } from "../stores/preferences"
+import { instances } from "../stores/instances"
+import { providers, agents, fetchProviders, fetchAgents } from "../stores/sessions"
+import type { Model } from "../types/session"
+
+interface FlatModel extends Model {
+  providerName: string
+  key: string
+  searchText: string
+}
+
+const ModelDefaultsPanel: Component = () => {
+  const { preferences, updatePreferences } = useConfig()
+
+  const instanceOptions = createMemo(() => Array.from(instances().values()).filter((i) => i.status === "ready" && i.client))
+  const [referenceInstanceId, setReferenceInstanceId] = createSignal<string | null>(null)
+
+  createEffect(() => {
+    if (!referenceInstanceId() && instanceOptions().length > 0) {
+      setReferenceInstanceId(instanceOptions()[0].id)
+    }
+  })
+
+  createEffect(() => {
+    const instanceId = referenceInstanceId()
+    if (!instanceId) return
+    if ((providers().get(instanceId) ?? []).length === 0) {
+      fetchProviders(instanceId).catch(() => {})
+    }
+    if ((agents().get(instanceId) ?? []).length === 0) {
+      fetchAgents(instanceId).catch(() => {})
+    }
+  })
+
+  const availableAgents = createMemo(() => {
+    const instanceId = referenceInstanceId()
+    if (!instanceId) return []
+    const list = agents().get(instanceId) ?? []
+    return list.map((a) => a.name).filter(Boolean).sort((a, b) => a.localeCompare(b))
+  })
+
+  const allModels = createMemo<FlatModel[]>(() => {
+    const instanceId = referenceInstanceId()
+    if (!instanceId) return []
+    const instanceProviders = providers().get(instanceId) ?? []
+    return instanceProviders
+      .flatMap((p) =>
+        p.models.map((m) => ({
+          ...m,
+          providerName: p.name,
+          key: `${m.providerId}/${m.id}`,
+          searchText: `${m.name} ${p.name} ${m.providerId} ${m.id} ${m.providerId}/${m.id}`,
+        })),
+      )
+      .sort((a, b) => `${a.providerId}/${a.id}`.localeCompare(`${b.providerId}/${b.id}`))
+  })
+
+  const [newAgentName, setNewAgentName] = createSignal("")
+  const [selectedModel, setSelectedModel] = createSignal<FlatModel | null>(null)
+
+  const defaults = createMemo(() => preferences().modelDefaultsByAgent ?? {})
+
+  const saveDefault = (agentName: string, model: ModelPreference) => {
+    const next = { ...(preferences().modelDefaultsByAgent ?? {}) }
+    next[agentName] = model
+    updatePreferences({ modelDefaultsByAgent: next })
+  }
+
+  const removeDefault = (agentName: string) => {
+    const next = { ...(preferences().modelDefaultsByAgent ?? {}) }
+    delete next[agentName]
+    updatePreferences({ modelDefaultsByAgent: next })
+  }
+
+  const addDefault = () => {
+    const agentName = newAgentName().trim()
+    const model = selectedModel()
+    if (!agentName || !model) return
+    saveDefault(agentName, { providerId: model.providerId, modelId: model.id })
+    setNewAgentName("")
+    setSelectedModel(null)
+  }
+
+  const customFilter = (option: FlatModel, inputValue: string) => {
+    return option.searchText.toLowerCase().includes(inputValue.toLowerCase())
+  }
+
+  return (
+    <div class="panel">
+      <div class="panel-header">
+        <h3 class="panel-title">Model Defaults (Per Agent)</h3>
+        <p class="panel-subtitle">Applied when sessions prompt using that agent</p>
+      </div>
+
+      <div class="panel-body" style={{ gap: "var(--space-md)" }}>
+        <div class="flex items-end flex-wrap" style={{ gap: "var(--space-sm)" }}>
+          <div class="flex flex-col" style={{ gap: "var(--space-xs)" }}>
+            <label class="text-xs text-secondary">Reference Instance</label>
+            <select
+              class="modal-input min-w-[200px]"
+              value={referenceInstanceId() ?? ""}
+              onChange={(event) => setReferenceInstanceId(event.currentTarget.value)}
+            >
+              <For each={instanceOptions()}>
+                {(instance) => (
+                  <option value={instance.id}>
+                    {instance.binaryLabel ?? "opencode"} • {instance.folder}
+                  </option>
+                )}
+              </For>
+            </select>
+          </div>
+
+          <div class="flex flex-col" style={{ gap: "var(--space-xs)" }}>
+            <label class="text-xs text-secondary">Agent</label>
+            <input
+              class="modal-input min-w-[180px]"
+              value={newAgentName()}
+              onInput={(event) => setNewAgentName(event.currentTarget.value)}
+              list="agent-name-suggestions"
+              placeholder="e.g. plan"
+            />
+            <datalist id="agent-name-suggestions">
+              <For each={availableAgents()}>{(name) => <option value={name} />}</For>
+            </datalist>
+          </div>
+
+          <div class="flex flex-col flex-1 min-w-[280px]" style={{ gap: "var(--space-xs)" }}>
+            <label class="text-xs text-secondary">Model</label>
+            <Combobox<FlatModel>
+              value={selectedModel()}
+              onChange={(value) => setSelectedModel(value)}
+              options={allModels()}
+              optionValue="key"
+              optionTextValue="searchText"
+              optionLabel="name"
+              placeholder="Search models..."
+              defaultFilter={customFilter}
+              allowsEmptyCollection
+              itemComponent={(itemProps) => (
+                <Combobox.Item item={itemProps.item} class="selector-option">
+                  <div class="selector-option-content">
+                    <Combobox.ItemLabel class="selector-option-label">{itemProps.item.rawValue.name}</Combobox.ItemLabel>
+                    <Combobox.ItemDescription class="selector-option-description">
+                      {itemProps.item.rawValue.providerName} • {itemProps.item.rawValue.providerId}/{itemProps.item.rawValue.id}
+                    </Combobox.ItemDescription>
+                  </div>
+                  <Combobox.ItemIndicator class="selector-option-indicator">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+                    </svg>
+                  </Combobox.ItemIndicator>
+                </Combobox.Item>
+              )}
+            >
+              <Combobox.Control class="relative w-full">
+                <Combobox.Input class="modal-input" />
+                <Combobox.Trigger class="selector-trigger" aria-label="Choose model">
+                  <Combobox.Icon class="selector-trigger-icon">
+                    <ChevronDown class="w-3 h-3" />
+                  </Combobox.Icon>
+                </Combobox.Trigger>
+              </Combobox.Control>
+              <Combobox.Portal>
+                <Combobox.Content class="selector-popover">
+                  <Combobox.Listbox class="selector-listbox" />
+                </Combobox.Content>
+              </Combobox.Portal>
+            </Combobox>
+          </div>
+
+          <button type="button" class="modal-button modal-button--primary" onClick={addDefault}>
+            Add
+          </button>
+        </div>
+
+        <Show
+          when={Object.keys(defaults()).length > 0}
+          fallback={<p class="text-xs text-secondary italic">No per-agent defaults configured yet.</p>}
+        >
+          <div class="flex flex-col" style={{ gap: "var(--space-sm)" }}>
+            <For each={Object.entries(defaults()).sort(([a], [b]) => a.localeCompare(b))}>
+              {([agentName, model]) => (
+                <div class="px-3 py-2 rounded-md border bg-surface-secondary border-base flex items-center justify-between" style={{ gap: "var(--space-sm)" }}>
+                  <div class="flex flex-col min-w-0">
+                    <div class="text-sm text-primary font-medium truncate">{agentName}</div>
+                    <div class="text-xs text-secondary truncate">
+                      {model.providerId}/{model.modelId}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    class="modal-button modal-button--danger"
+                    onClick={() => removeDefault(agentName)}
+                  >
+                    Remove
+                  </button>
+                </div>
+              )}
+            </For>
+          </div>
+        </Show>
+      </div>
+    </div>
+  )
+}
+
+export default ModelDefaultsPanel

--- a/packages/ui/src/components/opencode-binary-selector.tsx
+++ b/packages/ui/src/components/opencode-binary-selector.tsx
@@ -219,21 +219,21 @@ const OpenCodeBinarySelector: Component<OpenCodeBinarySelectorProps> = (props) =
   return (
     <>
       <div class="panel">
-        <div class="panel-header flex items-center justify-between gap-3">
+        <div class="panel-header flex items-center justify-between" style={{ gap: "var(--space-md)" }}>
           <div>
             <h3 class="panel-title">OpenCode Binary</h3>
             <p class="panel-subtitle">Choose which executable OpenCode should run</p>
           </div>
           <Show when={validating()}>
-            <div class="selector-loading text-xs">
-              <Loader2 class="selector-loading-spinner" />
+            <div class="flex items-center text-xs text-muted" style={{ gap: "var(--space-sm)" }}>
+              <Loader2 class="w-4 h-4 animate-spin text-accent" />
               <span>Checking versions…</span>
             </div>
           </Show>
         </div>
 
-        <div class="panel-body space-y-3">
-          <div class="selector-input-group">
+        <div class="panel-body" style={{ gap: "var(--space-md)" }}>
+          <div class="flex items-center" style={{ gap: "var(--space-sm)" }}>
             <input
               type="text"
               value={customPath()}
@@ -246,13 +246,13 @@ const OpenCodeBinarySelector: Component<OpenCodeBinarySelectorProps> = (props) =
               }}
               disabled={props.disabled}
               placeholder="Enter path to opencode binary…"
-              class="selector-input"
+              class="modal-input flex-1"
             />
             <button
               type="button"
               onClick={handleCustomPathSubmit}
               disabled={props.disabled || !customPath().trim()}
-              class="selector-button selector-button-primary"
+              class="modal-button modal-button--primary"
             >
               <Plus class="w-4 h-4" />
               Add
@@ -263,17 +263,17 @@ const OpenCodeBinarySelector: Component<OpenCodeBinarySelectorProps> = (props) =
             type="button"
             onClick={() => void handleBrowseBinary()}
             disabled={props.disabled}
-            class="selector-button selector-button-secondary w-full flex items-center justify-center gap-2"
+            class="modal-button modal-button--secondary w-full"
           >
             <FolderOpen class="w-4 h-4" />
             Browse for Binary…
           </button>
 
           <Show when={validationError()}>
-            <div class="selector-validation-error">
-              <div class="selector-validation-error-content">
-                <AlertCircle class="selector-validation-error-icon" />
-                <span class="selector-validation-error-text">{validationError()}</span>
+            <div class="px-3 py-2 rounded-md bg-danger-soft-bg border border-base">
+              <div class="flex items-center" style={{ gap: "var(--space-sm)" }}>
+                <AlertCircle class="w-4 h-4 text-status-error flex-shrink-0" />
+                <span class="text-sm text-status-error">{validationError()}</span>
               </div>
             </div>
           </Show>

--- a/packages/ui/src/components/provider-settings-panel.tsx
+++ b/packages/ui/src/components/provider-settings-panel.tsx
@@ -1,0 +1,418 @@
+import { Dialog } from "@kobalte/core/dialog"
+import { For, Show, createEffect, createMemo, createSignal, type Component } from "solid-js"
+import { Plus, Search, RefreshCw, Power, Trash2, Key } from "lucide-solid"
+import { useConfig } from "../stores/preferences"
+import { instances, stopInstance, createInstance } from "../stores/instances"
+import { providers, fetchProviders } from "../stores/sessions"
+import { getLogger } from "../lib/logger"
+
+const log = getLogger("actions")
+
+type ProviderCatalogEntry = {
+  id: string
+  name: string
+  env: string[]
+}
+
+type ProviderCatalog = {
+  all: ProviderCatalogEntry[]
+  connected: string[]
+  default: Record<string, string>
+}
+
+const ProviderSettingsPanel: Component = () => {
+  const { preferences, updateEnvironmentVariables } = useConfig()
+
+  const instanceOptions = createMemo(() => Array.from(instances().values()).filter((i) => i.status === "ready" && i.client))
+  const [referenceInstanceId, setReferenceInstanceId] = createSignal<string | null>(null)
+
+  const [catalog, setCatalog] = createSignal<ProviderCatalog | null>(null)
+  const [loadingCatalog, setLoadingCatalog] = createSignal(false)
+
+  const [modalOpen, setModalOpen] = createSignal(false)
+  const [providerSearch, setProviderSearch] = createSignal("")
+  const [selectedProviderId, setSelectedProviderId] = createSignal<string | null>(null)
+  const [draftKeys, setDraftKeys] = createSignal<Record<string, string>>({})
+
+  const envVars = createMemo(() => preferences().environmentVariables ?? {})
+
+  const activeProviderList = createMemo(() => {
+    const id = referenceInstanceId()
+    if (!id) return []
+    return providers().get(id) ?? []
+  })
+
+  const connectedProviderIds = createMemo(() => new Set((catalog()?.connected ?? []).map((id) => id)))
+
+  createEffect(() => {
+    if (!referenceInstanceId() && instanceOptions().length > 0) {
+      setReferenceInstanceId(instanceOptions()[0].id)
+    }
+  })
+
+  const loadCatalog = async (instanceId: string) => {
+    const instance = instances().get(instanceId)
+    if (!instance?.client) return
+
+    setLoadingCatalog(true)
+    try {
+      await fetchProviders(instanceId).catch(() => {})
+      const response = await instance.client.provider.list()
+      if (response.data) {
+        setCatalog(response.data as unknown as ProviderCatalog)
+      }
+    } catch (error) {
+      log.error("Failed to load provider catalog", { instanceId, error })
+      setCatalog(null)
+    } finally {
+      setLoadingCatalog(false)
+    }
+  }
+
+  createEffect(() => {
+    const id = referenceInstanceId()
+    if (!id) return
+    void loadCatalog(id)
+  })
+
+  const providerById = createMemo(() => {
+    const map = new Map<string, ProviderCatalogEntry>()
+    for (const entry of catalog()?.all ?? []) {
+      if (entry?.id) map.set(entry.id, entry)
+    }
+    return map
+  })
+
+  const activeProviders = createMemo(() => {
+    const map = providerById()
+    return activeProviderList().map((p) => ({
+      id: p.id,
+      name: p.name,
+      env: map.get(p.id)?.env ?? [],
+      modelCount: p.models?.length ?? 0,
+    }))
+  })
+
+  const configuredProviderIds = createMemo(() => {
+    const map = providerById()
+    const result = new Set<string>()
+    const vars = envVars()
+
+    for (const entry of map.values()) {
+      if (!entry.env?.length) {
+        result.add(entry.id)
+        continue
+      }
+      if (entry.env.every((key) => Boolean(vars[key]?.trim()))) {
+        result.add(entry.id)
+      }
+    }
+
+    return result
+  })
+
+  const openProviderModal = (providerId?: string) => {
+    const id = providerId ?? null
+    setSelectedProviderId(id)
+
+    if (id) {
+      const entry = providerById().get(id)
+      if (entry) {
+        const nextDraft: Record<string, string> = {}
+        for (const key of entry.env ?? []) {
+          nextDraft[key] = envVars()[key] ?? ""
+        }
+        setDraftKeys(nextDraft)
+      }
+    } else {
+      setDraftKeys({})
+    }
+
+    setProviderSearch("")
+    setModalOpen(true)
+  }
+
+  const closeProviderModal = () => {
+    setModalOpen(false)
+    setProviderSearch("")
+    setSelectedProviderId(null)
+    setDraftKeys({})
+  }
+
+  const filteredProviders = createMemo(() => {
+    const query = providerSearch().trim().toLowerCase()
+    const list = catalog()?.all ?? []
+
+    if (!query) {
+      return list.slice(0, 30)
+    }
+
+    return list
+      .filter((entry) => entry.name.toLowerCase().includes(query) || entry.id.toLowerCase().includes(query))
+      .slice(0, 50)
+  })
+
+  const selectedProvider = createMemo(() => {
+    const id = selectedProviderId()
+    if (!id) return null
+    return providerById().get(id) ?? null
+  })
+
+  const saveProviderKeys = () => {
+    const entry = selectedProvider()
+    if (!entry) return
+
+    const next = { ...envVars() }
+    for (const key of entry.env ?? []) {
+      const value = (draftKeys()[key] ?? "").trim()
+      if (value) next[key] = value
+      else delete next[key]
+    }
+
+    updateEnvironmentVariables(next)
+    closeProviderModal()
+  }
+
+  const removeProviderKeys = (providerId: string) => {
+    const entry = providerById().get(providerId)
+    if (!entry) return
+
+    const next = { ...envVars() }
+    for (const key of entry.env ?? []) {
+      delete next[key]
+    }
+
+    updateEnvironmentVariables(next)
+  }
+
+  const restartReferenceInstance = async () => {
+    const id = referenceInstanceId()
+    if (!id) return
+    const instance = instances().get(id)
+    if (!instance) return
+
+    const folder = instance.folder
+    await stopInstance(id)
+    await createInstance(folder)
+  }
+
+  const providerSummaryLabel = (providerId: string) => {
+    const entry = providerById().get(providerId)
+    if (!entry) return providerId
+    return entry.name
+  }
+
+  return (
+    <div class="panel">
+      <div class="panel-header">
+        <h3 class="panel-title">Providers</h3>
+        <p class="panel-subtitle">Show enabled providers, add more via a focused flow</p>
+      </div>
+
+      <div class="panel-body" style={{ gap: "var(--space-md)" }}>
+        <div class="flex items-end flex-wrap" style={{ gap: "var(--space-sm)" }}>
+          <div class="flex flex-col" style={{ gap: "var(--space-xs)" }}>
+            <label class="text-xs text-secondary">Reference Instance</label>
+            <select
+              class="modal-input min-w-[240px]"
+              value={referenceInstanceId() ?? ""}
+              onChange={(event) => setReferenceInstanceId(event.currentTarget.value)}
+              disabled={instanceOptions().length === 0}
+            >
+              <For each={instanceOptions()}>
+                {(instance) => (
+                  <option value={instance.id}>
+                    {instance.binaryLabel ?? "opencode"} • {instance.folder}
+                  </option>
+                )}
+              </For>
+            </select>
+          </div>
+
+          <button
+            type="button"
+            class="modal-button modal-button--secondary"
+            disabled={!referenceInstanceId() || loadingCatalog()}
+            onClick={() => referenceInstanceId() && void loadCatalog(referenceInstanceId()!)}
+          >
+            <RefreshCw class="w-3.5 h-3.5" />
+            {loadingCatalog() ? "Refreshing..." : "Refresh"}
+          </button>
+
+          <button type="button" class="modal-button modal-button--primary" disabled={!referenceInstanceId()} onClick={() => void restartReferenceInstance()}>
+            <Power class="w-3.5 h-3.5" />
+            Restart to Apply
+          </button>
+        </div>
+
+        <Show
+          when={referenceInstanceId()}
+          fallback={<p class="text-xs text-secondary italic">Start an instance first to manage providers.</p>}
+        >
+          <div class="flex flex-col" style={{ gap: "var(--space-sm)" }}>
+            <div class="flex items-center justify-between" style={{ gap: "var(--space-sm)" }}>
+              <div class="text-xs font-medium text-muted uppercase tracking-wide">Enabled providers</div>
+              <button type="button" class="modal-button modal-button--primary" onClick={() => openProviderModal()}>
+                <Plus class="w-3.5 h-3.5" />
+                Add Provider
+              </button>
+            </div>
+
+            <Show
+              when={activeProviders().length > 0}
+              fallback={<p class="text-xs text-secondary italic">No providers loaded yet. Add a provider and restart.</p>}
+            >
+              <div class="flex flex-col" style={{ gap: "var(--space-sm)" }}>
+                <For each={activeProviders()}>
+                  {(provider) => {
+                    const isConfigured = () => configuredProviderIds().has(provider.id)
+                    const isConnected = () => connectedProviderIds().has(provider.id)
+
+                    return (
+                      <div class="px-3 py-2 rounded-md border bg-surface-secondary border-base">
+                        <div class="flex items-center justify-between" style={{ gap: "var(--space-md)" }}>
+                          <div class="flex flex-col min-w-0">
+                            <div class="text-sm text-primary font-medium truncate">
+                              {provider.name} <span class="text-xs text-secondary">({provider.id})</span>
+                            </div>
+                            <div class="text-xs text-secondary">
+                              <span>Models: {provider.modelCount}</span>
+                              <span class="px-2">•</span>
+                              <span>Configured: {isConfigured() ? "yes" : "no"}</span>
+                              <span class="px-2">•</span>
+                              <span>Connected: {isConnected() ? "yes" : "no"}</span>
+                            </div>
+                          </div>
+
+                          <div class="flex items-center flex-shrink-0" style={{ gap: "var(--space-xs)" }}>
+                            <button
+                              type="button"
+                              class="modal-button modal-button--secondary"
+                              onClick={() => openProviderModal(provider.id)}
+                            >
+                              <Key class="w-3.5 h-3.5" />
+                              Keys
+                            </button>
+                            <button
+                              type="button"
+                              class="modal-button modal-button--danger"
+                              onClick={() => removeProviderKeys(provider.id)}
+                              title="Remove stored keys"
+                            >
+                              <Trash2 class="w-3.5 h-3.5" />
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    )
+                  }}
+                </For>
+              </div>
+            </Show>
+          </div>
+
+          <div class="text-xs text-secondary">
+            Adding provider keys updates global environment variables. Restart is required because OpenCode reads env vars at process start.
+          </div>
+        </Show>
+      </div>
+
+      <Dialog open={modalOpen()} onOpenChange={(open) => (open ? setModalOpen(true) : closeProviderModal())}>
+        <Dialog.Portal>
+          <Dialog.Overlay class="modal-overlay" />
+          <div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+            <Dialog.Content class="modal-surface w-full max-w-3xl max-h-[85vh] flex flex-col overflow-hidden">
+              <header class="px-6 py-4 border-b" style={{ "border-color": "var(--border-base)" }}>
+                <Dialog.Title class="text-lg font-semibold text-primary">
+                  {selectedProviderId() ? `Configure ${providerSummaryLabel(selectedProviderId()!)}` : "Add Provider"}
+                </Dialog.Title>
+                <div class="text-[11px] text-secondary mt-1">Pick a provider, enter only the keys it needs.</div>
+              </header>
+
+              <div class="p-6 flex flex-col gap-4 overflow-y-auto">
+                <Show when={!selectedProviderId()}>
+                  <div class="flex items-center gap-2">
+                    <Search class="w-4 h-4 icon-muted" />
+                    <input
+                      class="selector-search-input flex-1"
+                      value={providerSearch()}
+                      onInput={(event) => setProviderSearch(event.currentTarget.value)}
+                      placeholder="Search providers (openai, anthropic, openrouter...)"
+                    />
+                  </div>
+
+                  <div class="space-y-2">
+                    <For each={filteredProviders()}>
+                      {(entry) => (
+                        <button
+                          type="button"
+                          class="w-full px-3 py-2 rounded-lg border bg-surface-secondary border-base text-left hover:bg-surface-muted transition-colors"
+                          onClick={() => openProviderModal(entry.id)}
+                        >
+                          <div class="text-sm font-medium text-primary">{entry.name}</div>
+                          <div class="text-[11px] text-secondary">
+                            {entry.id} • requires {entry.env?.length ?? 0} key{(entry.env?.length ?? 0) === 1 ? "" : "s"}
+                          </div>
+                        </button>
+                      )}
+                    </For>
+                  </div>
+                </Show>
+
+                <Show when={selectedProvider()}>
+                  {(entry) => (
+                    <div class="space-y-3">
+                      <div class="px-3 py-2 rounded-lg border bg-surface-secondary border-base">
+                        <div class="text-sm font-medium text-primary">{entry().name}</div>
+                        <div class="text-[11px] text-secondary">{entry().id}</div>
+                      </div>
+
+                      <Show
+                        when={(entry().env?.length ?? 0) > 0}
+                        fallback={<p class="text-[11px] text-secondary italic">No environment variables required for this provider.</p>}
+                      >
+                        <div class="space-y-2">
+                          <For each={entry().env}>
+                            {(key) => (
+                              <div class="flex items-center gap-2 flex-wrap">
+                                <div class="text-xs text-secondary min-w-[220px]">{key}</div>
+                                <input
+                                  type="password"
+                                  class="selector-search-input flex-1 min-w-[240px]"
+                                  value={draftKeys()[key] ?? ""}
+                                  placeholder={envVars()[key] ? "(set)" : "Enter value"}
+                                  onInput={(event) => setDraftKeys((prev) => ({ ...prev, [key]: event.currentTarget.value }))}
+                                />
+                              </div>
+                            )}
+                          </For>
+                        </div>
+                      </Show>
+
+                      <div class="text-[11px] text-secondary">
+                        Restart the instance after saving keys to load provider models.
+                      </div>
+                    </div>
+                  )}
+                </Show>
+              </div>
+
+              <div class="px-6 py-4 border-t flex items-center justify-end gap-2" style={{ "border-color": "var(--border-base)" }}>
+                <button type="button" class="selector-button selector-button-secondary" onClick={closeProviderModal}>
+                  Close
+                </button>
+                <Show when={selectedProviderId()}>
+                  <button type="button" class="selector-button" onClick={saveProviderKeys}>
+                    Save Keys
+                  </button>
+                </Show>
+              </div>
+            </Dialog.Content>
+          </div>
+        </Dialog.Portal>
+      </Dialog>
+    </div>
+  )
+}
+
+export default ProviderSettingsPanel

--- a/packages/ui/src/components/session-list.tsx
+++ b/packages/ui/src/components/session-list.tsx
@@ -1,7 +1,7 @@
 import { Component, For, Show, createSignal, createMemo, JSX } from "solid-js"
 import type { Session, SessionStatus } from "../types/session"
 import { getSessionStatus } from "../stores/session-status"
-import { MessageSquare, Info, X, Copy, Trash2, Pencil } from "lucide-solid"
+import { MessageSquare, X, Copy, Trash2, Pencil, MoreVertical, Plus, Info } from "lucide-solid"
 import KeyboardHint from "./keyboard-hint"
 import Kbd from "./kbd"
 import SessionRenameDialog from "./session-rename-dialog"
@@ -10,6 +10,7 @@ import { formatShortcut } from "../lib/keyboard-utils"
 import { showToastNotification } from "../lib/notifications"
 import { deleteSession, loading, renameSession } from "../stores/sessions"
 import { getLogger } from "../lib/logger"
+import { DropdownMenu } from "@kobalte/core"
 const log = getLogger("session")
 
 

--- a/packages/ui/src/components/session/context-usage-panel.tsx
+++ b/packages/ui/src/components/session/context-usage-panel.tsx
@@ -1,6 +1,7 @@
 import { createMemo, type Component } from "solid-js"
 import { getSessionInfo } from "../../stores/sessions"
 import { formatTokenTotal } from "../../lib/formatters"
+import ContextProgressBar from "../context-progress-bar"
 
 interface ContextUsagePanelProps {
   instanceId: string

--- a/packages/ui/src/components/theme-toggle.tsx
+++ b/packages/ui/src/components/theme-toggle.tsx
@@ -1,0 +1,29 @@
+import { type Component } from "solid-js"
+import { Sun, Moon } from "lucide-solid"
+import { useTheme } from "../lib/theme"
+
+interface ThemeToggleProps {
+  compact?: boolean
+}
+
+const ThemeToggle: Component<ThemeToggleProps> = (props) => {
+  const { isDark, toggleTheme } = useTheme()
+
+  return (
+    <button
+      type="button"
+      class={`theme-toggle ${props.compact ? "theme-toggle--compact" : ""}`}
+      onClick={toggleTheme}
+      aria-label={isDark() ? "Switch to light mode" : "Switch to dark mode"}
+      title={isDark() ? "Switch to light mode" : "Switch to dark mode"}
+    >
+      {isDark() ? (
+        <Sun class="theme-toggle-icon" />
+      ) : (
+        <Moon class="theme-toggle-icon" />
+      )}
+    </button>
+  )
+}
+
+export default ThemeToggle

--- a/packages/ui/src/lib/api-client.ts
+++ b/packages/ui/src/lib/api-client.ts
@@ -21,7 +21,11 @@ import { getLogger } from "./logger"
 
 const FALLBACK_API_BASE = "http://127.0.0.1:9898"
 const RUNTIME_BASE = typeof window !== "undefined" ? window.location?.origin : undefined
-const DEFAULT_BASE = typeof window !== "undefined" ? window.__CODENOMAD_API_BASE__ ?? RUNTIME_BASE ?? FALLBACK_API_BASE : FALLBACK_API_BASE
+const IS_DEV = import.meta.env.DEV
+const DEFAULT_BASE =
+  typeof window !== "undefined"
+    ? window.__CODENOMAD_API_BASE__ ?? (IS_DEV ? FALLBACK_API_BASE : RUNTIME_BASE ?? FALLBACK_API_BASE)
+    : FALLBACK_API_BASE
 const DEFAULT_EVENTS_PATH = typeof window !== "undefined" ? window.__CODENOMAD_EVENTS_URL__ ?? "/api/events" : "/api/events"
 const API_BASE = import.meta.env.VITE_CODENOMAD_API_BASE ?? DEFAULT_BASE
 const EVENTS_URL = buildEventsUrl(API_BASE, DEFAULT_EVENTS_PATH)

--- a/packages/ui/src/lib/instance-api.ts
+++ b/packages/ui/src/lib/instance-api.ts
@@ -1,0 +1,67 @@
+import type { Instance } from "../types/instance"
+import type { McpServerConfig } from "../stores/preferences"
+import { CODENOMAD_API_BASE } from "./api-client"
+
+function normalizeProxyPath(proxyPath: string): string {
+  const withLeading = proxyPath.startsWith("/") ? proxyPath : `/${proxyPath}`
+  return withLeading.replace(/\/+/g, "/").replace(/\/+$/, "")
+}
+
+function buildInstanceBaseUrl(proxyPath: string): string {
+  const normalized = normalizeProxyPath(proxyPath)
+  const base = CODENOMAD_API_BASE.replace(/\/+$/, "")
+  return `${base}${normalized}`
+}
+
+async function requestInstance<T>(instance: Instance, path: string, init?: RequestInit): Promise<T> {
+  const url = `${buildInstanceBaseUrl(instance.proxyPath)}${path}`
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+  })
+
+  if (!response.ok) {
+    const message = await response.text()
+    throw new Error(message || `Instance request failed (${response.status})`)
+  }
+
+  if (response.status === 204) {
+    return undefined as T
+  }
+
+  return (await response.json()) as T
+}
+
+async function upsertMcp(instance: Instance, name: string, config: McpServerConfig) {
+  // opencode server: POST /mcp { name, config }
+  return requestInstance<Record<string, unknown>>(instance, "/mcp", {
+    method: "POST",
+    body: JSON.stringify({ name, config }),
+  })
+}
+
+async function connectMcp(instance: Instance, name: string) {
+  // Prefer the SDK method if present.
+  if (instance.client?.mcp?.connect) {
+    await instance.client.mcp.connect({ path: { name } })
+    return
+  }
+  await requestInstance(instance, `/mcp/${encodeURIComponent(name)}/connect`, { method: "POST" })
+}
+
+async function disconnectMcp(instance: Instance, name: string) {
+  if (instance.client?.mcp?.disconnect) {
+    await instance.client.mcp.disconnect({ path: { name } })
+    return
+  }
+  await requestInstance(instance, `/mcp/${encodeURIComponent(name)}/disconnect`, { method: "POST" })
+}
+
+export const instanceApi = {
+  upsertMcp,
+  connectMcp,
+  disconnectMcp,
+}

--- a/packages/ui/src/lib/theme.tsx
+++ b/packages/ui/src/lib/theme.tsx
@@ -79,9 +79,12 @@ export function ThemeProvider(props: { children: JSX.Element }) {
   const { themePreference, setThemePreference } = useConfig()
   const [isDark, setIsDarkSignal] = createSignal(true)
 
-  const resolveDarkTheme = () => {
-    themePreference()
-    return true
+  const resolveDarkTheme = (): boolean => {
+    const pref = themePreference()
+    if (pref === "light") return false
+    if (pref === "dark") return true
+    // "system" preference - use media query
+    return mediaQuery?.matches ?? true
   }
 
   const applyResolvedTheme = () => {
@@ -107,12 +110,12 @@ export function ThemeProvider(props: { children: JSX.Element }) {
     }
   })
 
-  const setTheme = (_dark: boolean) => {
-    setThemePreference("dark")
+  const setTheme = (dark: boolean) => {
+    setThemePreference(dark ? "dark" : "light")
   }
 
   const toggleTheme = () => {
-    setTheme(true)
+    setTheme(!isDark())
   }
 
   const muiTheme = createMemo(() => {

--- a/packages/ui/src/stores/instances.ts
+++ b/packages/ui/src/stores/instances.ts
@@ -14,7 +14,9 @@ import {
   clearInstanceDraftPrompts,
 } from "./sessions"
 import { fetchCommands, clearCommands } from "./commands"
-import { preferences } from "./preferences"
+import { preferences, setAgentModelPreference } from "./preferences"
+import { isModelValid } from "./session-models"
+import { instanceApi } from "../lib/instance-api"
 import { setSessionPendingPermission } from "./session-state"
 import { setHasInstances } from "./ui"
 import { messageStoreBus } from "./message-v2/bus"
@@ -117,12 +119,83 @@ function releaseInstanceResources(instanceId: string) {
   sseManager.seedStatus(instanceId, "disconnected")
 }
 
+async function applyGlobalModelDefaults(instanceId: string) {
+  const defaults = preferences().modelDefaultsByAgent ?? {}
+  const entries = Object.entries(defaults)
+  if (entries.length === 0) return
+
+  for (const [agentName, model] of entries) {
+    if (!agentName) continue
+    if (!isModelValid(instanceId, model)) {
+      continue
+    }
+    await setAgentModelPreference(instanceId, agentName, model)
+  }
+}
+
+async function applyGlobalMcpRegistry(instanceId: string) {
+  const config = preferences()
+  if (!config.mcpAutoApply) return
+
+  const registry = config.mcpRegistry ?? {}
+  const entries = Object.entries(registry)
+  if (entries.length === 0) return
+
+  const instance = instances().get(instanceId)
+  if (!instance?.client) return
+
+  for (const [name, serverConfig] of entries) {
+    if (!name) continue
+
+    const desired = config.mcpDesiredState?.[name] ?? (serverConfig.enabled ?? true)
+
+    try {
+      await instanceApi.upsertMcp(instance, name, { ...serverConfig, enabled: desired })
+      if (desired) {
+        await instanceApi.connectMcp(instance, name)
+      } else {
+        await instanceApi.disconnectMcp(instance, name)
+      }
+    } catch (error) {
+      log.error("Failed to sync MCP server", { instanceId, name, error })
+    }
+  }
+
+  try {
+    const mcpResult = await instance.client.mcp.status()
+    updateInstance(instanceId, {
+      metadata: {
+        ...(instance.metadata ?? {}),
+        mcpStatus: (mcpResult.data as any) ?? {},
+      },
+    })
+  } catch (error) {
+    log.error("Failed to refresh MCP metadata after sync", { instanceId, error })
+  }
+}
+
+async function applyGlobalSettingsToInstance(instanceId: string) {
+  try {
+    await applyGlobalModelDefaults(instanceId)
+  } catch (error) {
+    log.error("Failed to apply global model defaults", { instanceId, error })
+  }
+
+  try {
+    await applyGlobalMcpRegistry(instanceId)
+  } catch (error) {
+    log.error("Failed to apply global MCP registry", { instanceId, error })
+  }
+}
+
 async function hydrateInstanceData(instanceId: string) {
   try {
     await fetchSessions(instanceId)
     await fetchAgents(instanceId)
     await fetchProviders(instanceId)
     await ensureInstanceConfigLoaded(instanceId)
+    await applyGlobalSettingsToInstance(instanceId)
+
     const instance = instances().get(instanceId)
     if (!instance?.client) return
     await fetchCommands(instanceId, instance.client)

--- a/packages/ui/src/stores/message-v2/instance-store.ts
+++ b/packages/ui/src/stores/message-v2/instance-store.ts
@@ -520,7 +520,7 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
           draft.partIds = [...draft.partIds, partId]
         }
         const existing = draft.parts[partId]
-        const nextRevision = existing ? existing.revision + 1 : cloned.version ?? 0
+        const nextRevision = existing ? existing.revision + 1 : 0
         draft.parts[partId] = {
           id: partId,
           data: cloned,

--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -254,7 +254,7 @@ async function createSession(instanceId: string, agent?: string): Promise<Sessio
 async function forkSession(
   instanceId: string,
   sourceSessionId: string,
-  options?: { messageId?: string },
+  options?: { messageId?: string; parentId?: string },
 ): Promise<Session> {
   const instance = instances().get(instanceId)
   if (!instance || !instance.client) {

--- a/packages/ui/src/styles/components/buttons.css
+++ b/packages/ui/src/styles/components/buttons.css
@@ -1,47 +1,98 @@
-/* Button component styles */
+/* Button component styles - refined design system */
+
+/* Size variants */
+.button--sm {
+  padding: var(--space-xs) var(--space-md);
+  font-size: var(--font-size-xs);
+  border-radius: var(--radius-sm);
+  gap: var(--space-xs);
+}
+
+.button--md {
+  padding: var(--space-sm) var(--space-lg);
+  font-size: var(--font-size-sm);
+  border-radius: var(--radius-md);
+  gap: var(--space-sm);
+}
+
+.button--lg {
+  padding: var(--space-md) var(--space-xl);
+  font-size: var(--font-size-base);
+  border-radius: var(--radius-md);
+  gap: var(--space-sm);
+}
+
+/* Primary button - accent color, filled */
 .button-primary,
 button.button-primary {
-  @apply px-6 py-3 text-base rounded-lg;
-  background-color: var(--button-primary-bg);
-  color: var(--button-primary-text);
-  border-color: var(--button-primary-bg);
+  @apply px-5 py-2.5 text-sm;
+  border-radius: var(--radius-md);
+  background-color: var(--accent-primary);
+  color: #ffffff;
+  border: 1px solid var(--accent-primary);
+  font-weight: var(--font-weight-medium);
+  transition: all 0.15s ease;
 }
 
 .button-primary:hover:not(:disabled),
 button.button-primary:hover:not(:disabled) {
-  background-color: var(--button-primary-hover-bg);
-  border-color: var(--button-primary-hover-bg);
+  background-color: var(--accent-hover);
+  border-color: var(--accent-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.25);
+}
+
+.button-primary:active:not(:disabled),
+button.button-primary:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: none;
 }
 
 .button-primary:focus-visible,
 button.button-primary:focus-visible {
+  outline: none;
   box-shadow: 0 0 0 2px var(--focus-ring-offset), 0 0 0 4px var(--focus-ring-color);
 }
 
+/* Secondary button - outlined style */
 .button-secondary,
 button.button-secondary {
-  @apply px-6 py-3 text-base rounded-lg;
-  background-color: var(--surface-secondary);
+  @apply px-5 py-2.5 text-sm;
+  border-radius: var(--radius-md);
+  background-color: transparent;
   color: var(--text-primary);
-  border-color: var(--border-base);
+  border: 1px solid var(--border-secondary);
+  font-weight: var(--font-weight-medium);
+  transition: all 0.15s ease;
 }
 
 .button-secondary:hover:not(:disabled),
 button.button-secondary:hover:not(:disabled) {
   background-color: var(--surface-hover);
+  border-color: var(--border-focus);
+}
+
+.button-secondary:active:not(:disabled),
+button.button-secondary:active:not(:disabled) {
+  background-color: var(--surface-muted);
 }
 
 .button-secondary:focus-visible,
 button.button-secondary:focus-visible {
+  outline: none;
   box-shadow: 0 0 0 2px var(--focus-ring-offset), 0 0 0 4px var(--focus-ring-color);
 }
 
+/* Tertiary button - ghost style */
 .button-tertiary,
 button.button-tertiary {
-  @apply px-4 py-2 text-sm rounded-lg;
+  @apply px-3 py-2 text-sm;
+  border-radius: var(--radius-md);
   background-color: transparent;
   color: var(--text-secondary);
-  border-color: var(--border-base);
+  border: 1px solid transparent;
+  font-weight: var(--font-weight-medium);
+  transition: all 0.15s ease;
 }
 
 .button-tertiary:hover:not(:disabled),
@@ -50,7 +101,140 @@ button.button-tertiary:hover:not(:disabled) {
   background-color: var(--surface-hover);
 }
 
+.button-tertiary:active:not(:disabled),
+button.button-tertiary:active:not(:disabled) {
+  background-color: var(--surface-muted);
+}
+
 .button-tertiary:focus-visible,
 button.button-tertiary:focus-visible {
+  outline: none;
   box-shadow: 0 0 0 2px var(--focus-ring-offset), 0 0 0 4px var(--focus-ring-color);
+}
+
+/* Danger button variant */
+.button-danger,
+button.button-danger {
+  @apply px-5 py-2.5 text-sm;
+  border-radius: var(--radius-md);
+  background-color: var(--status-error);
+  color: #ffffff;
+  border: 1px solid var(--status-error);
+  font-weight: var(--font-weight-medium);
+  transition: all 0.15s ease;
+}
+
+.button-danger:hover:not(:disabled),
+button.button-danger:hover:not(:disabled) {
+  filter: brightness(1.1);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(239, 68, 68, 0.25);
+}
+
+.button-danger:active:not(:disabled),
+button.button-danger:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: none;
+  filter: brightness(0.95);
+}
+
+.button-danger:focus-visible,
+button.button-danger:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--focus-ring-offset), 0 0 0 4px var(--status-error);
+}
+
+/* Ghost danger button */
+.button-danger-ghost,
+button.button-danger-ghost {
+  @apply px-3 py-2 text-sm;
+  border-radius: var(--radius-md);
+  background-color: transparent;
+  color: var(--status-error);
+  border: 1px solid transparent;
+  font-weight: var(--font-weight-medium);
+  transition: all 0.15s ease;
+}
+
+.button-danger-ghost:hover:not(:disabled),
+button.button-danger-ghost:hover:not(:disabled) {
+  background-color: var(--danger-soft-bg);
+}
+
+.button-danger-ghost:active:not(:disabled),
+button.button-danger-ghost:active:not(:disabled) {
+  background-color: var(--danger-soft-bg-strong);
+}
+
+/* Icon button primitives */
+.icon-button--sm {
+  @apply w-6 h-6;
+}
+
+.icon-button--md {
+  @apply w-9 h-9;
+}
+
+.icon-button--lg {
+  @apply w-10 h-10;
+}
+
+.icon-button--primary {
+  background-color: var(--button-primary-bg);
+  border-color: var(--button-primary-bg);
+  color: var(--button-primary-text);
+}
+
+.icon-button--primary:hover:not(:disabled) {
+  background-color: var(--button-primary-hover-bg);
+  border-color: var(--button-primary-hover-bg);
+}
+
+.icon-button--ghost {
+  background-color: transparent;
+  border-color: var(--border-base);
+  color: var(--text-muted);
+}
+
+.icon-button--ghost:hover:not(:disabled) {
+  background-color: var(--surface-secondary);
+  color: var(--text-primary);
+}
+
+.icon-button--danger {
+  background-color: var(--status-error-fg);
+  border-color: var(--status-error-fg);
+  color: var(--button-primary-text);
+}
+
+.icon-button--danger:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+.icon-button--danger:active:not(:disabled) {
+  filter: brightness(0.95);
+}
+
+.icon-button--success {
+  background-color: var(--status-ready-fg);
+  border-color: var(--status-ready-fg);
+  color: var(--button-primary-text);
+}
+
+.icon-button--success:hover:not(:disabled) {
+  filter: brightness(1.05);
+}
+
+.icon-button--success:active:not(:disabled) {
+  filter: brightness(0.95);
+}
+
+.icon-button--chip {
+  background-color: transparent;
+  border-color: transparent;
+  color: inherit;
+}
+
+.icon-button--chip:hover:not(:disabled) {
+  background-color: var(--attachment-chip-ring);
 }

--- a/packages/ui/src/styles/components/context-progress.css
+++ b/packages/ui/src/styles/components/context-progress.css
@@ -1,0 +1,105 @@
+/* Context Progress Bar */
+.context-progress {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  min-width: 180px;
+}
+
+.context-progress--compact {
+  min-width: 140px;
+  gap: var(--space-xs);
+}
+
+.context-progress-bar-container {
+  position: relative;
+  flex: 1;
+  height: 6px;
+  min-width: 60px;
+  max-width: 120px;
+  border-radius: var(--radius-full);
+  overflow: hidden;
+}
+
+.context-progress--compact .context-progress-bar-container {
+  height: 4px;
+  min-width: 40px;
+  max-width: 80px;
+}
+
+.context-progress-track {
+  position: absolute;
+  inset: 0;
+  background-color: var(--context-progress-track);
+  border-radius: var(--radius-full);
+}
+
+.context-progress-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  border-radius: var(--radius-full);
+  transition: width 0.3s ease-out, background-color 0.2s ease;
+  z-index: 1;
+}
+
+.context-progress-bar--low {
+  background-color: var(--context-progress-low);
+}
+
+.context-progress-bar--moderate {
+  background-color: var(--context-progress-moderate);
+}
+
+.context-progress-bar--warning {
+  background-color: var(--context-progress-warning);
+}
+
+.context-progress-bar--critical {
+  background-color: var(--context-progress-critical);
+}
+
+.context-progress-labels {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2xs);
+  font-size: var(--font-size-xs);
+  font-family: var(--font-family-mono);
+  white-space: nowrap;
+}
+
+.context-progress--compact .context-progress-labels {
+  font-size: 10px;
+}
+
+.context-progress-used,
+.context-progress-available,
+.context-progress-total {
+  display: flex;
+  align-items: baseline;
+  gap: 3px;
+}
+
+.context-progress-label {
+  text-transform: uppercase;
+  font-size: 9px;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  font-family: var(--font-family-sans);
+  font-weight: var(--font-weight-medium);
+}
+
+.context-progress--compact .context-progress-label {
+  font-size: 8px;
+}
+
+.context-progress-value {
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+}
+
+.context-progress-divider {
+  color: var(--text-muted);
+  opacity: 0.5;
+}

--- a/packages/ui/src/styles/components/inputs.css
+++ b/packages/ui/src/styles/components/inputs.css
@@ -1,0 +1,337 @@
+/* Input component styles - refined design system */
+
+/* Base input styles */
+.input,
+input.input,
+textarea.input {
+  width: 100%;
+  padding: var(--input-padding-y) var(--input-padding-x);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-family-sans);
+  line-height: var(--line-height-normal);
+  color: var(--input-text);
+  background-color: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: var(--input-radius);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.input::placeholder,
+input.input::placeholder,
+textarea.input::placeholder {
+  color: var(--input-placeholder);
+}
+
+.input:hover:not(:disabled):not(:focus),
+input.input:hover:not(:disabled):not(:focus),
+textarea.input:hover:not(:disabled):not(:focus) {
+  border-color: var(--input-border-hover);
+}
+
+.input:focus,
+input.input:focus,
+textarea.input:focus {
+  outline: none;
+  border-color: var(--input-border-focus);
+  box-shadow: 0 0 0 3px var(--accent-subtle);
+}
+
+.input:disabled,
+input.input:disabled,
+textarea.input:disabled {
+  background-color: var(--input-disabled-bg);
+  color: var(--input-disabled-text);
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+/* Input sizes */
+.input--sm {
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--font-size-xs);
+  border-radius: var(--radius-sm);
+}
+
+.input--md {
+  padding: var(--space-sm) var(--space-md);
+  font-size: var(--font-size-sm);
+  border-radius: var(--radius-md);
+}
+
+.input--lg {
+  padding: var(--space-md) var(--space-lg);
+  font-size: var(--font-size-base);
+  border-radius: var(--radius-md);
+}
+
+/* Textarea specific */
+textarea.input {
+  min-height: 80px;
+  resize: vertical;
+}
+
+textarea.input--no-resize {
+  resize: none;
+}
+
+/* Input with icon */
+.input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.input-wrapper .input {
+  padding-left: 2.5rem;
+}
+
+.input-wrapper .input-icon {
+  position: absolute;
+  left: var(--space-sm);
+  color: var(--text-muted);
+  pointer-events: none;
+  width: 1rem;
+  height: 1rem;
+}
+
+.input-wrapper .input:focus + .input-icon,
+.input-wrapper .input:focus ~ .input-icon {
+  color: var(--accent-primary);
+}
+
+/* Input with trailing icon/button */
+.input-wrapper--trailing .input {
+  padding-left: var(--input-padding-x);
+  padding-right: 2.5rem;
+}
+
+.input-wrapper--trailing .input-icon {
+  left: auto;
+  right: var(--space-sm);
+}
+
+/* Input with both icons */
+.input-wrapper--both .input {
+  padding-left: 2.5rem;
+  padding-right: 2.5rem;
+}
+
+/* Input error state */
+.input--error,
+.input-wrapper--error .input {
+  border-color: var(--status-error);
+}
+
+.input--error:focus,
+.input-wrapper--error .input:focus {
+  border-color: var(--status-error);
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15);
+}
+
+/* Input success state */
+.input--success,
+.input-wrapper--success .input {
+  border-color: var(--status-success);
+}
+
+.input--success:focus,
+.input-wrapper--success .input:focus {
+  border-color: var(--status-success);
+  box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.15);
+}
+
+/* Form field container */
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.form-field-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--text-primary);
+}
+
+.form-field-label--required::after {
+  content: " *";
+  color: var(--status-error);
+}
+
+.form-field-helper {
+  font-size: var(--font-size-xs);
+  color: var(--text-muted);
+}
+
+.form-field-error {
+  font-size: var(--font-size-xs);
+  color: var(--status-error);
+}
+
+/* Select input */
+.select,
+select.select {
+  appearance: none;
+  width: 100%;
+  padding: var(--input-padding-y) var(--input-padding-x);
+  padding-right: 2.5rem;
+  font-size: var(--font-size-sm);
+  font-family: var(--font-family-sans);
+  line-height: var(--line-height-normal);
+  color: var(--input-text);
+  background-color: var(--input-bg);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%2371717a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 1rem;
+  border: 1px solid var(--input-border);
+  border-radius: var(--input-radius);
+  cursor: pointer;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.select:hover:not(:disabled),
+select.select:hover:not(:disabled) {
+  border-color: var(--input-border-hover);
+}
+
+.select:focus,
+select.select:focus {
+  outline: none;
+  border-color: var(--input-border-focus);
+  box-shadow: 0 0 0 3px var(--accent-subtle);
+}
+
+.select:disabled,
+select.select:disabled {
+  background-color: var(--input-disabled-bg);
+  color: var(--input-disabled-text);
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+/* Checkbox and radio base */
+.checkbox,
+.radio {
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  border: 1px solid var(--input-border);
+  background-color: var(--input-bg);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  flex-shrink: 0;
+}
+
+.checkbox {
+  border-radius: var(--radius-xs);
+}
+
+.radio {
+  border-radius: var(--radius-full);
+}
+
+.checkbox:hover:not(:disabled),
+.radio:hover:not(:disabled) {
+  border-color: var(--input-border-hover);
+}
+
+.checkbox:checked,
+.radio:checked {
+  background-color: var(--accent-primary);
+  border-color: var(--accent-primary);
+}
+
+.checkbox:checked {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='white' stroke-width='3' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='20 6 9 17 4 12'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 0.625rem;
+}
+
+.radio:checked {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3E%3Ccircle cx='4' cy='4' r='4' fill='white'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 0.375rem;
+}
+
+.checkbox:focus-visible,
+.radio:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--focus-ring-offset), 0 0 0 4px var(--focus-ring-color);
+}
+
+.checkbox:disabled,
+.radio:disabled {
+  background-color: var(--input-disabled-bg);
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+/* Checkbox/Radio with label */
+.checkbox-label,
+.radio-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  font-size: var(--font-size-sm);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.checkbox-label:has(:disabled),
+.radio-label:has(:disabled) {
+  color: var(--text-muted);
+  cursor: not-allowed;
+}
+
+/* Switch/Toggle */
+.switch {
+  appearance: none;
+  position: relative;
+  width: 2.5rem;
+  height: 1.5rem;
+  background-color: var(--surface-muted);
+  border: 1px solid var(--border-base);
+  border-radius: var(--radius-full);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  flex-shrink: 0;
+}
+
+.switch::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 1rem;
+  height: 1rem;
+  background-color: var(--text-muted);
+  border-radius: var(--radius-full);
+  transition: all 0.2s ease;
+}
+
+.switch:hover:not(:disabled) {
+  border-color: var(--border-secondary);
+}
+
+.switch:checked {
+  background-color: var(--accent-primary);
+  border-color: var(--accent-primary);
+}
+
+.switch:checked::after {
+  left: calc(100% - 1.125rem);
+  background-color: #ffffff;
+}
+
+.switch:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--focus-ring-offset), 0 0 0 4px var(--focus-ring-color);
+}
+
+.switch:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/packages/ui/src/styles/components/theme-toggle.css
+++ b/packages/ui/src/styles/components/theme-toggle.css
@@ -1,0 +1,40 @@
+/* Theme Toggle */
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-base);
+  background-color: var(--surface-secondary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.theme-toggle:hover {
+  background-color: var(--surface-hover);
+  color: var(--text-primary);
+  border-color: var(--accent-primary);
+}
+
+.theme-toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--focus-ring-offset), 0 0 0 4px var(--focus-ring-color);
+}
+
+.theme-toggle--compact {
+  width: 28px;
+  height: 28px;
+}
+
+.theme-toggle-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.theme-toggle--compact .theme-toggle-icon {
+  width: 14px;
+  height: 14px;
+}

--- a/packages/ui/src/styles/controls.css
+++ b/packages/ui/src/styles/controls.css
@@ -6,3 +6,4 @@
 @import "./components/env-vars.css";
 @import "./components/directory-browser.css";
 @import "./components/remote-access.css";
+@import "./components/context-progress.css";

--- a/packages/ui/src/styles/messaging/message-section.css
+++ b/packages/ui/src/styles/messaging/message-section.css
@@ -124,8 +124,9 @@
 }
 
 .connection-status-button {
-  @apply inline-flex items-center gap-2 px-3 py-1 text-sm font-medium border rounded-md transition-colors;
+  @apply inline-flex items-center gap-2 px-3 py-1 text-sm font-medium border transition-colors;
   border-color: var(--border-base);
+  border-radius: var(--button-radius);
   background-color: var(--surface-base);
   color: var(--text-primary);
 }
@@ -135,9 +136,8 @@
 }
 
 .connection-status-button:focus-visible {
-  @apply ring-2 ring-offset-1;
-  ring-color: var(--accent-primary);
-  ring-offset-color: var(--surface-secondary);
+  outline: none;
+  box-shadow: 0 0 0 2px var(--focus-ring-offset), 0 0 0 4px var(--focus-ring-color);
 }
 
 .connection-status-shortcut-hint {

--- a/packages/ui/src/styles/panels.css
+++ b/packages/ui/src/styles/panels.css
@@ -3,6 +3,7 @@
 @import "./panels/modal.css";
 @import "./panels/panel-shell.css";
 @import "./panels/session-layout.css";
+@import "./panels/control-panel.css";
 
 
 .tab-bar-instance {
@@ -585,6 +586,21 @@
 .session-list-item {
   @apply border-b last:border-b-0;
   border-color: var(--border-base);
+  min-width: 0;
+  max-width: 100%;
+}
+
+.session-item-menu {
+  @apply flex-shrink-0;
+  color: var(--text-muted);
+}
+
+.session-item-menu:hover {
+  color: var(--text-primary);
+}
+
+.session-item-actions-group {
+  @apply flex items-center gap-0.5 flex-shrink-0;
 }
 
 .session-item-base {

--- a/packages/ui/src/styles/panels/control-panel.css
+++ b/packages/ui/src/styles/panels/control-panel.css
@@ -1,0 +1,59 @@
+.control-panel-header {
+  @apply flex items-center justify-between px-4 py-2;
+  border-bottom: 1px solid var(--border-base);
+  background: linear-gradient(180deg, var(--surface-secondary) 0%, var(--surface-base) 100%);
+}
+
+.control-panel-title {
+  @apply uppercase tracking-wide text-xs font-semibold;
+  color: var(--text-secondary);
+}
+
+.control-panel-actions {
+  @apply flex items-center gap-1;
+}
+
+.control-panel-section {
+  @apply w-full overflow-hidden border-b;
+  border-color: var(--border-base);
+  background-color: transparent;
+}
+
+.control-panel-trigger {
+  @apply w-full flex items-center justify-between gap-3 px-4 py-2.5 text-xs font-semibold uppercase tracking-wide transition-colors;
+  color: var(--text-secondary);
+  background-color: transparent;
+  outline: none;
+}
+
+.control-panel-trigger:focus-visible {
+  box-shadow: 0 0 0 2px var(--focus-ring-offset), 0 0 0 4px var(--focus-ring-color);
+}
+
+.control-panel-trigger:hover {
+  background-color: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.control-panel-content {
+  @apply w-full px-4 pb-4;
+  border-top: 1px solid var(--border-base);
+  background-color: var(--surface-base);
+}
+
+.control-panel-empty {
+  @apply text-[11px] italic;
+  color: var(--text-muted);
+}
+
+.control-panel-inline-button {
+  @apply inline-flex items-center gap-2 px-2 py-1 rounded-md text-xs font-medium transition-colors;
+  background-color: var(--surface-secondary);
+  border: 1px solid var(--border-base);
+  color: var(--text-secondary);
+}
+
+.control-panel-inline-button:hover {
+  background-color: var(--surface-hover);
+  color: var(--text-primary);
+}

--- a/packages/ui/src/styles/panels/modal.css
+++ b/packages/ui/src/styles/panels/modal.css
@@ -1,17 +1,134 @@
 /* Modal utilities */
+
+.modal-header {
+  @apply px-5 py-4 border-b;
+  border-color: var(--border-base);
+}
+
+.modal-body {
+  @apply flex-1 overflow-y-auto p-5;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.modal-footer {
+  @apply px-5 py-3 border-t flex justify-end;
+  border-color: var(--border-base);
+  gap: var(--space-sm);
+}
+
 .modal-overlay {
   @apply fixed inset-0 z-50;
   background-color: var(--overlay-scrim);
 }
 
 .modal-surface {
-  @apply rounded-lg shadow-2xl flex flex-col;
+  @apply rounded-xl shadow-2xl flex flex-col;
   background-color: var(--surface-base);
   color: var(--text-primary);
   max-width: min(100%, calc(100vw - 32px));
   overflow-wrap: anywhere;
   word-break: break-word;
   min-width: 0;
+}
+
+/* Modal button styles - unified taxonomy */
+.modal-button {
+  @apply px-4 py-2 text-sm rounded-md transition-colors cursor-pointer inline-flex items-center justify-center font-medium;
+  gap: var(--space-xs);
+  border: 1px solid transparent;
+}
+
+.modal-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--focus-ring-offset), 0 0 0 4px var(--focus-ring-color);
+}
+
+.modal-button:disabled {
+  @apply opacity-50 cursor-not-allowed;
+}
+
+.modal-button--primary {
+  background-color: var(--accent-primary);
+  color: var(--text-inverted);
+  border-color: var(--accent-primary);
+}
+
+.modal-button--primary:hover:not(:disabled) {
+  background-color: var(--accent-hover);
+  border-color: var(--accent-hover);
+}
+
+.modal-button--secondary {
+  background-color: var(--surface-secondary);
+  color: var(--text-primary);
+  border-color: var(--border-base);
+}
+
+.modal-button--secondary:hover:not(:disabled) {
+  background-color: var(--surface-hover);
+}
+
+.modal-button--ghost {
+  background-color: transparent;
+  color: var(--text-secondary);
+  border-color: var(--border-base);
+}
+
+.modal-button--ghost:hover:not(:disabled) {
+  background-color: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.modal-button--danger {
+  background-color: transparent;
+  color: var(--status-error);
+  border-color: var(--border-base);
+}
+
+.modal-button--danger:hover:not(:disabled) {
+  background-color: var(--danger-soft-bg);
+}
+
+/* Modal input styles - unified inputs */
+.modal-input {
+  @apply w-full px-3 py-2 text-sm rounded-md transition-colors;
+  background-color: var(--surface-base);
+  color: var(--text-primary);
+  border: 1px solid var(--border-base);
+}
+
+.modal-input:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 2px rgba(0, 102, 255, 0.1);
+}
+
+.modal-input::placeholder {
+  color: var(--text-muted);
+}
+
+.modal-input:disabled {
+  @apply opacity-50 cursor-not-allowed;
+  background-color: var(--surface-secondary);
+}
+
+/* Modal section grouping */
+.modal-section {
+  @apply flex flex-col;
+  gap: var(--space-lg);
+}
+
+.modal-section-header {
+  @apply flex items-center pb-2 mb-1 border-b text-xs font-semibold uppercase tracking-wide;
+  border-color: var(--border-base);
+  color: var(--text-muted);
+  gap: var(--space-sm);
+}
+
+.modal-section-header svg {
+  @apply w-3.5 h-3.5;
 }
 
 .modal-search-container {

--- a/packages/ui/src/styles/panels/panel-shell.css
+++ b/packages/ui/src/styles/panels/panel-shell.css
@@ -4,6 +4,13 @@
   background-color: var(--surface-base);
   border-color: var(--border-base);
   color: var(--text-primary);
+  position: relative;
+  z-index: 1;
+}
+
+/* Ensure shrink-0 panels have higher z-index to prevent overlap issues */
+.panel.shrink-0 {
+  z-index: 2;
 }
 
 .panel-footer-hints {

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -20,6 +20,13 @@
   /* Accent tokens */
   --accent-primary: #0066ff;
   --accent-hover: #0052cc;
+
+  /* Context progress tokens */
+  --context-progress-track: rgba(0, 0, 0, 0.08);
+  --context-progress-low: #22c55e;
+  --context-progress-moderate: #3b82f6;
+  --context-progress-warning: #f59e0b;
+  --context-progress-critical: #ef4444;
   
   /* Status tokens */
   --status-success: #4caf50;

--- a/packages/ui/src/styles/utilities.css
+++ b/packages/ui/src/styles/utilities.css
@@ -66,8 +66,9 @@
     button.button-secondary,
     .button-tertiary,
     button.button-tertiary) {
-  @apply inline-flex items-center justify-center gap-2 font-medium transition-colors rounded-md;
+  @apply inline-flex items-center justify-center gap-2 font-medium transition-colors;
   border: 1px solid transparent;
+  border-radius: var(--button-radius);
 }
 
 :is(.button-primary,
@@ -89,6 +90,24 @@
   @apply cursor-not-allowed opacity-50;
 }
 
+:is(.icon-button,
+    button.icon-button) {
+  @apply inline-flex items-center justify-center transition-colors;
+  border: 1px solid transparent;
+  border-radius: var(--button-radius);
+}
+
+:is(.icon-button,
+    button.icon-button):focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--focus-ring-offset), 0 0 0 4px var(--focus-ring-color);
+}
+
+:is(.icon-button,
+    button.icon-button):disabled {
+  @apply cursor-not-allowed opacity-50;
+}
+
 :is(.attachment-chip,
     .neutral-badge,
     .status-badge) {
@@ -101,6 +120,31 @@
   outline: none;
   border-color: transparent;
   box-shadow: 0 0 0 2px var(--accent-primary);
+}
+
+.focus-ring:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--focus-ring-offset), 0 0 0 4px var(--focus-ring-color);
+}
+
+/* Shared row actions */
+.row-actions-reveal {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+
+.row-reveal:hover .row-actions-reveal,
+.row-reveal:focus-within .row-actions-reveal {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (pointer: coarse) {
+  .row-actions-reveal {
+    opacity: 1;
+    pointer-events: auto;
+  }
 }
 
 /* Shared animations */
@@ -132,4 +176,193 @@
 
 .kbd-separator {
   @apply opacity-50;
+}
+
+/* Typography utilities */
+.text-2xs {
+  font-size: var(--font-size-2xs);
+  line-height: var(--line-height-tight);
+}
+
+.text-xs {
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-tight);
+}
+
+.text-sm {
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+}
+
+.text-base {
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-normal);
+}
+
+.text-lg {
+  font-size: var(--font-size-lg);
+  line-height: var(--line-height-normal);
+}
+
+.text-xl {
+  font-size: var(--font-size-xl);
+  line-height: var(--line-height-tight);
+}
+
+.text-2xl {
+  font-size: var(--font-size-2xl);
+  line-height: var(--line-height-tight);
+}
+
+.text-3xl {
+  font-size: var(--font-size-3xl);
+  line-height: var(--line-height-tight);
+}
+
+.text-4xl {
+  font-size: var(--font-size-4xl);
+  line-height: var(--line-height-none);
+}
+
+/* Font weight utilities */
+.font-normal {
+  font-weight: var(--font-weight-regular);
+}
+
+.font-medium {
+  font-weight: var(--font-weight-medium);
+}
+
+.font-semibold {
+  font-weight: var(--font-weight-semibold);
+}
+
+.font-bold {
+  font-weight: var(--font-weight-bold);
+}
+
+/* Letter spacing utilities */
+.tracking-tighter {
+  letter-spacing: var(--letter-spacing-tighter);
+}
+
+.tracking-tight {
+  letter-spacing: var(--letter-spacing-tight);
+}
+
+.tracking-normal {
+  letter-spacing: var(--letter-spacing-normal);
+}
+
+.tracking-wide {
+  letter-spacing: var(--letter-spacing-wide);
+}
+
+.tracking-wider {
+  letter-spacing: var(--letter-spacing-wider);
+}
+
+.tracking-widest {
+  letter-spacing: var(--letter-spacing-widest);
+}
+
+/* Line height utilities */
+.leading-none {
+  line-height: var(--line-height-none);
+}
+
+.leading-tight {
+  line-height: var(--line-height-tight);
+}
+
+.leading-snug {
+  line-height: var(--line-height-snug);
+}
+
+.leading-normal {
+  line-height: var(--line-height-normal);
+}
+
+.leading-relaxed {
+  line-height: var(--line-height-relaxed);
+}
+
+.leading-loose {
+  line-height: var(--line-height-loose);
+}
+
+/* Font family utilities */
+.font-sans {
+  font-family: var(--font-family-sans);
+}
+
+.font-mono {
+  font-family: var(--font-family-mono);
+}
+
+/* Label styles - useful for form labels, headings */
+.label {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--letter-spacing-wide);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.label-sm {
+  font-size: var(--font-size-2xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--letter-spacing-wider);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+/* Heading presets */
+.heading-lg {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--letter-spacing-tight);
+  line-height: var(--line-height-tight);
+  color: var(--text-primary);
+}
+
+.heading-md {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--letter-spacing-tight);
+  line-height: var(--line-height-tight);
+  color: var(--text-primary);
+}
+
+.heading-sm {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--line-height-tight);
+  color: var(--text-primary);
+}
+
+/* Body text presets */
+.body-lg {
+  font-size: var(--font-size-lg);
+  line-height: var(--line-height-relaxed);
+  color: var(--text-primary);
+}
+
+.body-base {
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-normal);
+  color: var(--text-primary);
+}
+
+.body-sm {
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+  color: var(--text-secondary);
+}
+
+/* Caption/helper text */
+.caption {
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-normal);
+  color: var(--text-muted);
 }


### PR DESCRIPTION
## Summary

- **MCP Settings Panel**: New panel for managing Model Context Protocol servers with connect/disconnect functionality
- **Provider Settings Panel**: Configure AI providers and their settings
- **Model Defaults Panel**: Set default models per agent for consistent behavior
- **Bug Fixes**: Fixed several UI issues including missing icon import, SolidJS warnings, and CSS click handling problems

## Changes

### New Components
- `instance-mcp-control.tsx` - MCP server control in status panel
- `mcp-settings-panel.tsx` - Full MCP settings management
- `provider-settings-panel.tsx` - Provider configuration
- `model-defaults-panel.tsx` - Model defaults per agent
- `theme-toggle.tsx` - Theme switcher component
- `instance-api.ts` - API wrapper for instance operations

### Bug Fixes
- Fixed `ReferenceError: Info is not defined` in session-list.tsx that prevented workspace initialization
- Fixed SolidJS "computations created outside createRoot" warning in preferences.tsx
- Fixed CSS z-index/overflow issues that prevented clicking on folder selection buttons

### Styling
- Enhanced button variants and styles
- Improved modal layouts
- New control panel styling
- Better form input styling

## Test plan

- [ ] Verify MCP settings panel opens and displays servers
- [ ] Test provider settings configuration
- [ ] Confirm model defaults can be set per agent
- [ ] Verify folder selection clicking works
- [ ] Check that workspace initialization succeeds on page load
- [ ] Confirm no console errors on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)