### PR TITLE
[QOL improvement]: Timeline deletion + compaction grouping

### DIFF
--- a/packages/ui/src/components/message-section.tsx
+++ b/packages/ui/src/components/message-section.tsx
@@ -111,7 +111,7 @@ export default function MessageSection(props: MessageSectionProps) {
 
   const [selectedTimelineIds, setSelectedTimelineIds] = createSignal<Set<string>>(new Set())
   const [lastSelectionAnchorId, setLastSelectionAnchorId] = createSignal<string | null>(null)
-  const [expandedMessageIds, setExpandedMessageIds] = createSignal<Set<string>>(new Set())
+  const [expandedMessageIds] = createSignal<Set<string>>(new Set())
   const [selectionMode, setSelectionMode] = createSignal<"all" | "tools">("all")
   const [isDeleteMenuOpen, setIsDeleteMenuOpen] = createSignal(false)
   let deleteMenuRef: HTMLDivElement | undefined
@@ -150,6 +150,37 @@ export default function MessageSection(props: MessageSectionProps) {
     const segmentIndex = segments.findIndex((s) => s.id === id)
     if (segmentIndex === -1) return
     const segment = segments[segmentIndex]
+
+    if (segment.type === "compaction") {
+      setLastSelectionAnchorId(id)
+      let startIndex = 0
+      for (let idx = segmentIndex - 1; idx >= 0; idx -= 1) {
+        if (segments[idx].type === "compaction") {
+          startIndex = idx + 1
+          break
+        }
+      }
+      const group = segments.slice(startIndex, segmentIndex + 1)
+      const groupSegments = selectionMode() === "tools"
+        ? group.filter((s) => s.type === "tool")
+        : group
+      if (groupSegments.length === 0) {
+        return
+      }
+      setSelectedTimelineIds((prev) => {
+        const next = new Set(prev)
+        const hasAnySelected = groupSegments.some((s) => next.has(s.id))
+        for (const item of groupSegments) {
+          if (hasAnySelected) {
+            next.delete(item.id)
+          } else {
+            next.add(item.id)
+          }
+        }
+        return next
+      })
+      return
+    }
 
     setLastSelectionAnchorId(id)
 
@@ -428,8 +459,6 @@ export default function MessageSection(props: MessageSectionProps) {
     if (tokens >= 1000) return `${(tokens / 1000).toFixed(1)}K`
     return String(tokens)
   }
-
-  const isMessageSelectedForDeletion = (messageId: string) => selectedForDeletion().has(messageId)
 
   const setMessageSelectedForDeletion = (messageId: string, selected: boolean) => {
     if (!messageId) return

--- a/packages/ui/src/components/message-section.tsx
+++ b/packages/ui/src/components/message-section.tsx
@@ -117,42 +117,6 @@ export default function MessageSection(props: MessageSectionProps) {
   let deleteMenuRef: HTMLDivElement | undefined
   let deleteMenuButtonRef: HTMLButtonElement | undefined
 
-  // Deletion is only allowed for messages/tool parts that occur AFTER the most
-  // recent compaction. Compaction effectively resets the stored context; deleting
-  // earlier items would not reliably reflect what the model sees.
-  const messageIndexById = createMemo(() => {
-    const ids = messageIds()
-    const map = new Map<string, number>()
-    for (let i = 0; i < ids.length; i++) {
-      map.set(ids[i], i)
-    }
-    return map
-  })
-
-  const lastCompactionIndex = createMemo(() => {
-    // Depend on a single session revision signal (not every message/part read)
-    // to keep reactive overhead small.
-    sessionRevision()
-    return untrack(() => store().getLastCompactionMessageIndex(props.sessionId))
-  })
-
-  const deletableStartIndex = createMemo(() => {
-    const idx = lastCompactionIndex()
-    return idx === -1 ? 0 : idx + 1
-  })
-
-  const deletableMessageIds = createMemo(() => {
-    const ids = messageIds()
-    const start = deletableStartIndex()
-    return new Set(ids.slice(start))
-  })
-
-  const isMessageDeletable = (messageId: string): boolean => {
-    const idx = messageIndexById().get(messageId)
-    if (idx === undefined) return false
-    return idx >= deletableStartIndex()
-  }
-
   // Build the message group for a segment.
   // Tool calls belong to the same assistant turn (between user messages).
   // Only assistant badges trigger group selection; user/tool badges are standalone.
@@ -186,10 +150,6 @@ export default function MessageSection(props: MessageSectionProps) {
     const segmentIndex = segments.findIndex((s) => s.id === id)
     if (segmentIndex === -1) return
     const segment = segments[segmentIndex]
-
-    if (!isMessageDeletable(segment.messageId)) {
-      return
-    }
 
     setLastSelectionAnchorId(id)
 
@@ -235,10 +195,6 @@ export default function MessageSection(props: MessageSectionProps) {
     const segments = timelineSegments()
     const segmentIndex = segments.findIndex((s) => s.id === segment.id)
     if (segmentIndex === -1) return
-
-    if (!isMessageDeletable(segment.messageId)) {
-      return
-    }
 
     setLastSelectionAnchorId(segment.id)
 
@@ -287,8 +243,8 @@ export default function MessageSection(props: MessageSectionProps) {
     const end = Math.max(anchorIndex, targetIndex)
 
     const rangeSegments = selectionMode() === "tools"
-      ? segments.slice(start, end + 1).filter((s) => s.type === "tool" && isMessageDeletable(s.messageId))
-      : segments.slice(start, end + 1).filter((s) => isMessageDeletable(s.messageId))
+      ? segments.slice(start, end + 1).filter((s) => s.type === "tool")
+      : segments.slice(start, end + 1)
     // Range selection replaces current selection so it can grow or shrink.
     setSelectedTimelineIds(new Set(rangeSegments.map((segment) => segment.id)))
   }
@@ -301,11 +257,7 @@ export default function MessageSection(props: MessageSectionProps) {
     setSelectionMode(mode)
     if (mode !== "tools") return
     const segments = timelineSegments()
-    const toolIds = new Set(
-      segments
-        .filter((segment) => segment.type === "tool" && isMessageDeletable(segment.messageId))
-        .map((segment) => segment.id),
-    )
+    const toolIds = new Set(segments.filter((segment) => segment.type === "tool").map((segment) => segment.id))
     setSelectedTimelineIds((prev) => {
       if (prev.size === 0) return prev
       const next = new Set([...prev].filter((id) => toolIds.has(id)))
@@ -408,8 +360,7 @@ export default function MessageSection(props: MessageSectionProps) {
   const deleteMessageIds = createMemo(() => selectedForDeletion())
   const deleteToolParts = createMemo(() => {
     const messageIds = deleteMessageIds()
-    const allowed = deletableMessageIds()
-    return selectedToolParts().filter((entry) => allowed.has(entry.messageId) && !messageIds.has(entry.messageId))
+    return selectedToolParts().filter((entry) => !messageIds.has(entry.messageId))
   })
 
   const deleteToolPartKeys = createMemo(() => {
@@ -482,7 +433,6 @@ export default function MessageSection(props: MessageSectionProps) {
 
   const setMessageSelectedForDeletion = (messageId: string, selected: boolean) => {
     if (!messageId) return
-    if (!isMessageDeletable(messageId)) return
     setSelectedForDeletion((prev) => {
       const next = new Set(prev)
       if (selected) {
@@ -513,7 +463,7 @@ export default function MessageSection(props: MessageSectionProps) {
     const affectedMessageIds = new Set<string>()
     for (const segId of timelineIds) {
       const segment = segmentById.get(segId)
-      if (segment && segment.type !== "tool" && isMessageDeletable(segment.messageId)) {
+      if (segment && segment.type !== "tool") {
         affectedMessageIds.add(segment.messageId)
       }
     }
@@ -521,12 +471,11 @@ export default function MessageSection(props: MessageSectionProps) {
   })
 
   const selectAllForDeletion = () => {
-    const allMessageIds = [...deletableMessageIds()]
-    setSelectedForDeletion(new Set<string>(allMessageIds))
+    setSelectedForDeletion(new Set<string>(messageIds()))
     // Also select all timeline segments — tool visibility is handled by
     // isSelectionActive() in isHidden(), no expand/collapse needed.
     const segments = timelineSegments()
-    setSelectedTimelineIds(new Set(segments.filter((s) => isMessageDeletable(s.messageId)).map((s) => s.id)))
+    setSelectedTimelineIds(new Set(segments.map((s) => s.id)))
   }
 
   const deleteSelectedMessages = async () => {
@@ -534,13 +483,11 @@ export default function MessageSection(props: MessageSectionProps) {
     const toolParts = deleteToolParts()
     if (selected.size === 0 && toolParts.length === 0) return
 
-    const allowed = deletableMessageIds()
-
     const idsInSessionOrder = messageIds()
     const toDelete: string[] = []
     for (let idx = idsInSessionOrder.length - 1; idx >= 0; idx -= 1) {
       const id = idsInSessionOrder[idx]
-      if (allowed.has(id) && selected.has(id)) {
+      if (selected.has(id)) {
         toDelete.push(id)
       }
     }
@@ -550,7 +497,6 @@ export default function MessageSection(props: MessageSectionProps) {
         await deleteMessage(props.instanceId, props.sessionId, messageId)
       }
       for (const { messageId, partId } of toolParts) {
-        if (!allowed.has(messageId)) continue
         await deleteMessagePart(props.instanceId, props.sessionId, messageId, partId)
       }
       clearDeleteMode()
@@ -1239,7 +1185,6 @@ export default function MessageSection(props: MessageSectionProps) {
               onClearSelection={handleClearTimelineSelection}
               selectedIds={selectedTimelineIds}
               expandedMessageIds={expandedMessageIds}
-              deletableMessageIds={deletableMessageIds}
               activeSegmentId={activeSegmentId()}
               instanceId={props.instanceId}
               sessionId={props.sessionId}

--- a/packages/ui/src/components/message-timeline.tsx
+++ b/packages/ui/src/components/message-timeline.tsx
@@ -35,9 +35,6 @@ interface MessageTimelineProps {
   onClearSelection?: () => void
   selectedIds?: Accessor<Set<string>>
   expandedMessageIds?: Accessor<Set<string>>
-  // Optional: restrict histogram/xray overlay to only show for these message ids.
-  // Used to hide ribs for messages before the last compaction.
-  deletableMessageIds?: Accessor<Set<string>>
   activeSegmentId?: string | null
   instanceId: string
   sessionId: string
@@ -321,12 +318,6 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
   const showTools = () => props.showToolSegments ?? true
   const deleteHover = () => props.deleteHover?.() ?? { kind: "none" as const }
 
-  const isHistogramEligible = (segment: TimelineSegment): boolean => {
-    const allowed = props.deletableMessageIds?.()
-    if (!allowed) return true
-    return allowed.has(segment.messageId)
-  }
-
   const registerButtonRef = (segmentId: string, element: HTMLButtonElement | null) => {
     if (element) {
       buttonRefs.set(segmentId, element)
@@ -404,12 +395,10 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
   // --- Selection & histogram rib state ---
   const isSelectionActive = createMemo(() => (props.selectedIds?.().size ?? 0) > 0)
 
-  // Segments eligible for xray ribs. We intentionally exclude messages before
-  // the last compaction (when provided by the parent) to avoid misleading token
-  // weights for content that's no longer in context.
+  // Segments eligible for xray ribs.
   const xraySegments = createMemo(() => {
     if (!isSelectionActive()) return [] as TimelineSegment[]
-    return props.segments.filter((segment) => isHistogramEligible(segment))
+    return props.segments
   })
 
   // Stable layout offsets per badge (relative to scroll content), recomputed only


### PR DESCRIPTION
## Purpose
- Restore deletion and selection for timeline badges that occur before compaction.
- Add compaction-badge grouping so Ctrl/Cmd click selects the slice up to the previous compaction.

## Changes by file

### `packages/ui/src/components/message-section.tsx`
- Selection/deletion gating removed to allow pre-compaction badges to be selected and deleted.
- Added compaction group selection in `handleToggleTimelineSelection`:
  - Find the previous compaction badge.
  - Select the slice `[previous_compaction + 1 .. current_compaction]`.
  - Respect selection mode (`all` vs `tools`), toggle on/off as a group.
- Cleaned unused signals removed after selection refactor.

### `packages/ui/src/components/message-timeline.tsx`
- Xray overlay now uses all segments when selection is active (no compaction filter).

## Commit mapping
1) `fix(ui): restore pre-compaction timeline deletion`
   - Files: `packages/ui/src/components/message-section.tsx`, `packages/ui/src/components/message-timeline.tsx`
   - Reasoning: compaction resets context but should not lock users out of selecting/deleting historical badges.

2) `fix(ui): group compaction timeline selection`
   - File: `packages/ui/src/components/message-section.tsx`
   - Reasoning: compaction badges are natural group boundaries; range selection speeds cleanup.

## Line anchors (current)
- Compaction group selection logic: `packages/ui/src/components/message-section.tsx:148`
- Delete toolbar token stats: `packages/ui/src/components/message-section.tsx:407`
- Xray selection eligibility: `packages/ui/src/components/message-timeline.tsx:398`

## Behavior notes
- Ctrl/Cmd click on a compaction badge toggles selection for the badges between it and the previous compaction.
- Selection mode "tools" limits compaction group selection to tool segments only.
- Deletion and xray overlay now treat pre-compaction segments consistently with the rest of the timeline.
