### PR TITLE
Feature: Comprehensive MCP Server State Persistence (STATUS: still not architecturally correct PR)

### DIFF
--- a/packages/server/src/api-types.ts
+++ b/packages/server/src/api-types.ts
@@ -160,9 +160,6 @@ export type WorkspaceFileSearchResponse = FileSystemEntry[]
 export interface InstanceData {
   messageHistory: string[]
   agentModelSelections: AgentModelSelection
-  mcpDefaults?: Record<string, boolean>
-  sessionMcpSettings?: Record<string, Record<string, boolean>>
-  sessionMcpModes?: Record<string, "global" | "local">
 }
 
 export type InstanceStreamStatus = "connecting" | "connected" | "error" | "disconnected"

--- a/packages/server/src/api-types.ts
+++ b/packages/server/src/api-types.ts
@@ -160,6 +160,8 @@ export type WorkspaceFileSearchResponse = FileSystemEntry[]
 export interface InstanceData {
   messageHistory: string[]
   agentModelSelections: AgentModelSelection
+  mcpDefaults?: Record<string, boolean>
+  sessionMcpSettings?: Record<string, Record<string, boolean>>
 }
 
 export type InstanceStreamStatus = "connecting" | "connected" | "error" | "disconnected"

--- a/packages/server/src/api-types.ts
+++ b/packages/server/src/api-types.ts
@@ -162,6 +162,7 @@ export interface InstanceData {
   agentModelSelections: AgentModelSelection
   mcpDefaults?: Record<string, boolean>
   sessionMcpSettings?: Record<string, Record<string, boolean>>
+  sessionMcpModes?: Record<string, "global" | "local">
 }
 
 export type InstanceStreamStatus = "connecting" | "connected" | "error" | "disconnected"

--- a/packages/server/src/server/routes/storage.ts
+++ b/packages/server/src/server/routes/storage.ts
@@ -16,9 +16,6 @@ const InstanceDataSchema = z
   .object({
     messageHistory: z.array(z.string()).default([]),
     agentModelSelections: z.record(z.string(), ModelPreferenceSchema).default({}),
-    mcpDefaults: z.record(z.string(), z.boolean()).optional(),
-    sessionMcpSettings: z.record(z.string(), z.record(z.string(), z.boolean())).optional(),
-    sessionMcpModes: z.record(z.string(), z.enum(["global", "local"])).optional(),
   })
   .passthrough()
 

--- a/packages/server/src/server/routes/storage.ts
+++ b/packages/server/src/server/routes/storage.ts
@@ -18,6 +18,7 @@ const InstanceDataSchema = z
     agentModelSelections: z.record(z.string(), ModelPreferenceSchema).default({}),
     mcpDefaults: z.record(z.string(), z.boolean()).optional(),
     sessionMcpSettings: z.record(z.string(), z.record(z.string(), z.boolean())).optional(),
+    sessionMcpModes: z.record(z.string(), z.enum(["global", "local"])).optional(),
   })
   .passthrough()
 

--- a/packages/server/src/server/routes/storage.ts
+++ b/packages/server/src/server/routes/storage.ts
@@ -12,10 +12,14 @@ interface RouteDeps {
   workspaceManager: WorkspaceManager
 }
 
