### PR TITLE
Implement shared compact split and unified tool-call diff layout

### DIFF
--- a/packages/ui/src/components/diff-viewer.tsx
+++ b/packages/ui/src/components/diff-viewer.tsx
@@ -1,4 +1,4 @@
-import { createMemo, Show, createEffect, onCleanup } from "solid-js"
+import { createMemo, Show, createEffect } from "solid-js"
 import { DiffView, DiffModeEnum } from "@git-diff-view/solid"
 import "@git-diff-view/solid/styles/diff-view-pure.css"
 import { disableCache } from "@git-diff-view/core"
@@ -21,7 +21,6 @@ interface ToolCallDiffViewerProps {
   theme: "light" | "dark"
   mode: DiffViewMode
   wrap?: boolean
-  compactDiffLayout?: boolean
   onRendered?: () => void
   cachedHtml?: string
   cacheEntryParams?: CacheEntryParams
@@ -31,15 +30,6 @@ type DiffData = {
   oldFile?: { fileName?: string | null; fileLang?: string | null; content?: string | null }
   newFile?: { fileName?: string | null; fileLang?: string | null; content?: string | null }
   hunks: string[]
-}
-
-type CaptureContext = {
-  theme: ToolCallDiffViewerProps["theme"]
-  mode: DiffViewMode
-  wrap?: boolean
-  compactDiffLayout?: boolean
-  diffText: string
-  cacheEntryParams?: CacheEntryParams
 }
 
 function measureTextWidth(container: HTMLElement, text: string, source: HTMLElement) {
@@ -224,13 +214,13 @@ export function ToolCallDiffViewer(props: ToolCallDiffViewerProps) {
   const contextKey = createMemo(() => {
     const data = diffData()
     if (!data) return ""
-    return `${props.theme}|${props.mode}|${props.wrap ? "wrap" : "nowrap"}|${props.compactDiffLayout ? "compact" : "regular"}|${props.diffText}`
+    return `${props.theme}|${props.mode}|${props.wrap ? "wrap" : "nowrap"}|${props.diffText}`
   })
  
   createEffect(() => {
     const cachedHtml = props.cachedHtml
     if (cachedHtml) {
-      if (props.compactDiffLayout && diffContainerRef) {
+      if (diffContainerRef) {
         applyCompactDiffLayout(diffContainerRef, props.mode)
       }
       // When we are given cached HTML, we rely on the caller's cache
@@ -246,9 +236,7 @@ export function ToolCallDiffViewer(props: ToolCallDiffViewerProps) {
 
     requestAnimationFrame(() => {
       if (!diffContainerRef) return
-      if (props.compactDiffLayout) {
-        applyCompactDiffLayout(diffContainerRef, props.mode)
-      }
+      applyCompactDiffLayout(diffContainerRef, props.mode)
       const markup = diffContainerRef.innerHTML
       if (!markup) return
       lastCapturedKey = key
@@ -259,7 +247,6 @@ export function ToolCallDiffViewer(props: ToolCallDiffViewerProps) {
           theme: props.theme,
           mode: props.mode,
           wrap: props.wrap,
-          compactDiffLayout: props.compactDiffLayout,
         })
       }
       props.onRendered?.()

--- a/packages/ui/src/components/diff-viewer.tsx
+++ b/packages/ui/src/components/diff-viewer.tsx
@@ -57,13 +57,17 @@ function measureTextWidth(container: HTMLElement, text: string, source: HTMLElem
   return width
 }
 
-function computeCompactWidth(container: HTMLElement, entries: Array<{ text: string; source: HTMLElement }>) {
+function computeCompactWidth(
+  container: HTMLElement,
+  entries: Array<{ text: string; source: HTMLElement }>,
+  maxWidthPx = 40,
+) {
   const measuredLabelWidthPx = entries.reduce((max, entry) => {
     return Math.max(max, measureTextWidth(container, entry.text, entry.source))
   }, 0)
   const fallbackTextLength = entries.reduce((max, entry) => Math.max(max, entry.text.length), 1)
   const fallbackWidthPx = Math.round(fallbackTextLength * 7 + 4)
-  return Math.max(2, Math.min(40, measuredLabelWidthPx > 0 ? measuredLabelWidthPx + 2 : fallbackWidthPx))
+  return Math.max(2, Math.min(maxWidthPx, measuredLabelWidthPx > 0 ? measuredLabelWidthPx + 2 : fallbackWidthPx))
 }
 
 function applyCompactUnifiedGutter(container: HTMLElement) {
@@ -148,7 +152,11 @@ function applyCompactSplitGutter(container: HTMLElement) {
     .map((cell) => ({ cell, span: cell.querySelector<HTMLElement>("[data-line-num]") }))
     .filter((entry): entry is { cell: HTMLElement; span: HTMLElement } => Boolean(entry.span))
 
-  const gutterWidthPx = computeCompactWidth(container, numberSpans.map(({ span }) => ({ text: span.textContent?.trim() ?? "", source: span })))
+  const gutterWidthPx = computeCompactWidth(
+    container,
+    numberSpans.map(({ span }) => ({ text: span.textContent?.trim() ?? "", source: span })),
+    64,
+  )
   const gutterWidth = `${gutterWidthPx}px`
 
   ;[oldWrapper, newWrapper].forEach((wrapper) => {
@@ -164,6 +172,15 @@ function applyCompactSplitGutter(container: HTMLElement) {
     cell.style.paddingLeft = "2px"
     cell.style.paddingRight = "2px"
     cell.style.textAlign = "left"
+    cell.style.whiteSpace = "nowrap"
+    cell.style.overflowWrap = "normal"
+    cell.style.wordBreak = "normal"
+  })
+
+  numberSpans.forEach(({ span }) => {
+    span.style.whiteSpace = "nowrap"
+    span.style.overflowWrap = "normal"
+    span.style.wordBreak = "normal"
   })
 
   hunkActions.forEach((cell) => {

--- a/packages/ui/src/components/diff-viewer.tsx
+++ b/packages/ui/src/components/diff-viewer.tsx
@@ -70,7 +70,7 @@ function computeCompactWidth(
   return Math.max(2, Math.min(maxWidthPx, measuredLabelWidthPx > 0 ? measuredLabelWidthPx + 2 : fallbackWidthPx))
 }
 
-function applyCompactUnifiedGutter(container: HTMLElement) {
+function applyCompactUnifiedGutter(container: HTMLElement, wrap: boolean) {
   const tableWrapper = container.querySelector<HTMLElement>(".unified-diff-table-wrapper")
   const table = container.querySelector<HTMLTableElement>(".unified-diff-table")
   const numberCol = container.querySelector<HTMLTableColElement>(".unified-diff-table-num-col")
@@ -79,8 +79,17 @@ function applyCompactUnifiedGutter(container: HTMLElement) {
   const entries: Array<{ gutter: HTMLElement; label: HTMLElement; text: string }> = []
 
   if (table) {
-    table.classList.add("table-fixed")
-    table.style.tableLayout = "fixed"
+    if (wrap) {
+      table.classList.add("table-fixed")
+      table.style.tableLayout = "fixed"
+      table.style.width = "100%"
+      table.style.minWidth = "100%"
+    } else {
+      table.classList.remove("table-fixed")
+      table.style.tableLayout = "auto"
+      table.style.width = "max-content"
+      table.style.minWidth = "100%"
+    }
   }
 
   gutterRows.forEach((gutter) => {
@@ -192,9 +201,9 @@ function applyCompactSplitGutter(container: HTMLElement) {
   })
 }
 
-function applyCompactDiffLayout(container: HTMLElement, mode: DiffViewMode) {
+function applyCompactDiffLayout(container: HTMLElement, mode: DiffViewMode, wrap = false) {
   if (mode === "unified") {
-    applyCompactUnifiedGutter(container)
+    applyCompactUnifiedGutter(container, wrap)
     return
   }
   if (mode === "split") {
@@ -238,7 +247,7 @@ export function ToolCallDiffViewer(props: ToolCallDiffViewerProps) {
     const cachedHtml = props.cachedHtml
     if (cachedHtml) {
       if (diffContainerRef) {
-        applyCompactDiffLayout(diffContainerRef, props.mode)
+        applyCompactDiffLayout(diffContainerRef, props.mode, Boolean(props.wrap))
       }
       // When we are given cached HTML, we rely on the caller's cache
       // and simply notify once rendered.
@@ -253,7 +262,7 @@ export function ToolCallDiffViewer(props: ToolCallDiffViewerProps) {
 
     requestAnimationFrame(() => {
       if (!diffContainerRef) return
-      applyCompactDiffLayout(diffContainerRef, props.mode)
+      applyCompactDiffLayout(diffContainerRef, props.mode, Boolean(props.wrap))
       const markup = diffContainerRef.innerHTML
       if (!markup) return
       lastCapturedKey = key

--- a/packages/ui/src/components/diff-viewer.tsx
+++ b/packages/ui/src/components/diff-viewer.tsx
@@ -20,6 +20,8 @@ interface ToolCallDiffViewerProps {
   filePath?: string
   theme: "light" | "dark"
   mode: DiffViewMode
+  wrap?: boolean
+  compactDiffLayout?: boolean
   onRendered?: () => void
   cachedHtml?: string
   cacheEntryParams?: CacheEntryParams
@@ -34,8 +36,163 @@ type DiffData = {
 type CaptureContext = {
   theme: ToolCallDiffViewerProps["theme"]
   mode: DiffViewMode
+  wrap?: boolean
+  compactDiffLayout?: boolean
   diffText: string
   cacheEntryParams?: CacheEntryParams
+}
+
+function measureTextWidth(container: HTMLElement, text: string, source: HTMLElement) {
+  const computed = window.getComputedStyle(source)
+  const probe = document.createElement("span")
+  probe.textContent = text || ""
+  probe.style.position = "absolute"
+  probe.style.visibility = "hidden"
+  probe.style.pointerEvents = "none"
+  probe.style.display = "inline-block"
+  probe.style.width = "auto"
+  probe.style.maxWidth = "none"
+  probe.style.whiteSpace = "nowrap"
+  probe.style.fontFamily = computed.fontFamily
+  probe.style.fontSize = computed.fontSize
+  probe.style.fontWeight = computed.fontWeight
+  probe.style.fontStyle = computed.fontStyle
+  probe.style.letterSpacing = computed.letterSpacing
+  probe.style.fontVariant = computed.fontVariant
+  probe.style.textTransform = computed.textTransform
+  probe.style.lineHeight = computed.lineHeight
+  container.appendChild(probe)
+  const width = Math.ceil(probe.getBoundingClientRect().width)
+  probe.remove()
+  return width
+}
+
+function computeCompactWidth(container: HTMLElement, entries: Array<{ text: string; source: HTMLElement }>) {
+  const measuredLabelWidthPx = entries.reduce((max, entry) => {
+    return Math.max(max, measureTextWidth(container, entry.text, entry.source))
+  }, 0)
+  const fallbackTextLength = entries.reduce((max, entry) => Math.max(max, entry.text.length), 1)
+  const fallbackWidthPx = Math.round(fallbackTextLength * 7 + 4)
+  return Math.max(2, Math.min(40, measuredLabelWidthPx > 0 ? measuredLabelWidthPx + 2 : fallbackWidthPx))
+}
+
+function applyCompactUnifiedGutter(container: HTMLElement) {
+  const tableWrapper = container.querySelector<HTMLElement>(".unified-diff-table-wrapper")
+  const table = container.querySelector<HTMLTableElement>(".unified-diff-table")
+  const numberCol = container.querySelector<HTMLTableColElement>(".unified-diff-table-num-col")
+  const gutterRows = container.querySelectorAll<HTMLElement>(".diff-line-num")
+  const hunkGutters = container.querySelectorAll<HTMLElement>(".diff-line-hunk-action, .diff-line-widget-wrapper, .diff-line-extend-wrapper")
+  const entries: Array<{ gutter: HTMLElement; label: HTMLElement; text: string }> = []
+
+  if (table) {
+    table.classList.add("table-fixed")
+    table.style.tableLayout = "fixed"
+  }
+
+  gutterRows.forEach((gutter) => {
+    const oldSpan = gutter.querySelector<HTMLElement>("[data-line-old-num]")
+    const newSpan = gutter.querySelector<HTMLElement>("[data-line-new-num]")
+    const spacer = gutter.querySelector<HTMLElement>(".shrink-0")
+    const flexWrapper = gutter.querySelector<HTMLElement>(":scope > .flex")
+    const currentLabel = gutter.querySelector<HTMLElement>(":scope > .tool-call-diff-compact-line-number")
+
+    const oldText = oldSpan?.textContent?.trim() ?? ""
+    const newText = newSpan?.textContent?.trim() ?? ""
+    const hasUsableNew = newText.length > 0 && newText !== "0"
+    const hasUsableOld = oldText.length > 0 && oldText !== "0"
+    const visibleText = hasUsableNew ? newText : hasUsableOld ? oldText : newText || oldText
+
+    if (flexWrapper) flexWrapper.style.display = "none"
+    if (spacer) spacer.style.display = "none"
+    if (oldSpan) { oldSpan.style.display = "none"; oldSpan.style.width = "auto" }
+    if (newSpan) { newSpan.style.display = "none"; newSpan.style.width = "auto" }
+
+    gutter.style.paddingLeft = "1px"
+    gutter.style.paddingRight = "1px"
+    gutter.style.textAlign = "left"
+
+    const label = currentLabel ?? document.createElement("span")
+    label.className = "tool-call-diff-compact-line-number"
+    label.textContent = visibleText
+    label.setAttribute("aria-hidden", visibleText ? "false" : "true")
+    if (!currentLabel) gutter.appendChild(label)
+
+    entries.push({ gutter, label, text: visibleText })
+  })
+
+  const gutterWidthPx = computeCompactWidth(container, entries.map((entry) => ({ text: entry.text, source: entry.label })))
+  const gutterWidth = `${gutterWidthPx}px`
+  const compactAsideWidth = `${Math.max(8, gutterWidthPx - 10)}px`
+
+  if (tableWrapper) {
+    tableWrapper.style.setProperty("--diff-aside-width", compactAsideWidth)
+    tableWrapper.style.setProperty("--diff-aside-width--", compactAsideWidth)
+  }
+  if (numberCol) {
+    numberCol.style.width = gutterWidth
+  }
+
+  entries.forEach(({ gutter, label }) => {
+    gutter.style.width = gutterWidth
+    gutter.style.minWidth = gutterWidth
+    gutter.style.maxWidth = gutterWidth
+    label.style.width = "auto"
+    label.style.maxWidth = "none"
+  })
+
+  hunkGutters.forEach((gutter) => {
+    gutter.style.width = gutterWidth
+    gutter.style.minWidth = gutterWidth
+    gutter.style.maxWidth = gutterWidth
+    gutter.style.paddingLeft = "0"
+    gutter.style.paddingRight = "0"
+  })
+}
+
+function applyCompactSplitGutter(container: HTMLElement) {
+  const oldWrapper = container.querySelector<HTMLElement>(".old-diff-table-wrapper")
+  const newWrapper = container.querySelector<HTMLElement>(".new-diff-table-wrapper")
+  const numberCells = Array.from(container.querySelectorAll<HTMLElement>(".diff-line-old-num, .diff-line-new-num"))
+  const hunkActions = Array.from(container.querySelectorAll<HTMLElement>(".diff-line-hunk-action, .diff-line-widget-wrapper, .diff-line-extend-wrapper"))
+  const numberSpans = numberCells
+    .map((cell) => ({ cell, span: cell.querySelector<HTMLElement>("[data-line-num]") }))
+    .filter((entry): entry is { cell: HTMLElement; span: HTMLElement } => Boolean(entry.span))
+
+  const gutterWidthPx = computeCompactWidth(container, numberSpans.map(({ span }) => ({ text: span.textContent?.trim() ?? "", source: span })))
+  const gutterWidth = `${gutterWidthPx}px`
+
+  ;[oldWrapper, newWrapper].forEach((wrapper) => {
+    if (wrapper) {
+      wrapper.style.setProperty("--diff-aside-width", gutterWidth)
+    }
+  })
+
+  numberCells.forEach((cell) => {
+    cell.style.width = gutterWidth
+    cell.style.minWidth = gutterWidth
+    cell.style.maxWidth = gutterWidth
+    cell.style.paddingLeft = "2px"
+    cell.style.paddingRight = "2px"
+    cell.style.textAlign = "left"
+  })
+
+  hunkActions.forEach((cell) => {
+    cell.style.width = gutterWidth
+    cell.style.minWidth = gutterWidth
+    cell.style.maxWidth = gutterWidth
+    cell.style.paddingLeft = "0"
+    cell.style.paddingRight = "0"
+  })
+}
+
+function applyCompactDiffLayout(container: HTMLElement, mode: DiffViewMode) {
+  if (mode === "unified") {
+    applyCompactUnifiedGutter(container)
+    return
+  }
+  if (mode === "split") {
+    applyCompactSplitGutter(container)
+  }
 }
 
 export function ToolCallDiffViewer(props: ToolCallDiffViewerProps) {
@@ -67,12 +224,15 @@ export function ToolCallDiffViewer(props: ToolCallDiffViewerProps) {
   const contextKey = createMemo(() => {
     const data = diffData()
     if (!data) return ""
-    return `${props.theme}|${props.mode}|${props.diffText}`
+    return `${props.theme}|${props.mode}|${props.wrap ? "wrap" : "nowrap"}|${props.compactDiffLayout ? "compact" : "regular"}|${props.diffText}`
   })
  
   createEffect(() => {
     const cachedHtml = props.cachedHtml
     if (cachedHtml) {
+      if (props.compactDiffLayout && diffContainerRef) {
+        applyCompactDiffLayout(diffContainerRef, props.mode)
+      }
       // When we are given cached HTML, we rely on the caller's cache
       // and simply notify once rendered.
       props.onRendered?.()
@@ -83,9 +243,12 @@ export function ToolCallDiffViewer(props: ToolCallDiffViewerProps) {
     if (!key) return
     if (!diffContainerRef) return
     if (lastCapturedKey === key) return
- 
+
     requestAnimationFrame(() => {
       if (!diffContainerRef) return
+      if (props.compactDiffLayout) {
+        applyCompactDiffLayout(diffContainerRef, props.mode)
+      }
       const markup = diffContainerRef.innerHTML
       if (!markup) return
       lastCapturedKey = key
@@ -95,6 +258,8 @@ export function ToolCallDiffViewer(props: ToolCallDiffViewerProps) {
           html: markup,
           theme: props.theme,
           mode: props.mode,
+          wrap: props.wrap,
+          compactDiffLayout: props.compactDiffLayout,
         })
       }
       props.onRendered?.()
@@ -122,7 +287,7 @@ export function ToolCallDiffViewer(props: ToolCallDiffViewerProps) {
                     diffViewMode={props.mode === "split" ? DiffModeEnum.Split : DiffModeEnum.Unified}
                     diffViewTheme={props.theme}
                     diffViewHighlight
-                    diffViewWrap={false}
+                    diffViewWrap={Boolean(props.wrap)}
                     diffViewFontSize={13}
                   />
                 </ErrorBoundary>
@@ -131,7 +296,7 @@ export function ToolCallDiffViewer(props: ToolCallDiffViewerProps) {
           </div>
         }
       >
-        <div innerHTML={props.cachedHtml} />
+        <div ref={diffContainerRef} innerHTML={props.cachedHtml} />
       </Show>
     </div>
   )

--- a/packages/ui/src/components/tool-call/diff-render.tsx
+++ b/packages/ui/src/components/tool-call/diff-render.tsx
@@ -1,6 +1,7 @@
 import { Suspense, createEffect, createMemo, createSignal, lazy, onMount, type Accessor, type JSXElement } from "solid-js"
 import type { ToolState } from "@opencode-ai/sdk/v2"
 import useMediaQuery from "@suid/material/useMediaQuery"
+import { AlignJustify, Split, WrapText } from "lucide-solid"
 import type { RenderCache } from "../../types/message"
 import type { DiffViewMode } from "../../stores/preferences"
 import type { DiffPayload, DiffRenderOptions, ToolScrollHelpers } from "./types"
@@ -46,6 +47,7 @@ export function createDiffContentRenderer(params: {
 }) {
   const compactDiffQuery = useMediaQuery("(max-width: 640px)")
   const [mobileModeOverride, setMobileModeOverride] = createSignal<DiffViewMode | undefined>(undefined)
+  const [wordWrapEnabled, setWordWrapEnabled] = createSignal(true)
 
   createEffect(() => {
     if (!compactDiffQuery()) {
@@ -73,7 +75,7 @@ export function createDiffContentRenderer(params: {
       if (!compactDiffQuery()) return preferredMode()
       return mobileModeOverride() || "unified"
     }
-    const shouldWrap = () => compactDiffQuery() && effectiveMode() === "unified"
+    const shouldWrap = () => wordWrapEnabled()
     const themeKey = params.isDark() ? "dark" : "light"
     const state = params.toolState()
     const disableScrollTracking = Boolean(
@@ -114,6 +116,16 @@ export function createDiffContentRenderer(params: {
       params.setDiffViewMode(mode)
     }
 
+    const nextViewMode = (): DiffViewMode => (currentMode() === "split" ? "unified" : "split")
+    const viewModeTitle = () =>
+      nextViewMode() === "split"
+        ? params.t("toolCall.diff.switchToSplit")
+        : params.t("toolCall.diff.switchToUnified")
+    const wordWrapTitle = () =>
+      wordWrapEnabled()
+        ? params.t("toolCall.diff.disableWordWrap")
+        : params.t("toolCall.diff.enableWordWrap")
+
     const handleDiffRendered = () => {
       if (!disableScrollTracking) {
         params.handleScrollRendered()
@@ -130,22 +142,24 @@ export function createDiffContentRenderer(params: {
         >
         <div class="tool-call-diff-toolbar" role="group" aria-label={params.t("toolCall.diff.viewMode.ariaLabel")}>
           <span class="tool-call-diff-toolbar-label">{toolbarLabel}</span>
-          <div class="tool-call-diff-toggle">
+          <div class="file-viewer-toolbar">
             <button
               type="button"
-              class={`tool-call-diff-mode-button${currentMode() === "split" ? " active" : ""}`}
-              aria-pressed={currentMode() === "split"}
-              onClick={() => handleModeChange("split")}
+              class="file-viewer-toolbar-icon-button"
+              onClick={() => handleModeChange(nextViewMode())}
+              aria-label={viewModeTitle()}
+              title={viewModeTitle()}
             >
-              {params.t("toolCall.diff.viewMode.split")}
+              {nextViewMode() === "split" ? <Split class="h-4 w-4" aria-hidden="true" /> : <AlignJustify class="h-4 w-4" aria-hidden="true" />}
             </button>
             <button
               type="button"
-              class={`tool-call-diff-mode-button${currentMode() === "unified" ? " active" : ""}`}
-              aria-pressed={currentMode() === "unified"}
-              onClick={() => handleModeChange("unified")}
+              class={`file-viewer-toolbar-icon-button${wordWrapEnabled() ? " active" : ""}`}
+              onClick={() => setWordWrapEnabled((enabled) => !enabled)}
+              aria-label={wordWrapTitle()}
+              title={wordWrapTitle()}
             >
-              {params.t("toolCall.diff.viewMode.unified")}
+              <WrapText class="h-4 w-4" aria-hidden="true" />
             </button>
           </div>
         </div>

--- a/packages/ui/src/components/tool-call/diff-render.tsx
+++ b/packages/ui/src/components/tool-call/diff-render.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, onMount, type Accessor, type JSXElement } from "solid-js"
+import { Suspense, createEffect, createSignal, lazy, onMount, type Accessor, type JSXElement } from "solid-js"
 import type { ToolState } from "@opencode-ai/sdk/v2"
 import useMediaQuery from "@suid/material/useMediaQuery"
 import type { RenderCache } from "../../types/message"
@@ -45,6 +45,13 @@ export function createDiffContentRenderer(params: {
   onContentRendered?: () => void
 }) {
   const compactDiffQuery = useMediaQuery("(max-width: 640px)")
+  const [mobileModeOverride, setMobileModeOverride] = createSignal<DiffViewMode | undefined>(undefined)
+
+  createEffect(() => {
+    if (!compactDiffQuery()) {
+      setMobileModeOverride(undefined)
+    }
+  })
 
   const registerTracked = (element: HTMLDivElement | null) => {
     params.scrollHelpers.registerContainer(element)
@@ -62,7 +69,10 @@ export function createDiffContentRenderer(params: {
     const selectedVariant = options?.variant === "permission-diff" ? "permission-diff" : "diff"
     const cacheHandle = selectedVariant === "permission-diff" ? params.permissionDiffCache : params.diffCache
     const preferredMode = () => (params.preferences().diffViewMode || "split") as DiffViewMode
-    const effectiveMode = () => (compactDiffQuery() ? "unified" : preferredMode()) as DiffViewMode
+    const effectiveMode = () => {
+      if (!compactDiffQuery()) return preferredMode()
+      return mobileModeOverride() || "unified"
+    }
     const shouldWrap = () => compactDiffQuery() && effectiveMode() === "unified"
     const themeKey = params.isDark() ? "dark" : "light"
     const state = params.toolState()
@@ -96,6 +106,9 @@ export function createDiffContentRenderer(params: {
     }
 
     const handleModeChange = (mode: DiffViewMode) => {
+      if (compactDiffQuery()) {
+        setMobileModeOverride(mode)
+      }
       params.setDiffViewMode(mode)
     }
 

--- a/packages/ui/src/components/tool-call/diff-render.tsx
+++ b/packages/ui/src/components/tool-call/diff-render.tsx
@@ -64,7 +64,6 @@ export function createDiffContentRenderer(params: {
     const preferredMode = () => (params.preferences().diffViewMode || "split") as DiffViewMode
     const effectiveMode = () => (compactDiffQuery() ? "unified" : preferredMode()) as DiffViewMode
     const shouldWrap = () => compactDiffQuery() && effectiveMode() === "unified"
-    const compactDiffLayout = () => true
     const themeKey = params.isDark() ? "dark" : "light"
     const state = params.toolState()
     const disableScrollTracking = Boolean(
@@ -92,7 +91,6 @@ export function createDiffContentRenderer(params: {
       && cached.theme === themeKey
       && cached.mode === currentMode
       && cached.wrap === currentWrap
-      && cached.compactDiffLayout === compactDiffLayout()
     ) {
       cachedHtml = cached.html
     }
@@ -146,7 +144,6 @@ export function createDiffContentRenderer(params: {
               theme={themeKey}
               mode={effectiveMode()}
               wrap={shouldWrap()}
-              compactDiffLayout={compactDiffLayout()}
               cacheEntryParams={cacheEntryParams as any}
               onRendered={handleDiffRendered}
             />

--- a/packages/ui/src/components/tool-call/diff-render.tsx
+++ b/packages/ui/src/components/tool-call/diff-render.tsx
@@ -1,12 +1,13 @@
 import { Suspense, createEffect, createMemo, createSignal, lazy, onMount, type Accessor, type JSXElement } from "solid-js"
 import type { ToolState } from "@opencode-ai/sdk/v2"
 import useMediaQuery from "@suid/material/useMediaQuery"
-import { AlignJustify, Split, WrapText } from "lucide-solid"
+import { AlignJustify, Copy, Split, WrapText } from "lucide-solid"
 import type { RenderCache } from "../../types/message"
 import type { DiffViewMode } from "../../stores/preferences"
 import type { DiffPayload, DiffRenderOptions, ToolScrollHelpers } from "./types"
 import { getRelativePath } from "./utils"
 import { getCacheEntry } from "../../lib/global-cache"
+import { copyToClipboard } from "../../lib/clipboard"
 
 const LazyToolCallDiffViewer = lazy(() =>
   import("../diff-viewer").then((module) => ({ default: module.ToolCallDiffViewer })),
@@ -125,6 +126,7 @@ export function createDiffContentRenderer(params: {
       wordWrapEnabled()
         ? params.t("toolCall.diff.disableWordWrap")
         : params.t("toolCall.diff.enableWordWrap")
+    const copyPatchTitle = () => params.t("toolCall.diff.copyPatch")
 
     const handleDiffRendered = () => {
       if (!disableScrollTracking) {
@@ -143,6 +145,15 @@ export function createDiffContentRenderer(params: {
         <div class="tool-call-diff-toolbar" role="group" aria-label={params.t("toolCall.diff.viewMode.ariaLabel")}>
           <span class="tool-call-diff-toolbar-label">{toolbarLabel}</span>
           <div class="file-viewer-toolbar">
+            <button
+              type="button"
+              class="file-viewer-toolbar-icon-button"
+              onClick={() => void copyToClipboard(payload.diffText)}
+              aria-label={copyPatchTitle()}
+              title={copyPatchTitle()}
+            >
+              <Copy class="h-4 w-4" aria-hidden="true" />
+            </button>
             <button
               type="button"
               class="file-viewer-toolbar-icon-button"

--- a/packages/ui/src/components/tool-call/diff-render.tsx
+++ b/packages/ui/src/components/tool-call/diff-render.tsx
@@ -1,5 +1,6 @@
 import { Suspense, lazy, onMount, type Accessor, type JSXElement } from "solid-js"
 import type { ToolState } from "@opencode-ai/sdk/v2"
+import useMediaQuery from "@suid/material/useMediaQuery"
 import type { RenderCache } from "../../types/message"
 import type { DiffViewMode } from "../../stores/preferences"
 import type { DiffPayload, DiffRenderOptions, ToolScrollHelpers } from "./types"
@@ -43,6 +44,8 @@ export function createDiffContentRenderer(params: {
   handleScrollRendered: () => void
   onContentRendered?: () => void
 }) {
+  const compactDiffQuery = useMediaQuery("(max-width: 640px)")
+
   const registerTracked = (element: HTMLDivElement | null) => {
     params.scrollHelpers.registerContainer(element)
   }
@@ -58,7 +61,10 @@ export function createDiffContentRenderer(params: {
       : params.t("toolCall.diff.label"))
     const selectedVariant = options?.variant === "permission-diff" ? "permission-diff" : "diff"
     const cacheHandle = selectedVariant === "permission-diff" ? params.permissionDiffCache : params.diffCache
-    const diffMode = () => (params.preferences().diffViewMode || "split") as DiffViewMode
+    const preferredMode = () => (params.preferences().diffViewMode || "split") as DiffViewMode
+    const effectiveMode = () => (compactDiffQuery() ? "unified" : preferredMode()) as DiffViewMode
+    const shouldWrap = () => compactDiffQuery() && effectiveMode() === "unified"
+    const compactDiffLayout = () => true
     const themeKey = params.isDark() ? "dark" : "light"
     const state = params.toolState()
     const disableScrollTracking = Boolean(
@@ -78,8 +84,16 @@ export function createDiffContentRenderer(params: {
 
     let cachedHtml: string | undefined
     const cached = getCacheEntry<RenderCache>(cacheEntryParams)
-    const currentMode = diffMode()
-    if (cached && cached.text === payload.diffText && cached.theme === themeKey && cached.mode === currentMode) {
+    const currentMode = effectiveMode()
+    const currentWrap = shouldWrap()
+    if (
+      cached
+      && cached.text === payload.diffText
+      && cached.theme === themeKey
+      && cached.mode === currentMode
+      && cached.wrap === currentWrap
+      && cached.compactDiffLayout === compactDiffLayout()
+    ) {
       cachedHtml = cached.html
     }
 
@@ -97,6 +111,7 @@ export function createDiffContentRenderer(params: {
     return (
       <div
         class="message-text tool-call-markdown tool-call-markdown-large tool-call-diff-shell"
+        data-diff-mode={effectiveMode()}
         ref={registerRef}
         onScroll={disableScrollTracking ? undefined : params.scrollHelpers.handleScroll}
       >
@@ -105,16 +120,16 @@ export function createDiffContentRenderer(params: {
           <div class="tool-call-diff-toggle">
             <button
               type="button"
-              class={`tool-call-diff-mode-button${diffMode() === "split" ? " active" : ""}`}
-              aria-pressed={diffMode() === "split"}
+              class={`tool-call-diff-mode-button${effectiveMode() === "split" ? " active" : ""}`}
+              aria-pressed={effectiveMode() === "split"}
               onClick={() => handleModeChange("split")}
             >
               {params.t("toolCall.diff.viewMode.split")}
             </button>
             <button
               type="button"
-              class={`tool-call-diff-mode-button${diffMode() === "unified" ? " active" : ""}`}
-              aria-pressed={diffMode() === "unified"}
+              class={`tool-call-diff-mode-button${effectiveMode() === "unified" ? " active" : ""}`}
+              aria-pressed={effectiveMode() === "unified"}
               onClick={() => handleModeChange("unified")}
             >
               {params.t("toolCall.diff.viewMode.unified")}
@@ -129,7 +144,9 @@ export function createDiffContentRenderer(params: {
               diffText={payload.diffText}
               filePath={payload.filePath}
               theme={themeKey}
-              mode={diffMode()}
+              mode={effectiveMode()}
+              wrap={shouldWrap()}
+              compactDiffLayout={compactDiffLayout()}
               cacheEntryParams={cacheEntryParams as any}
               onRendered={handleDiffRendered}
             />

--- a/packages/ui/src/components/tool-call/diff-render.tsx
+++ b/packages/ui/src/components/tool-call/diff-render.tsx
@@ -1,4 +1,4 @@
-import { Suspense, createEffect, createSignal, lazy, onMount, type Accessor, type JSXElement } from "solid-js"
+import { Suspense, createEffect, createMemo, createSignal, lazy, onMount, type Accessor, type JSXElement } from "solid-js"
 import type { ToolState } from "@opencode-ai/sdk/v2"
 import useMediaQuery from "@suid/material/useMediaQuery"
 import type { RenderCache } from "../../types/message"
@@ -91,19 +91,21 @@ export function createDiffContentRenderer(params: {
       }
     })()
 
-    let cachedHtml: string | undefined
-    const cached = getCacheEntry<RenderCache>(cacheEntryParams)
-    const currentMode = effectiveMode()
-    const currentWrap = shouldWrap()
-    if (
-      cached
-      && cached.text === payload.diffText
-      && cached.theme === themeKey
-      && cached.mode === currentMode
-      && cached.wrap === currentWrap
-    ) {
-      cachedHtml = cached.html
-    }
+    const currentMode = createMemo(() => effectiveMode())
+    const currentWrap = createMemo(() => shouldWrap())
+    const cachedHtml = createMemo(() => {
+      const cached = getCacheEntry<RenderCache>(cacheEntryParams)
+      if (
+        cached
+        && cached.text === payload.diffText
+        && cached.theme === themeKey
+        && cached.mode === currentMode()
+        && cached.wrap === currentWrap()
+      ) {
+        return cached.html
+      }
+      return undefined
+    })
 
     const handleModeChange = (mode: DiffViewMode) => {
       if (compactDiffQuery()) {
@@ -120,43 +122,43 @@ export function createDiffContentRenderer(params: {
     }
 
     return (
-      <div
-        class="message-text tool-call-markdown tool-call-markdown-large tool-call-diff-shell"
-        data-diff-mode={effectiveMode()}
-        ref={registerRef}
-        onScroll={disableScrollTracking ? undefined : params.scrollHelpers.handleScroll}
-      >
+        <div
+          class="message-text tool-call-markdown tool-call-markdown-large tool-call-diff-shell"
+          data-diff-mode={currentMode()}
+          ref={registerRef}
+          onScroll={disableScrollTracking ? undefined : params.scrollHelpers.handleScroll}
+        >
         <div class="tool-call-diff-toolbar" role="group" aria-label={params.t("toolCall.diff.viewMode.ariaLabel")}>
           <span class="tool-call-diff-toolbar-label">{toolbarLabel}</span>
           <div class="tool-call-diff-toggle">
             <button
               type="button"
-              class={`tool-call-diff-mode-button${effectiveMode() === "split" ? " active" : ""}`}
-              aria-pressed={effectiveMode() === "split"}
+              class={`tool-call-diff-mode-button${currentMode() === "split" ? " active" : ""}`}
+              aria-pressed={currentMode() === "split"}
               onClick={() => handleModeChange("split")}
             >
               {params.t("toolCall.diff.viewMode.split")}
             </button>
             <button
               type="button"
-              class={`tool-call-diff-mode-button${effectiveMode() === "unified" ? " active" : ""}`}
-              aria-pressed={effectiveMode() === "unified"}
+              class={`tool-call-diff-mode-button${currentMode() === "unified" ? " active" : ""}`}
+              aria-pressed={currentMode() === "unified"}
               onClick={() => handleModeChange("unified")}
             >
               {params.t("toolCall.diff.viewMode.unified")}
             </button>
           </div>
         </div>
-        {cachedHtml ? (
-          <CachedDiffMarkup html={cachedHtml} onRendered={handleDiffRendered} />
+        {cachedHtml() ? (
+          <CachedDiffMarkup html={cachedHtml()!} onRendered={handleDiffRendered} />
         ) : (
           <Suspense fallback={<pre class="tool-call-diff-fallback">{payload.diffText}</pre>}>
             <LazyToolCallDiffViewer
               diffText={payload.diffText}
               filePath={payload.filePath}
               theme={themeKey}
-              mode={effectiveMode()}
-              wrap={shouldWrap()}
+              mode={currentMode()}
+              wrap={currentWrap()}
               cacheEntryParams={cacheEntryParams as any}
               onRendered={handleDiffRendered}
             />

--- a/packages/ui/src/lib/i18n/messages/en/toolCall.ts
+++ b/packages/ui/src/lib/i18n/messages/en/toolCall.ts
@@ -18,6 +18,10 @@ export const toolCallMessages = {
   "toolCall.diff.viewMode.ariaLabel": "Diff view mode",
   "toolCall.diff.viewMode.split": "Split",
   "toolCall.diff.viewMode.unified": "Unified",
+  "toolCall.diff.switchToSplit": "Switch to split view",
+  "toolCall.diff.switchToUnified": "Switch to unified view",
+  "toolCall.diff.enableWordWrap": "Enable word wrap",
+  "toolCall.diff.disableWordWrap": "Disable word wrap",
 
   "toolCall.diagnostics.title": "Diagnostics",
   "toolCall.diagnostics.ariaLabel": "Diagnostics",

--- a/packages/ui/src/lib/i18n/messages/en/toolCall.ts
+++ b/packages/ui/src/lib/i18n/messages/en/toolCall.ts
@@ -22,6 +22,7 @@ export const toolCallMessages = {
   "toolCall.diff.switchToUnified": "Switch to unified view",
   "toolCall.diff.enableWordWrap": "Enable word wrap",
   "toolCall.diff.disableWordWrap": "Disable word wrap",
+  "toolCall.diff.copyPatch": "Copy patch",
 
   "toolCall.diagnostics.title": "Diagnostics",
   "toolCall.diagnostics.ariaLabel": "Diagnostics",

--- a/packages/ui/src/lib/i18n/messages/es/toolCall.ts
+++ b/packages/ui/src/lib/i18n/messages/es/toolCall.ts
@@ -18,6 +18,11 @@ export const toolCallMessages = {
   "toolCall.diff.viewMode.ariaLabel": "Modo de vista de diff",
   "toolCall.diff.viewMode.split": "Dividida",
   "toolCall.diff.viewMode.unified": "Unificada",
+  "toolCall.diff.switchToSplit": "Cambiar a vista dividida",
+  "toolCall.diff.switchToUnified": "Cambiar a vista unificada",
+  "toolCall.diff.enableWordWrap": "Activar ajuste de línea",
+  "toolCall.diff.disableWordWrap": "Desactivar ajuste de línea",
+  "toolCall.diff.copyPatch": "Copiar patch",
 
   "toolCall.diagnostics.title": "Diagnósticos",
   "toolCall.diagnostics.ariaLabel": "Diagnósticos",

--- a/packages/ui/src/lib/i18n/messages/fr/toolCall.ts
+++ b/packages/ui/src/lib/i18n/messages/fr/toolCall.ts
@@ -18,6 +18,11 @@ export const toolCallMessages = {
   "toolCall.diff.viewMode.ariaLabel": "Mode d'affichage du diff",
   "toolCall.diff.viewMode.split": "Côte à côte",
   "toolCall.diff.viewMode.unified": "Unifié",
+  "toolCall.diff.switchToSplit": "Passer à la vue côte à côte",
+  "toolCall.diff.switchToUnified": "Passer à la vue unifiée",
+  "toolCall.diff.enableWordWrap": "Activer le retour à la ligne",
+  "toolCall.diff.disableWordWrap": "Désactiver le retour à la ligne",
+  "toolCall.diff.copyPatch": "Copier le patch",
 
   "toolCall.diagnostics.title": "Diagnostics",
   "toolCall.diagnostics.ariaLabel": "Diagnostics",

--- a/packages/ui/src/lib/i18n/messages/he/toolCall.ts
+++ b/packages/ui/src/lib/i18n/messages/he/toolCall.ts
@@ -18,6 +18,10 @@ export const toolCallMessages = {
   "toolCall.diff.viewMode.ariaLabel": "מצב תצוגת diff",
   "toolCall.diff.viewMode.split": "מפוצל",
   "toolCall.diff.viewMode.unified": "מאוחד",
+  "toolCall.diff.switchToSplit": "עבור לתצוגה מפוצלת",
+  "toolCall.diff.switchToUnified": "עבור לתצוגה מאוחדת",
+  "toolCall.diff.enableWordWrap": "הפעל גלישת מילים",
+  "toolCall.diff.disableWordWrap": "כבה גלישת מילים",
 
   "toolCall.diagnostics.title": "אבחון",
   "toolCall.diagnostics.ariaLabel": "אבחון",

--- a/packages/ui/src/lib/i18n/messages/he/toolCall.ts
+++ b/packages/ui/src/lib/i18n/messages/he/toolCall.ts
@@ -22,6 +22,7 @@ export const toolCallMessages = {
   "toolCall.diff.switchToUnified": "עבור לתצוגה מאוחדת",
   "toolCall.diff.enableWordWrap": "הפעל גלישת מילים",
   "toolCall.diff.disableWordWrap": "כבה גלישת מילים",
+  "toolCall.diff.copyPatch": "העתק patch",
 
   "toolCall.diagnostics.title": "אבחון",
   "toolCall.diagnostics.ariaLabel": "אבחון",

--- a/packages/ui/src/lib/i18n/messages/ja/toolCall.ts
+++ b/packages/ui/src/lib/i18n/messages/ja/toolCall.ts
@@ -18,6 +18,11 @@ export const toolCallMessages = {
   "toolCall.diff.viewMode.ariaLabel": "diff 表示モード",
   "toolCall.diff.viewMode.split": "分割",
   "toolCall.diff.viewMode.unified": "ユニファイド",
+  "toolCall.diff.switchToSplit": "分割表示に切り替え",
+  "toolCall.diff.switchToUnified": "ユニファイド表示に切り替え",
+  "toolCall.diff.enableWordWrap": "折り返しを有効化",
+  "toolCall.diff.disableWordWrap": "折り返しを無効化",
+  "toolCall.diff.copyPatch": "パッチをコピー",
 
   "toolCall.diagnostics.title": "診断",
   "toolCall.diagnostics.ariaLabel": "診断",

--- a/packages/ui/src/lib/i18n/messages/ru/toolCall.ts
+++ b/packages/ui/src/lib/i18n/messages/ru/toolCall.ts
@@ -18,6 +18,10 @@ export const toolCallMessages = {
   "toolCall.diff.viewMode.ariaLabel": "Режим просмотра diff",
   "toolCall.diff.viewMode.split": "Раздельный",
   "toolCall.diff.viewMode.unified": "Единый",
+  "toolCall.diff.switchToSplit": "Переключить на раздельный вид",
+  "toolCall.diff.switchToUnified": "Переключить на единый вид",
+  "toolCall.diff.enableWordWrap": "Включить перенос слов",
+  "toolCall.diff.disableWordWrap": "Выключить перенос слов",
 
   "toolCall.diagnostics.title": "Диагностика",
   "toolCall.diagnostics.ariaLabel": "Диагностика",

--- a/packages/ui/src/lib/i18n/messages/ru/toolCall.ts
+++ b/packages/ui/src/lib/i18n/messages/ru/toolCall.ts
@@ -22,6 +22,7 @@ export const toolCallMessages = {
   "toolCall.diff.switchToUnified": "Переключить на единый вид",
   "toolCall.diff.enableWordWrap": "Включить перенос слов",
   "toolCall.diff.disableWordWrap": "Выключить перенос слов",
+  "toolCall.diff.copyPatch": "Скопировать patch",
 
   "toolCall.diagnostics.title": "Диагностика",
   "toolCall.diagnostics.ariaLabel": "Диагностика",

--- a/packages/ui/src/lib/i18n/messages/zh-Hans/toolCall.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-Hans/toolCall.ts
@@ -22,6 +22,7 @@ export const toolCallMessages = {
   "toolCall.diff.switchToUnified": "切换到统一视图",
   "toolCall.diff.enableWordWrap": "启用自动换行",
   "toolCall.diff.disableWordWrap": "禁用自动换行",
+  "toolCall.diff.copyPatch": "复制补丁",
 
   "toolCall.diagnostics.title": "诊断",
   "toolCall.diagnostics.ariaLabel": "诊断",

--- a/packages/ui/src/lib/i18n/messages/zh-Hans/toolCall.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-Hans/toolCall.ts
@@ -18,6 +18,10 @@ export const toolCallMessages = {
   "toolCall.diff.viewMode.ariaLabel": "Diff 视图模式",
   "toolCall.diff.viewMode.split": "分栏",
   "toolCall.diff.viewMode.unified": "统一",
+  "toolCall.diff.switchToSplit": "切换到分栏视图",
+  "toolCall.diff.switchToUnified": "切换到统一视图",
+  "toolCall.diff.enableWordWrap": "启用自动换行",
+  "toolCall.diff.disableWordWrap": "禁用自动换行",
 
   "toolCall.diagnostics.title": "诊断",
   "toolCall.diagnostics.ariaLabel": "诊断",

--- a/packages/ui/src/styles/messaging/tool-call.css
+++ b/packages/ui/src/styles/messaging/tool-call.css
@@ -321,6 +321,7 @@
 
 .tool-call-diff-shell {
   padding: 0;
+  scrollbar-gutter: auto;
 }
 
 .tool-call-diff-viewer {
@@ -343,6 +344,8 @@
 .tool-call-diff-shell .tool-call-diff-viewer {
   max-height: none;
   overflow: visible;
+  width: 100%;
+  min-width: 100%;
 }
 
 .tool-call-diff-toolbar-label {
@@ -511,6 +514,77 @@
 .tool-call-diff-viewer .diff-line-num {
   color: var(--text-secondary);
   font-size: var(--font-size-xs);
+}
+
+.tool-call-diff-shell .tool-call-diff-viewer .diff-line-content,
+.tool-call-diff-shell .tool-call-diff-viewer .diff-line-hunk-content,
+.tool-call-diff-shell .tool-call-diff-viewer .diff-line-old-content,
+.tool-call-diff-shell .tool-call-diff-viewer .diff-line-new-content {
+  padding-right: 0 !important;
+}
+
+.tool-call-diff-shell[data-diff-mode="unified"] .tool-call-diff-viewer .diff-line-num {
+  padding-left: 1px !important;
+  padding-right: 1px !important;
+  text-align: left !important;
+}
+
+.tool-call-diff-shell[data-diff-mode="unified"] .tool-call-diff-viewer .unified-diff-table {
+  table-layout: fixed;
+}
+
+.tool-call-diff-shell[data-diff-mode="unified"] .tool-call-diff-viewer .unified-diff-table-num-col {
+  width: auto !important;
+}
+
+.tool-call-diff-shell[data-diff-mode="unified"] .tool-call-diff-viewer .tool-call-diff-compact-line-number {
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.tool-call-diff-shell[data-diff-mode="split"] .tool-call-diff-viewer .diff-line-old-num,
+.tool-call-diff-shell[data-diff-mode="split"] .tool-call-diff-viewer .diff-line-new-num,
+.tool-call-diff-shell[data-diff-mode="split"] .tool-call-diff-viewer .diff-line-hunk-action {
+  padding-left: 2px !important;
+  padding-right: 2px !important;
+  text-align: left !important;
+}
+
+.tool-call-diff-shell[data-diff-mode="split"] .tool-call-diff-viewer .diff-line-hunk-action {
+  padding-top: 1px !important;
+  padding-bottom: 1px !important;
+}
+
+.tool-call-diff-shell[data-diff-mode="split"] .tool-call-diff-viewer .diff-line-content-item {
+  padding-left: 1.1em !important;
+}
+
+.tool-call-diff-shell[data-diff-mode="split"] .tool-call-diff-viewer .diff-line-content-operator {
+  margin-left: -1.1em !important;
+  width: 0.9em !important;
+  min-width: 0.9em !important;
+  text-indent: 0 !important;
+}
+
+@media (max-width: 640px) {
+  .tool-call-diff-shell[data-diff-mode="unified"] .tool-call-diff-viewer .unified-diff-table-wrapper {
+    --diff-aside-width: 18px;
+  }
+
+  .tool-call-diff-shell[data-diff-mode="unified"] .tool-call-diff-viewer .diff-line-content-item,
+  .tool-call-diff-shell[data-diff-mode="split"] .tool-call-diff-viewer .diff-line-content-item {
+    padding-left: 1.5em !important;
+  }
+
+  .tool-call-diff-shell[data-diff-mode="unified"] .tool-call-diff-viewer .diff-line-content-operator,
+  .tool-call-diff-shell[data-diff-mode="split"] .tool-call-diff-viewer .diff-line-content-operator {
+    margin-left: -1.5em !important;
+    width: 1.1em !important;
+    min-width: 1.1em !important;
+  }
 }
 
 .tool-call-markdown .markdown-code-block {

--- a/packages/ui/src/styles/messaging/tool-call.css
+++ b/packages/ui/src/styles/messaging/tool-call.css
@@ -558,11 +558,11 @@
   padding-bottom: 1px !important;
 }
 
-.tool-call-diff-shell[data-diff-mode="split"] .tool-call-diff-viewer .diff-line-content-item {
+.tool-call-diff-shell .tool-call-diff-viewer .diff-line-content-item {
   padding-left: 1.1em !important;
 }
 
-.tool-call-diff-shell[data-diff-mode="split"] .tool-call-diff-viewer .diff-line-content-operator {
+.tool-call-diff-shell .tool-call-diff-viewer .diff-line-content-operator {
   margin-left: -1.1em !important;
   width: 0.9em !important;
   min-width: 0.9em !important;
@@ -574,13 +574,11 @@
     --diff-aside-width: 18px;
   }
 
-  .tool-call-diff-shell[data-diff-mode="unified"] .tool-call-diff-viewer .diff-line-content-item,
-  .tool-call-diff-shell[data-diff-mode="split"] .tool-call-diff-viewer .diff-line-content-item {
+  .tool-call-diff-shell .tool-call-diff-viewer .diff-line-content-item {
     padding-left: 1.5em !important;
   }
 
-  .tool-call-diff-shell[data-diff-mode="unified"] .tool-call-diff-viewer .diff-line-content-operator,
-  .tool-call-diff-shell[data-diff-mode="split"] .tool-call-diff-viewer .diff-line-content-operator {
+  .tool-call-diff-shell .tool-call-diff-viewer .diff-line-content-operator {
     margin-left: -1.5em !important;
     width: 1.1em !important;
     min-width: 1.1em !important;

--- a/packages/ui/src/styles/messaging/tool-call.css
+++ b/packages/ui/src/styles/messaging/tool-call.css
@@ -553,6 +553,15 @@
   text-align: left !important;
 }
 
+.tool-call-diff-shell[data-diff-mode="split"] .tool-call-diff-viewer .diff-line-old-num,
+.tool-call-diff-shell[data-diff-mode="split"] .tool-call-diff-viewer .diff-line-new-num,
+.tool-call-diff-shell[data-diff-mode="split"] .tool-call-diff-viewer .diff-line-old-num [data-line-num],
+.tool-call-diff-shell[data-diff-mode="split"] .tool-call-diff-viewer .diff-line-new-num [data-line-num] {
+  white-space: nowrap !important;
+  word-break: normal !important;
+  overflow-wrap: normal !important;
+}
+
 .tool-call-diff-shell[data-diff-mode="split"] .tool-call-diff-viewer .diff-line-hunk-action {
   padding-top: 1px !important;
   padding-bottom: 1px !important;

--- a/packages/ui/src/types/message.ts
+++ b/packages/ui/src/types/message.ts
@@ -41,7 +41,6 @@ export interface RenderCache {
   theme?: string
   mode?: string
   wrap?: boolean
-  compactDiffLayout?: boolean
 }
 
 export interface PendingPermissionState {

--- a/packages/ui/src/types/message.ts
+++ b/packages/ui/src/types/message.ts
@@ -40,6 +40,8 @@ export interface RenderCache {
   html: string
   theme?: string
   mode?: string
+  wrap?: boolean
+  compactDiffLayout?: boolean
 }
 
 export interface PendingPermissionState {


### PR DESCRIPTION
# PR Title

Implement shared compact split and unified tool-call diff layout

---
Fixes #268 
# PR Description

## Summary

This PR makes tool-call diffs more compact in both `Unified` and `Split` views by reducing wasted horizontal space in line-number gutters and content indentation.

## What changed

- introduced a shared compact-diff framework for tool-call diffs
- kept mobile-specific policy limited to:
  - forcing unified mode below the breakpoint
  - enabling wrap only in mobile unified mode
- added mode-specific compact applicators in the diff viewer:
  - unified applicator
  - split applicator
- reduced gutter width waste by measuring rendered line-number text and tightening column width around it
- removed unnecessary right-side content padding
- aligned `+` / `-` markers closer to the left edge across both views
- simplified cleanup after gatekeeper review by removing extra plumbing and residue

## Screenshots

### Before

<img width="581" height="341" alt="image" src="https://github.com/user-attachments/assets/ec47b256-749a-4afc-8879-aaf33f0b46b6" />

### After

<img width="470" height="586" alt="image" src="https://github.com/user-attachments/assets/7258a5a2-47c4-408d-84bc-1b497761c7ad" />

## Architectural approach

This change intentionally uses:

- shared policy in `packages/ui/src/components/tool-call/diff-render.tsx`
- shared helper/measurement logic in `packages/ui/src/components/diff-viewer.tsx`
- mode-specific applicators where unified and split DOM differ
- CSS for shared visual spacing and alignment cleanup

The goal was to keep the implementation architecturally clean and avoid building separate duplicated compact-diff features for:

- mobile vs desktop
- unified vs split

Instead, the feature shares one compact-diff concept and only diverges where the upstream diff DOM requires separate handling.

## Files changed

- `packages/ui/src/components/tool-call/diff-render.tsx`
- `packages/ui/src/components/diff-viewer.tsx`
- `packages/ui/src/styles/messaging/tool-call.css`
- `packages/ui/src/types/message.ts`

## Validation

Manual validation was performed in the running UI.

Verified manually:

- compact unified gutters on mobile
- compact unified gutters on desktop
- compact split gutters on desktop
- tighter operator alignment in both modes

Also verified:

- `npm run typecheck` passes

## Notes

- This PR is intended to address the compact diff layout problem described in the related issue.
- Diff-specific CSS still lives in `tool-call.css`; future extraction into a smaller dedicated stylesheet is possible but not required for this change.
