### PR TITLE
fix(ui): prevent timeline auto-scroll when removing badges (#189)

### DIFF
--- a/packages/ui/src/components/message-timeline.tsx
+++ b/packages/ui/src/components/message-timeline.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createEffect, createMemo, createSignal, onCleanup, type Component } from "solid-js"
+import { For, Show, createEffect, createMemo, createSignal, onCleanup, on, untrack, type Component } from "solid-js"
 import MessagePreview from "./message-preview"
 import { messageStoreBus } from "../stores/message-v2/bus"
 import type { ClientPart } from "../types/message"
@@ -350,11 +350,9 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
     clearCloseTimer()
   })
 
-  createEffect(() => {
-    const activeId = props.activeMessageId
-
+  createEffect(on(() => props.activeMessageId, (activeId) => {
     if (!activeId) return
-    const targetSegment = props.segments.find((segment) => segment.messageId === activeId)
+    const targetSegment = untrack(() => props.segments).find((segment) => segment.messageId === activeId)
     if (!targetSegment) return
     const element = buttonRefs.get(targetSegment.id)
     if (!element) return
@@ -366,7 +364,7 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
         window.clearTimeout(timer)
       }
     })
-  })
+  }))
 
   createEffect(() => {
     const element = tooltipElement()


### PR DESCRIPTION
## Summary
This PR fixes an issue #189 where the timeline sidebar would automatically scroll to the bottom (the active message) every time a badge was deleted.

## Changes
- **Refined Scroll Logic**: Updated the scroll-into-view effect in `MessageTimeline.tsx` to use Solid's `on()` helper.
- **Strict Tracking**: The effect now explicitly tracks `activeMessageId` only, ignoring incidental updates to the `segments` list.
- **Isolated State**: Wrapped the `segments` access in `untrack()` within the scroll effect to prevent it from triggering during badge deletion or list modifications.

## Impact
Users can now delete history items without losing their current scroll position in the sidebar. The sidebar will only auto-scroll if the user explicitly navigates to a different message or a new message is added.

## Verification Results
- [x] Confirmed that deleting a badge maintains the current scroll position.
- [x] Confirmed that clicking a badge still correctly scrolls the main view.
- [x] Confirmed that auto-scrolling to the active icon still works when the active message changes.