### PR TITLE
fix(tauri): sync server UI bundle during prebuild

### DIFF
--- a/packages/tauri-app/scripts/prebuild.js
+++ b/packages/tauri-app/scripts/prebuild.js
@@ -20,6 +20,7 @@ const serverDevInstallCommand =
   "npm install --workspace @neuralnomads/codenomad --include-workspace-root=false --install-strategy=nested --fund=false --audit=false"
 const uiDevInstallCommand =
   "npm install --workspace @codenomad/ui --include-workspace-root=false --install-strategy=nested --fund=false --audit=false"
+const serverPrepareUiCommand = "npm run prepare-ui --workspace @neuralnomads/codenomad"
 
 const envWithRootBin = {
   ...process.env,
@@ -89,6 +90,15 @@ function ensureUiBuild() {
   if (!fs.existsSync(loadingHtml)) {
     throw new Error("[prebuild] ui loading assets missing after build")
   }
+}
+
+function syncServerUiBundle() {
+  console.log("[prebuild] syncing server public UI bundle...")
+  execSync(serverPrepareUiCommand, {
+    cwd: workspaceRoot,
+    stdio: "inherit",
+    env: envWithRootBin,
+  })
 }
 
 function ensureServerDevDependencies() {
@@ -246,6 +256,7 @@ function copyUiLoadingAssets() {
   ensureServerDependencies()
   ensureServerBuild()
   ensureUiBuild()
+  syncServerUiBundle()
   copyServerArtifacts()
   stripNodeModuleBins()
   copyUiLoadingAssets()


### PR DESCRIPTION
## Summary
- refresh the server-side UI bundle as part of the Tauri prebuild step
- make desktop packaging pick up the latest UI output instead of reusing stale copied assets
- reduce confusion when local source changes appear to be ignored by packaged builds

## Testing
- npm run build --workspace @codenomad/ui
- npm run build:tauri