### PR TITLE
fix(tauri): restore Windows desktop startup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3305,6 +3305,22 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tauri-apps/cli-win32-x64-msvc": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-2.9.4.tgz",
+      "integrity": "sha512-EdYd4c9wGvtPB95kqtEyY+bUR+k4kRw3IA30mAQ1jPH6z57AftT8q84qwv0RDp6kkEqOBKxeInKfqi4BESYuqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 OR MIT",
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@tauri-apps/plugin-notification": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.3.tgz",
@@ -12066,7 +12082,8 @@
       "version": "0.12.2",
       "license": "MIT",
       "devDependencies": {
-        "@tauri-apps/cli": "^2.9.4"
+        "@tauri-apps/cli": "^2.9.4",
+        "@tauri-apps/cli-win32-x64-msvc": "^2.9.4"
       }
     },
     "packages/ui": {

--- a/packages/tauri-app/package.json
+++ b/packages/tauri-app/package.json
@@ -13,6 +13,7 @@
     "build": "tauri build"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^2.9.4"
+    "@tauri-apps/cli": "^2.9.4",
+    "@tauri-apps/cli-win32-x64-msvc": "^2.9.4"
   }
 }

--- a/packages/tauri-app/src-tauri/src/cli_manager.rs
+++ b/packages/tauri-app/src-tauri/src/cli_manager.rs
@@ -900,6 +900,11 @@ fn resolve_dist_entry(_app: &AppHandle) -> Option<String> {
 
     if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent() {
+            candidates.push(Some(dir.join("resources/server/dist/bin.js")));
+            candidates.push(Some(dir.join("resources/server/dist/index.js")));
+            candidates.push(Some(dir.join("resources/server/dist/server/bin.js")));
+            candidates.push(Some(dir.join("resources/server/dist/server/index.js")));
+
             let resources = dir.join("../Resources");
             candidates.push(Some(resources.join("server/dist/bin.js")));
             candidates.push(Some(resources.join("server/dist/index.js")));
@@ -995,9 +1000,18 @@ fn first_existing(paths: Vec<Option<PathBuf>>) -> Option<String> {
 }
 
 fn normalize_path(path: PathBuf) -> String {
-    if let Ok(clean) = path.canonicalize() {
-        clean.to_string_lossy().to_string()
+    let resolved = if let Ok(clean) = path.canonicalize() {
+        clean
     } else {
-        path.to_string_lossy().to_string()
+        path
+    };
+
+    let rendered = resolved.to_string_lossy().to_string();
+    if let Some(stripped) = rendered.strip_prefix("\\\\?\\UNC\\") {
+        format!("\\\\{}", stripped)
+    } else if let Some(stripped) = rendered.strip_prefix("\\\\?\\") {
+        stripped.to_string()
+    } else {
+        rendered
     }
 }


### PR DESCRIPTION
## Summary
- fix Windows packaged startup by resolving the bundled server entry from `resources/server/dist/*` next to the desktop executable
- strip Windows extended-length path prefixes (`\?\`) from canonicalized paths before spawning Node
- add the native `@tauri-apps/cli-win32-x64-msvc` dependency so `tauri build` works reliably on Windows

## Verification
- built the desktop app on Windows with `npm run build:tauri`
- launched the generated executable and confirmed the bundled CLI resolves successfully
- verified the app reaches `cli ready on http://127.0.0.1:...` instead of hanging on the splash screen