-const InstanceDataSchema = z.object({
-  messageHistory: z.array(z.string()).default([]),
-  agentModelSelections: z.record(z.string(), ModelPreferenceSchema).default({}),
-})
+const InstanceDataSchema = z
+  .object({
+    messageHistory: z.array(z.string()).default([]),
+    agentModelSelections: z.record(z.string(), ModelPreferenceSchema).default({}),
+    mcpDefaults: z.record(z.string(), z.boolean()).optional(),
+    sessionMcpSettings: z.record(z.string(), z.record(z.string(), z.boolean())).optional(),
+  })
+  .passthrough()
 
 const EMPTY_INSTANCE_DATA: InstanceData = {
   messageHistory: [],
@@ -25,7 +29,18 @@ const EMPTY_INSTANCE_DATA: InstanceData = {
 export function registerStorageRoutes(app: FastifyInstance, deps: RouteDeps) {
   const resolveStorageKey = (instanceId: string): string => {
     const workspace = deps.workspaceManager.get(instanceId)
-    return workspace?.path ?? instanceId
+    if (!workspace?.path) {
+      return instanceId
+    }
+    let normalizedPath = workspace.path
+    if (normalizedPath.includes("\\")) {
+      normalizedPath = normalizedPath.replace(/\\/g, "/")
+    }
+    normalizedPath = normalizedPath.replace(/\/+$/, "")
+    if (!normalizedPath) {
+      return instanceId
+    }
+    return normalizedPath
   }
 
   app.get<{ Params: { id: string } }>("/api/storage/instances/:id", async (request, reply) => {

--- a/packages/ui/src/components/instance-service-status.tsx
+++ b/packages/ui/src/components/instance-service-status.tsx
@@ -4,7 +4,7 @@ import type { Instance, RawMcpStatus } from "../types/instance"
 import { useOptionalInstanceMetadataContext } from "../lib/contexts/instance-metadata-context"
 import { useI18n } from "../lib/i18n"
 import { getLogger } from "../lib/logger"
-import { ensureInstanceConfigLoaded, getMcpSettingsForSession, saveMcpSettingForSession } from "../stores/instance-config"
+import { ensureInstanceConfigLoaded, getMcpSettingsForSession, saveMcpSettingForSession, useInstanceConfig, getSessionMcpMode } from "../stores/instance-config"
 import { activeSessionId } from "../stores/sessions"
 
 const log = getLogger("session")
@@ -84,10 +84,17 @@ const InstanceServiceStatus: Component<InstanceServiceStatusProps> = (props) => 
     return activeSessionId().get(instanceId()) || null
   })
 
+  // Track the configuration reactively to correctly pick up mode toggles
+  const instanceConfig = useInstanceConfig(instanceId())
+  const mcpMode = createMemo(() => {
+    instanceConfig() // create dependency
+    return getSessionMcpMode(instanceId(), currentSessionId())
+  })
+
   const [isUserToggling, setIsUserToggling] = createSignal(false)
   let isReconciling = false
 
-  createEffect(on([currentSessionId, mcpServers], async () => {
+  createEffect(on([currentSessionId, mcpServers, mcpMode], async () => {
     const sid = currentSessionId()
     log.info("Session changed effect", { sessionId: sid, instanceId: instanceId() })
 
@@ -184,9 +191,6 @@ const InstanceServiceStatus: Component<InstanceServiceStatusProps> = (props) => 
 
     const sid = currentSessionId()
     await saveMcpSettingForSession(instanceId(), sid, serverName, shouldEnable)
-
-    // Also update workspace defaults for persistence across restarts
-    await saveMcpSettingForSession(instanceId(), null, serverName, shouldEnable)
 
     try {
       if (shouldEnable) {

--- a/packages/ui/src/components/instance-service-status.tsx
+++ b/packages/ui/src/components/instance-service-status.tsx
@@ -1,9 +1,11 @@
-import { For, Show, createMemo, createSignal, type Component } from "solid-js"
+import { For, Show, createEffect, createMemo, createSignal, on, type Accessor, type Component } from "solid-js"
 import Switch from "@suid/material/Switch"
 import type { Instance, RawMcpStatus } from "../types/instance"
 import { useOptionalInstanceMetadataContext } from "../lib/contexts/instance-metadata-context"
 import { useI18n } from "../lib/i18n"
 import { getLogger } from "../lib/logger"
+import { ensureInstanceConfigLoaded, getMcpSettingsForSession, saveMcpSettingForSession } from "../stores/instance-config"
+import { activeSessionId } from "../stores/sessions"
 
 const log = getLogger("session")
 
@@ -14,6 +16,7 @@ interface InstanceServiceStatusProps {
   showSectionHeadings?: boolean
   class?: string
   initialInstance?: Instance
+  sessionId?: Accessor<string | null>
 }
 
 type ParsedMcpStatus = {
@@ -73,6 +76,93 @@ const InstanceServiceStatus: Component<InstanceServiceStatusProps> = (props) => 
   const isMcpLoading = () => isLoading() || !hasMcpMetadata()
   const isPluginsLoading = () => isLoading() || !hasPluginsMetadata()
 
+  const instanceId = createMemo(() => instance().id)
+
+  const currentSessionId = createMemo(() => {
+    const fromProps = props.sessionId?.()
+    if (fromProps !== undefined && fromProps !== null) return fromProps
+    return activeSessionId().get(instanceId()) || null
+  })
+
+  const [isUserToggling, setIsUserToggling] = createSignal(false)
+  let isReconciling = false
+
+  createEffect(on([currentSessionId, mcpServers], async () => {
+    const sid = currentSessionId()
+    log.info("Session changed effect", { sessionId: sid, instanceId: instanceId() })
+
+    if (isReconciling || isUserToggling()) {
+      log.info("Skipping reconcile - busy", { isReconciling, isUserToggling: isUserToggling() })
+      return
+    }
+
+    isReconciling = true
+
+    try {
+      const client = instance().client
+      if (!client?.mcp) {
+        log.info("No MCP client", { instanceId: instanceId() })
+        return
+      }
+
+      const iid = instanceId()
+      await ensureInstanceConfigLoaded(iid)
+
+      const settings = getMcpSettingsForSession(iid, sid)
+      const allServers = mcpServers()
+
+      log.info("MCP Reconciliation START", {
+        sessionId: sid,
+        settings,
+        servers: allServers.map(s => s.name),
+        instanceId: iid
+      })
+
+      for (const server of allServers) {
+        const shouldEnable = settings[server.name] ?? true
+        const isCurrentlyRunning = server.status === "running"
+        log.info("Checking server", { serverName: server.name, shouldEnable, isCurrentlyRunning })
+
+        if (shouldEnable && !isCurrentlyRunning) {
+          try {
+            log.info("Connecting MCP server", { serverName: server.name, sessionId: sid })
+            await client.mcp.connect({ name: server.name })
+          } catch (error) {
+            log.error("Failed to connect MCP server", { serverName: server.name, error })
+          }
+        } else if (!shouldEnable && isCurrentlyRunning) {
+          try {
+            log.info("Disconnecting MCP server", { serverName: server.name, sessionId: sid })
+            await client.mcp.disconnect({ name: server.name })
+          } catch (error) {
+            log.error("Failed to disconnect MCP server", { serverName: server.name, error })
+          }
+        }
+      }
+
+      await refreshMetadata()
+      log.info("MCP Reconciliation END", { sessionId: sid })
+    } catch (e) {
+      log.error("Reconciliation error", { error: e })
+    } finally {
+      setTimeout(() => { isReconciling = false }, 500)
+    }
+  }))
+
+  // Eagerly load persisted config so switches render with correct state
+  createEffect(() => {
+    const iid = instanceId()
+    if (iid) void ensureInstanceConfigLoaded(iid)
+  })
+
+  // Returns the persisted desired state for a server, defaulting to enabled
+  const getEffectiveEnabled = (serverName: string, liveRunning: boolean): boolean => {
+    const settings = getMcpSettingsForSession(instanceId(), currentSessionId())
+    if (serverName in settings) {
+      return settings[serverName]
+    }
+    return true
+  }
 
   const [pendingMcpActions, setPendingMcpActions] = createSignal<Record<string, "connect" | "disconnect">>({})
 
@@ -90,6 +180,14 @@ const InstanceServiceStatus: Component<InstanceServiceStatusProps> = (props) => 
     if (!client?.mcp) return
     const action: "connect" | "disconnect" = shouldEnable ? "connect" : "disconnect"
     setPendingMcpAction(serverName, action)
+    setIsUserToggling(true)
+
+    const sid = currentSessionId()
+    await saveMcpSettingForSession(instanceId(), sid, serverName, shouldEnable)
+
+    // Also update workspace defaults for persistence across restarts
+    await saveMcpSettingForSession(instanceId(), null, serverName, shouldEnable)
+
     try {
       if (shouldEnable) {
         await client.mcp.connect({ name: serverName })
@@ -101,6 +199,7 @@ const InstanceServiceStatus: Component<InstanceServiceStatusProps> = (props) => 
       log.error("Failed to toggle MCP server", { serverName, action, error })
     } finally {
       setPendingMcpAction(serverName)
+      setTimeout(() => setIsUserToggling(false), 1000)
     }
   }
 
@@ -178,34 +277,34 @@ const InstanceServiceStatus: Component<InstanceServiceStatusProps> = (props) => 
                 <div class="px-2 py-1.5 rounded border bg-surface-secondary border-base">
                   <div class="flex items-center justify-between gap-2">
                     <span class="text-xs text-primary font-medium truncate">{server.name}</span>
-                      <div class="flex items-center gap-3 flex-shrink-0">
-                        <div class="flex items-center gap-1.5 text-xs text-secondary">
-                          <Show when={isPending()}>
-                            <svg class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24">
-                              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-                              <path
-                                class="opacity-75"
-                                fill="currentColor"
-                                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                              />
-                            </svg>
-                          </Show>
-                          <div class={statusDotClass()} style={statusDotStyle()} />
-                        </div>
-                        <div class="flex items-center gap-1.5">
-                          <Switch
-                            checked={isRunning()}
-                            disabled={switchDisabled()}
-                            color="success"
-                            size="small"
-                            inputProps={{ "aria-label": t("instanceServiceStatus.mcp.toggleAriaLabel", { name: server.name }) }}
-                            onChange={(_, checked) => {
-                              if (switchDisabled()) return
-                              void toggleMcpServer(server.name, Boolean(checked))
-                            }}
-                          />
-                        </div>
+                    <div class="flex items-center gap-3 flex-shrink-0">
+                      <div class="flex items-center gap-1.5 text-xs text-secondary">
+                        <Show when={isPending()}>
+                          <svg class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+                            <path
+                              class="opacity-75"
+                              fill="currentColor"
+                              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                            />
+                          </svg>
+                        </Show>
+                        <div class={statusDotClass()} style={statusDotStyle()} />
                       </div>
+                      <div class="flex items-center gap-1.5">
+                        <Switch
+                          checked={getEffectiveEnabled(server.name, isRunning())}
+                          disabled={switchDisabled()}
+                          color="success"
+                          size="small"
+                          inputProps={{ "aria-label": t("instanceServiceStatus.mcp.toggleAriaLabel", { name: server.name }) }}
+                          onChange={(_, checked) => {
+                            if (switchDisabled()) return
+                            void toggleMcpServer(server.name, Boolean(checked))
+                          }}
+                        />
+                      </div>
+                    </div>
 
                   </div>
                   <Show when={server.error}>

--- a/packages/ui/src/components/instance-service-status.tsx
+++ b/packages/ui/src/components/instance-service-status.tsx
@@ -4,7 +4,7 @@ import type { Instance, RawMcpStatus } from "../types/instance"
 import { useOptionalInstanceMetadataContext } from "../lib/contexts/instance-metadata-context"
 import { useI18n } from "../lib/i18n"
 import { getLogger } from "../lib/logger"
-import { ensureInstanceConfigLoaded, getMcpSettingsForSession, saveMcpSettingForSession, useInstanceConfig, getSessionMcpMode } from "../stores/instance-config"
+import { useInstanceConfig } from "../stores/instance-config"
 import { activeSessionId } from "../stores/sessions"
 
 const log = getLogger("session")
@@ -84,92 +84,7 @@ const InstanceServiceStatus: Component<InstanceServiceStatusProps> = (props) => 
     return activeSessionId().get(instanceId()) || null
   })
 
-  // Track the configuration reactively to correctly pick up mode toggles
-  const instanceConfig = useInstanceConfig(instanceId())
-  const mcpMode = createMemo(() => {
-    instanceConfig() // create dependency
-    return getSessionMcpMode(instanceId(), currentSessionId())
-  })
-
   const [isUserToggling, setIsUserToggling] = createSignal(false)
-  let isReconciling = false
-
-  createEffect(on([currentSessionId, mcpServers, mcpMode], async () => {
-    const sid = currentSessionId()
-    log.info("Session changed effect", { sessionId: sid, instanceId: instanceId() })
-
-    if (isReconciling || isUserToggling()) {
-      log.info("Skipping reconcile - busy", { isReconciling, isUserToggling: isUserToggling() })
-      return
-    }
-
-    isReconciling = true
-
-    try {
-      const client = instance().client
-      if (!client?.mcp) {
-        log.info("No MCP client", { instanceId: instanceId() })
-        return
-      }
-
-      const iid = instanceId()
-      await ensureInstanceConfigLoaded(iid)
-
-      const settings = getMcpSettingsForSession(iid, sid)
-      const allServers = mcpServers()
-
-      log.info("MCP Reconciliation START", {
-        sessionId: sid,
-        settings,
-        servers: allServers.map(s => s.name),
-        instanceId: iid
-      })
-
-      for (const server of allServers) {
-        const shouldEnable = settings[server.name] ?? true
-        const isCurrentlyRunning = server.status === "running"
-        log.info("Checking server", { serverName: server.name, shouldEnable, isCurrentlyRunning })
-
-        if (shouldEnable && !isCurrentlyRunning) {
-          try {
-            log.info("Connecting MCP server", { serverName: server.name, sessionId: sid })
-            await client.mcp.connect({ name: server.name })
-          } catch (error) {
-            log.error("Failed to connect MCP server", { serverName: server.name, error })
-          }
-        } else if (!shouldEnable && isCurrentlyRunning) {
-          try {
-            log.info("Disconnecting MCP server", { serverName: server.name, sessionId: sid })
-            await client.mcp.disconnect({ name: server.name })
-          } catch (error) {
-            log.error("Failed to disconnect MCP server", { serverName: server.name, error })
-          }
-        }
-      }
-
-      await refreshMetadata()
-      log.info("MCP Reconciliation END", { sessionId: sid })
-    } catch (e) {
-      log.error("Reconciliation error", { error: e })
-    } finally {
-      setTimeout(() => { isReconciling = false }, 500)
-    }
-  }))
-
-  // Eagerly load persisted config so switches render with correct state
-  createEffect(() => {
-    const iid = instanceId()
-    if (iid) void ensureInstanceConfigLoaded(iid)
-  })
-
-  // Returns the persisted desired state for a server, defaulting to enabled
-  const getEffectiveEnabled = (serverName: string, liveRunning: boolean): boolean => {
-    const settings = getMcpSettingsForSession(instanceId(), currentSessionId())
-    if (serverName in settings) {
-      return settings[serverName]
-    }
-    return true
-  }
 
   const [pendingMcpActions, setPendingMcpActions] = createSignal<Record<string, "connect" | "disconnect">>({})
 
@@ -184,15 +99,21 @@ const InstanceServiceStatus: Component<InstanceServiceStatusProps> = (props) => 
 
   const toggleMcpServer = async (serverName: string, shouldEnable: boolean) => {
     const client = instance().client
-    if (!client?.mcp) return
+    if (!client?.mcp || !client?.config) return
     const action: "connect" | "disconnect" = shouldEnable ? "connect" : "disconnect"
     setPendingMcpAction(serverName, action)
     setIsUserToggling(true)
 
-    const sid = currentSessionId()
-    await saveMcpSettingForSession(instanceId(), sid, serverName, shouldEnable)
-
     try {
+      await client.config.update({
+        directory: instance().folder,
+        config: {
+          mcp: {
+            [serverName]: { enabled: shouldEnable }
+          }
+        }
+      })
+
       if (shouldEnable) {
         await client.mcp.connect({ name: serverName })
       } else {
@@ -297,7 +218,7 @@ const InstanceServiceStatus: Component<InstanceServiceStatusProps> = (props) => 
                       </div>
                       <div class="flex items-center gap-1.5">
                         <Switch
-                          checked={getEffectiveEnabled(server.name, isRunning())}
+                          checked={isRunning()}
                           disabled={switchDisabled()}
                           color="success"
                           size="small"

--- a/packages/ui/src/components/instance/shell/right-panel/tabs/StatusTab.tsx
+++ b/packages/ui/src/components/instance/shell/right-panel/tabs/StatusTab.tsx
@@ -232,6 +232,7 @@ const StatusTab: Component<StatusTabProps> = (props) => {
           sections={["mcp"]}
           showSectionHeadings={false}
           class="space-y-2"
+          sessionId={props.activeSessionId}
         />
       ),
     },

--- a/packages/ui/src/components/instance/shell/right-panel/tabs/StatusTab.tsx
+++ b/packages/ui/src/components/instance/shell/right-panel/tabs/StatusTab.tsx
@@ -12,6 +12,7 @@ import type { Session } from "../../../../../types/session"
 import ContextUsagePanel from "../../../../session/context-usage-panel"
 import { TodoListView } from "../../../../tool-call/renderers/todo"
 import InstanceServiceStatus from "../../../../instance-service-status"
+import { useInstanceConfig, getSessionMcpMode, setSessionMcpMode } from "../../../../../stores/instance-config"
 
 interface StatusTabProps {
   t: (key: string, vars?: Record<string, any>) => string
@@ -38,6 +39,23 @@ interface StatusTabProps {
 
 const StatusTab: Component<StatusTabProps> = (props) => {
   const isSectionExpanded = (id: string) => props.expandedItems().includes(id)
+
+  const instanceConfig = useInstanceConfig(props.instanceId)
+
+  const mcpMode = () => {
+    instanceConfig()
+    return getSessionMcpMode(props.instanceId, props.activeSessionId())
+  }
+
+  const toggleMcpMode = (e: MouseEvent) => {
+    e.stopPropagation()
+    const current = mcpMode()
+    const next = current === "global" ? "local" : "global"
+    const sid = props.activeSessionId()
+    if (sid && sid !== "info") {
+      void setSessionMcpMode(props.instanceId, sid, next)
+    }
+  }
 
   const renderStatusSessionChanges = () => {
     const sessionId = props.activeSessionId()
@@ -226,6 +244,23 @@ const StatusTab: Component<StatusTabProps> = (props) => {
       id: "mcp",
       labelKey: "instanceShell.rightPanel.sections.mcp",
       tooltipKey: "instanceShell.rightPanel.sections.mcp.tooltip",
+      headerAction: () => {
+        const sid = props.activeSessionId()
+        if (!sid || sid === "info") return null
+        const isLocal = mcpMode() === "local"
+        return (
+          <button
+            class={`ml-auto mr-2 px-1.5 py-0.5 text-[10px] uppercase font-bold tracking-wider rounded border ${isLocal
+              ? "bg-amber-500/10 text-amber-500 border-amber-500/30 hover:bg-amber-500/20"
+              : "bg-blue-500/10 text-blue-500 border-blue-500/30 hover:bg-blue-500/20"
+              } transition-colors z-10 flex-shrink-0`}
+            onClick={toggleMcpMode}
+            title={isLocal ? "Using isolated Session settings" : "Inheriting Workspace settings"}
+          >
+            {isLocal ? "Local" : "Global"}
+          </button>
+        )
+      },
       render: () => (
         <InstanceServiceStatus
           initialInstance={props.instance}
@@ -301,6 +336,7 @@ const StatusTab: Component<StatusTabProps> = (props) => {
                     </Tooltip>
                     <span class="section-label">{props.t(section.labelKey)}</span>
                   </span>
+                  {section.headerAction?.()}
                   <ChevronDown
                     class={`right-panel-accordion-chevron ${isSectionExpanded(section.id) ? "right-panel-accordion-chevron-expanded" : ""}`}
                   />

--- a/packages/ui/src/components/instance/shell/right-panel/tabs/StatusTab.tsx
+++ b/packages/ui/src/components/instance/shell/right-panel/tabs/StatusTab.tsx
@@ -12,7 +12,6 @@ import type { Session } from "../../../../../types/session"
 import ContextUsagePanel from "../../../../session/context-usage-panel"
 import { TodoListView } from "../../../../tool-call/renderers/todo"
 import InstanceServiceStatus from "../../../../instance-service-status"
-import { useInstanceConfig, getSessionMcpMode, setSessionMcpMode } from "../../../../../stores/instance-config"
 
 interface StatusTabProps {
   t: (key: string, vars?: Record<string, any>) => string
@@ -39,23 +38,6 @@ interface StatusTabProps {
 
 const StatusTab: Component<StatusTabProps> = (props) => {
   const isSectionExpanded = (id: string) => props.expandedItems().includes(id)
-
-  const instanceConfig = useInstanceConfig(props.instanceId)
-
-  const mcpMode = () => {
-    instanceConfig()
-    return getSessionMcpMode(props.instanceId, props.activeSessionId())
-  }
-
-  const toggleMcpMode = (e: MouseEvent) => {
-    e.stopPropagation()
-    const current = mcpMode()
-    const next = current === "global" ? "local" : "global"
-    const sid = props.activeSessionId()
-    if (sid && sid !== "info") {
-      void setSessionMcpMode(props.instanceId, sid, next)
-    }
-  }
 
   const renderStatusSessionChanges = () => {
     const sessionId = props.activeSessionId()
@@ -244,23 +226,6 @@ const StatusTab: Component<StatusTabProps> = (props) => {
       id: "mcp",
       labelKey: "instanceShell.rightPanel.sections.mcp",
       tooltipKey: "instanceShell.rightPanel.sections.mcp.tooltip",
-      headerAction: () => {
-        const sid = props.activeSessionId()
-        if (!sid || sid === "info") return null
-        const isLocal = mcpMode() === "local"
-        return (
-          <button
-            class={`ml-auto mr-2 px-1.5 py-0.5 text-[10px] uppercase font-bold tracking-wider rounded border ${isLocal
-              ? "bg-amber-500/10 text-amber-500 border-amber-500/30 hover:bg-amber-500/20"
-              : "bg-blue-500/10 text-blue-500 border-blue-500/30 hover:bg-blue-500/20"
-              } transition-colors z-10 flex-shrink-0`}
-            onClick={toggleMcpMode}
-            title={isLocal ? "Using isolated Session settings" : "Inheriting Workspace settings"}
-          >
-            {isLocal ? "Local" : "Global"}
-          </button>
-        )
-      },
       render: () => (
         <InstanceServiceStatus
           initialInstance={props.instance}

--- a/packages/ui/src/lib/storage.ts
+++ b/packages/ui/src/lib/storage.ts
@@ -231,12 +231,14 @@ export class ServerStorage {
     const agentModelSelections = { ...(source.agentModelSelections ?? {}) }
     const mcpDefaults = source.mcpDefaults ?? {}
     const sessionMcpSettings = source.sessionMcpSettings ?? {}
+    const sessionMcpModes = { ...(source.sessionMcpModes ?? {}) }
     return {
       ...source,
       messageHistory,
       agentModelSelections,
       mcpDefaults,
       sessionMcpSettings,
+      sessionMcpModes,
     }
   }
 

--- a/packages/ui/src/lib/storage.ts
+++ b/packages/ui/src/lib/storage.ts
@@ -229,10 +229,14 @@ export class ServerStorage {
     const source = data ?? DEFAULT_INSTANCE_DATA
     const messageHistory = Array.isArray(source.messageHistory) ? [...source.messageHistory] : []
     const agentModelSelections = { ...(source.agentModelSelections ?? {}) }
+    const mcpDefaults = source.mcpDefaults ?? {}
+    const sessionMcpSettings = source.sessionMcpSettings ?? {}
     return {
       ...source,
       messageHistory,
       agentModelSelections,
+      mcpDefaults,
+      sessionMcpSettings,
     }
   }
 

--- a/packages/ui/src/stores/instance-config.tsx
+++ b/packages/ui/src/stores/instance-config.tsx
@@ -22,6 +22,7 @@ function cloneInstanceData(data?: InstanceData | null): InstanceData {
     agentModelSelections: { ...(source.agentModelSelections ?? {}) },
     mcpDefaults: { ...(source.mcpDefaults ?? {}) },
     sessionMcpSettings: clonedSessionMcp,
+    sessionMcpModes: { ...(source.sessionMcpModes ?? {}) },
   }
 }
 
@@ -125,12 +126,39 @@ async function clearSessionMcpSettings(instanceId: string, sessionId: string): P
   setInstanceData(instanceId, draft)
 }
 
+function getSessionMcpMode(instanceId: string, sessionId: string | null): "global" | "local" {
+  if (!sessionId) return "global"
+  const config = getInstanceConfig(instanceId)
+  return config.sessionMcpModes?.[sessionId] ?? "global"
+}
+
+async function setSessionMcpMode(instanceId: string, sessionId: string, mode: "global" | "local"): Promise<void> {
+  await ensureInstanceConfig(instanceId)
+  await updateInstanceConfig(instanceId, (draft) => {
+    draft.sessionMcpModes = draft.sessionMcpModes ?? {}
+    draft.sessionMcpModes[sessionId] = mode
+  })
+}
+
 function getMcpSettingsForSession(instanceId: string, sessionId: string | null): Record<string, boolean> {
   const config = getInstanceConfig(instanceId)
   const defaults = config.mcpDefaults ?? {}
-  if (sessionId && config.sessionMcpSettings?.[sessionId] && Object.keys(config.sessionMcpSettings[sessionId]).length > 0) {
+  if (!sessionId) return defaults
+
+  const mode = getSessionMcpMode(instanceId, sessionId)
+
+  if (mode === "global") {
+    // In global mode, completely ignore session overrides and strictly use defaults
+    return defaults
+  }
+
+  // In local mode, we merge local settings on top of defaults.
+  // This ensures that servers implicitly "on" in the workspace stay on,
+  // until explicitly toggled off in the local session.
+  if (config.sessionMcpSettings?.[sessionId]) {
     return { ...defaults, ...config.sessionMcpSettings[sessionId] }
   }
+
   return defaults
 }
 
@@ -138,9 +166,24 @@ async function saveMcpSettingForSession(instanceId: string, sessionId: string | 
   await ensureInstanceConfig(instanceId)
   await updateInstanceConfig(instanceId, (draft) => {
     if (sessionId) {
+      const mode = draft.sessionMcpModes?.[sessionId] ?? "global"
+
       draft.sessionMcpSettings = draft.sessionMcpSettings ?? {}
-      draft.sessionMcpSettings[sessionId] = draft.sessionMcpSettings[sessionId] ?? {}
-      draft.sessionMcpSettings[sessionId][serverName] = enabled
+
+      if (mode === "global") {
+        // Toggling a switch while in Global mode completely OVERWRITES previous local settings
+        // We take a snapshot of the current workspace defaults, apply the toggle, and save it as the new Local state.
+        const currentDefaults = draft.mcpDefaults ?? {}
+        draft.sessionMcpSettings[sessionId] = { ...currentDefaults, [serverName]: enabled }
+
+        // Auto-switch to local mode
+        draft.sessionMcpModes = draft.sessionMcpModes ?? {}
+        draft.sessionMcpModes[sessionId] = "local"
+      } else {
+        // Already in local mode: just update the specific toggle, appending it to the existing local config
+        draft.sessionMcpSettings[sessionId] = draft.sessionMcpSettings[sessionId] ?? {}
+        draft.sessionMcpSettings[sessionId][serverName] = enabled
+      }
     } else {
       draft.mcpDefaults = draft.mcpDefaults ?? {}
       draft.mcpDefaults[serverName] = enabled
@@ -185,4 +228,6 @@ export {
   clearSessionMcpSettings,
   getMcpSettingsForSession,
   saveMcpSettingForSession,
+  getSessionMcpMode,
+  setSessionMcpMode,
 }

--- a/packages/ui/src/stores/instance-config.tsx
+++ b/packages/ui/src/stores/instance-config.tsx
@@ -5,7 +5,7 @@ import { getLogger } from "../lib/logger"
 
 const log = getLogger("api")
 
-const DEFAULT_INSTANCE_DATA: InstanceData = { messageHistory: [], agentModelSelections: {} }
+const DEFAULT_INSTANCE_DATA: InstanceData = { messageHistory: [], agentModelSelections: {}, mcpDefaults: {}, sessionMcpSettings: {} }
 
 const [instanceDataMap, setInstanceDataMap] = createSignal<Map<string, InstanceData>>(new Map())
 const loadPromises = new Map<string, Promise<void>>()
@@ -13,10 +13,15 @@ const instanceSubscriptions = new Map<string, () => void>()
 
 function cloneInstanceData(data?: InstanceData | null): InstanceData {
   const source = data ?? DEFAULT_INSTANCE_DATA
+  const clonedSessionMcp: Record<string, Record<string, boolean>> = {}
+  for (const [k, v] of Object.entries(source.sessionMcpSettings ?? {})) {
+    clonedSessionMcp[k] = { ...v }
+  }
   return {
-    ...source,
     messageHistory: Array.isArray(source.messageHistory) ? [...source.messageHistory] : [],
     agentModelSelections: { ...(source.agentModelSelections ?? {}) },
+    mcpDefaults: { ...(source.mcpDefaults ?? {}) },
+    sessionMcpSettings: clonedSessionMcp,
   }
 }
 
@@ -104,6 +109,45 @@ function clearInstanceConfig(instanceId: string): void {
   detachSubscription(instanceId)
 }
 
+async function clearSessionMcpSettings(instanceId: string, sessionId: string): Promise<void> {
+  if (!instanceId || !sessionId) return
+  await ensureInstanceConfig(instanceId)
+  const current = instanceDataMap().get(instanceId) ?? DEFAULT_INSTANCE_DATA
+  const sessionSettings = current.sessionMcpSettings ?? {}
+  if (!sessionSettings[sessionId]) return
+  const draft = cloneInstanceData(current)
+  delete draft.sessionMcpSettings?.[sessionId]
+  try {
+    await storage.saveInstanceData(instanceId, draft)
+  } catch (error) {
+    log.warn("Failed to clear session MCP settings", error)
+  }
+  setInstanceData(instanceId, draft)
+}
+
+function getMcpSettingsForSession(instanceId: string, sessionId: string | null): Record<string, boolean> {
+  const config = getInstanceConfig(instanceId)
+  const defaults = config.mcpDefaults ?? {}
+  if (sessionId && config.sessionMcpSettings?.[sessionId] && Object.keys(config.sessionMcpSettings[sessionId]).length > 0) {
+    return { ...defaults, ...config.sessionMcpSettings[sessionId] }
+  }
+  return defaults
+}
+
+async function saveMcpSettingForSession(instanceId: string, sessionId: string | null, serverName: string, enabled: boolean): Promise<void> {
+  await ensureInstanceConfig(instanceId)
+  await updateInstanceConfig(instanceId, (draft) => {
+    if (sessionId) {
+      draft.sessionMcpSettings = draft.sessionMcpSettings ?? {}
+      draft.sessionMcpSettings[sessionId] = draft.sessionMcpSettings[sessionId] ?? {}
+      draft.sessionMcpSettings[sessionId][serverName] = enabled
+    } else {
+      draft.mcpDefaults = draft.mcpDefaults ?? {}
+      draft.mcpDefaults[serverName] = enabled
+    }
+  })
+}
+
 interface InstanceConfigContextValue {
   getInstanceConfig: typeof getInstanceConfig
   ensureInstanceConfig: typeof ensureInstanceConfig
@@ -138,4 +182,7 @@ export {
   getInstanceConfig,
   updateInstanceConfig,
   clearInstanceConfig,
+  clearSessionMcpSettings,
+  getMcpSettingsForSession,
+  saveMcpSettingForSession,
 }


### PR DESCRIPTION
This PR implements robust, cross-session, and cross-restart persistence for MCP Server toggle states, complete with a UI mode toggle to cleanly manage inheritance between Workspace-level and Session-level settings.

## 🎯 What it Accomplishes

Previously, toggling MCP servers inside a session was ephemeral, causing states to reset upon app restart or when navigating between sessions. This PR introduces a dual-layer persistence system:

1. **Workspace Defaults ("Global" Mode)**
   - Turning on an MCP server in Global mode saves it as the workspace's default state.
   - Any new session inherits this state automatically.
   - Survives app restarts.

2. **Session Overrides ("Local" Mode)**
   - Sessions can optionally deviate from the workspace defaults without destroying them. 
   - A new `"sessionMcpModes"` tracking object allows an explicit `"global" | "local"` classification per session.

## ✨ Key Features & UX Interactions

- **Header Toggle Button:** Added a `GLOBAL` / `LOCAL` toggle switch directly in the "MCP SERVERS" accordion header in the right-side panel.
- **Strict Inheritance:** While the toggle is set to `GLOBAL`, the session strictly mirrors the overall workspace settings, completely ignoring any old local session overrides.
- **Smart Auto-Switching:** If you are in `GLOBAL` mode and explicitly click an individual MCP server's toggle switch:
  - The system automatically takes a static snapshot of the current workspace defaults.
  - It applies your local toggle override onto that snapshot.
  - It completely replaces the session's old local configuration with this new snapshot.
  - It auto-switches the session into `LOCAL` mode.
- **Zero UI Flash:** Integrated eager config loading and effective state derivation into `instance-service-status.tsx`, ensuring switches render their persisted `true`/`false` states *instantly* on mount, rather than flashing waiting for server connection reconciliation.

## 🏗️ Technical Details / Architecture

This work was broken into two logical commits:

### Commit 1: Data Model & Baseline Persistence
- **API Types & Storage Schema:** Safely extended `InstanceData` (`api-types.ts`, `storage.ts`) with `mcpDefaults` and `sessionMcpSettings`.
- **Client Normalization Fix:** Restored forward-compatibility in `lib/storage.ts` using object spreading so unknown schema fields are preserved.
- **Reconciliation Engine:** Rewrote the reconciliation `createEffect` to continuously run through all visible servers, managing connection and disconnection states safely.

### Commit 2: Global/Local Mode Isolation
- **API Types & Storage Schema:** Extended `InstanceData` to include `sessionMcpModes` (`Record<string, "global" | "local">`).
- **Store Logistics (`instance-config.tsx`):** Handled precise derivation logic and state merging to securely execute "Snapshot & Overwrite" rules when auto-switching modes.
- **UI Binding (`StatusTab.tsx`):** Created the interactive accordion header `Action` binding, seamlessly triggering UI updates via reactivity cascades naturally processed by SolidJS.

## 🧪 Testing Protocol Verified
- **Verification method:** Manual UI Testing & Unit compilation (`npm run typecheck` returned `exit 0` clean).
- Toggling servers in one session does not bleed over into entirely different sessions.
- Toggling servers while in "Global mode" immediately segregates the session appropriately into Local mode, utilizing snapshot overwriting instead of erroneous state merging. 
- All changes withstand full application restarts.