### PR TITLE
Fix markdown code block text visibility in light mode

### DIFF
--- a/packages/ui/src/styles/markdown.css
+++ b/packages/ui/src/styles/markdown.css
@@ -157,16 +157,6 @@
     width: 100%;
     margin: 1rem 0;
     background-color: transparent;
-    display: block;
-    padding-right: 0.75rem;
-  }
-
-  .markdown-body thead,
-  .markdown-body tbody,
-  .markdown-body tfoot {
-    width: 100%;
-    display: table;
-    table-layout: fixed;
   }
 
   .markdown-body th,
@@ -182,8 +172,12 @@
     background-color: var(--surface-secondary);
   }
 
-  .markdown-body tbody tr:nth-child(2n) {
-    background-color: var(--surface-muted);
+  .markdown-body tbody > tr:nth-child(odd) > td {
+    background-color: var(--markdown-table-row-odd);
+  }
+
+  .markdown-body tbody > tr:nth-child(even) > td {
+    background-color: var(--markdown-table-row-even);
   }
 
   .markdown-code-block {

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -6,6 +6,8 @@
   --surface-muted: #f8fafc;
   --surface-code: #f1f5f9;
   --surface-hover: #e0e0e0;
+  --markdown-table-row-odd: transparent;
+  --markdown-table-row-even: #f1f5f9;
   
   /* Border tokens */
   --border-base: #e0e0e0;
@@ -180,6 +182,8 @@
     --surface-muted: #212529;
     --surface-code: #1a1a1a;
     --surface-hover: #3a3a3a;
+    --markdown-table-row-odd: #0f1114;
+    --markdown-table-row-even: #181c22;
     
     /* Border tokens */
     --border-base: #3a3a3a;
@@ -347,6 +351,8 @@
   --surface-muted: #212529;
   --surface-code: #1a1a1a;
   --surface-hover: #3a3a3a;
+  --markdown-table-row-odd: #0f1114;
+  --markdown-table-row-even: #181c22;
   
   /* Border tokens */
   --border-base: #3a3a3a;


### PR DESCRIPTION
* Fixes markdown code block text in light mode by using token-based text color for code blocks.
* Another pass indicated diagnostic sections and tables had the same issue in light mode, made those changes as well.


Before, the invisible text in light mode:
<img width="657" height="519" alt="Screenshot From 2026-02-11 14-32-29" src="https://github.com/user-attachments/assets/32aa619b-303e-44a4-b4da-b92ed1272f55" />

After:
<img width="657" height="519" alt="Screenshot From 2026-02-11 15-22-14" src="https://github.com/user-attachments/assets/aa6a81d3-8a94-4d71-bd47-de8946bf2e47" />

And regression testing on dark mode checks out:
<img width="450" height="490" alt="Screenshot From 2026-02-11 15-34-52" src="https://github.com/user-attachments/assets/f1f42a9a-3afe-4f81-80a3-6f69b711bc1b" />
