### PR TITLE
perf(ui): virtualize message timeline rendering, #274 follow-up ( BIG SPEED IMPROVEMENT )

### DIFF
--- a/packages/ui/src/components/message-timeline.tsx
+++ b/packages/ui/src/components/message-timeline.tsx
@@ -1,4 +1,5 @@
 import { For, Show, createEffect, createMemo, createSignal, onCleanup, on, untrack, type Component, type Accessor } from "solid-js"
+import { Virtualizer, type VirtualizerHandle } from "virtua/solid"
 import MessagePreview from "./message-preview"
 import { messageStoreBus } from "../stores/message-v2/bus"
 import type { ClientPart } from "../types/message"
@@ -53,6 +54,7 @@ const MAX_TOOLTIP_LENGTH = 220
 const LONG_PRESS_MS = 500
 const JITTER_THRESHOLD = 10
 const ABSOLUTE_TOKEN_CAP = 10000
+const TIMELINE_VIRTUALIZER_BUFFER_PX = 240
 
 type ToolCallPart = Extract<ClientPart, { type: "tool" }>
 
@@ -416,6 +418,8 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
   // on activation, resize, or expansion — NOT on every scroll frame.
   const [badgeOffsets, setBadgeOffsets] = createSignal<Record<string, { layoutTop: number; height: number }>>({})
   const [windowWidth, setWindowWidth] = createSignal(typeof window !== "undefined" ? window.innerWidth : 1200)
+  const [scrollElement, setScrollElement] = createSignal<HTMLDivElement | undefined>()
+  const [virtualizerHandle, setVirtualizerHandle] = createSignal<VirtualizerHandle | undefined>()
   let scrollContainerRef: HTMLDivElement | undefined
   let xrayOverlayRef: HTMLDivElement | undefined
 
@@ -474,6 +478,8 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
       requestAnimationFrame(computeBadgeLayout)
     }
   })
+
+  const renderVirtualizedTimeline = createMemo(() => !isSelectionActive())
 
   const maxRibWidth = createMemo(() => Math.round(windowWidth() * 0.5))
 
@@ -629,9 +635,17 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
 
   createEffect(on(() => props.activeSegmentId, (activeId) => {
     if (!activeId) return
-    const element = buttonRefs.get(activeId)
-    if (!element) return
     const timer = typeof window !== "undefined" ? window.setTimeout(() => {
+      if (renderVirtualizedTimeline()) {
+        const index = segmentIndexById().get(activeId)
+        if (index !== undefined) {
+          virtualizerHandle()?.scrollToIndex(index, { align: "nearest", smooth: true })
+        }
+        return
+      }
+
+      const element = buttonRefs.get(activeId)
+      if (!element) return
       element.scrollIntoView({ block: "nearest", behavior: "smooth" })
     }, 120) : null
     onCleanup(() => {
@@ -682,17 +696,160 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
     return map
   })
 
+  const segmentIndexById = createMemo(() => {
+    const map = new Map<string, number>()
+    for (let i = 0; i < props.segments.length; i++) map.set(props.segments[i].id, i)
+    return map
+  })
+
   return (
     <div class="message-timeline-container">
       <div
-        ref={scrollContainerRef}
+        ref={(element) => {
+          scrollContainerRef = element
+          setScrollElement(element)
+        }}
         class={`message-timeline${isSelectionActive() ? " message-timeline--selection-active" : ""}`}
         role="navigation"
         aria-label={t("messageTimeline.ariaLabel")}
         onScroll={handleScroll}
       >
-        <For each={props.segments}>
-          {(segment, segIndex) => {
+        <Show
+          when={renderVirtualizedTimeline()}
+          fallback={(
+            <For each={props.segments}>
+              {(segment, segIndex) => {
+                onCleanup(() => buttonRefs.delete(segment.id))
+                const isActive = () => props.activeSegmentId === segment.id
+                const isSelected = () => props.selectedIds?.().has(segment.id)
+
+                const isDeleteHovered = () => {
+                  const hover = deleteHover() as DeleteHoverState
+                  if (hover.kind === "message") {
+                    return hover.messageId === segment.messageId
+                  }
+
+                  if (hover.kind === "deleteUpTo") {
+                    const indexMap = messageIdToSessionIndex()
+                    const targetIndex = indexMap.get(hover.messageId)
+                    if (targetIndex === undefined) return false
+                    const segmentIndex = indexMap.get(segment.messageId)
+                    if (segmentIndex === undefined) return false
+                    return segmentIndex >= targetIndex
+                  }
+
+                  return false
+                }
+
+                const isDeleteSelected = () => {
+                  const selected = props.selectedMessageIds?.()
+                  if (!selected) return false
+                  return selected.has(segment.messageId)
+                }
+
+                const hasActivePermission = () => {
+                  if (segment.type !== "tool") return false
+                  const partIds = segment.toolPartIds ?? []
+                  if (partIds.length === 0) return false
+                  for (const partId of partIds) {
+                    const permissionState = store().getPermissionState(segment.messageId, partId)
+                    if (permissionState?.active) return true
+                  }
+                  return false
+                }
+
+                const isExpanded = () => props.expandedMessageIds?.().has(segment.messageId) ?? false
+                const isHidden = () =>
+                  segment.type === "tool" &&
+                  !(showTools() || isExpanded() || isSelectionActive() || isActive() || hasActivePermission() || isDeleteHovered() || isDeleteSelected())
+
+                const groupRole = (): "child" | "parent" | "none" => {
+                  if (segment.type === "tool") return "child"
+                  if (segment.type === "assistant" && messagesWithTools().has(segment.messageId)) return "parent"
+                  return "none"
+                }
+                const isGroupStart = () => {
+                  if (segment.type !== "tool") return false
+                  const idx = segIndex()
+                  const prev = idx > 0 ? props.segments[idx - 1] : null
+                  return !prev || prev.type !== "tool" || prev.messageId !== segment.messageId
+                }
+
+                const shortLabelContent = () => {
+                  if (segment.type === "tool") {
+                    if (hasActivePermission()) {
+                      return <ShieldAlert class="message-timeline-icon" aria-hidden="true" />
+                    }
+                    return segment.shortLabel ?? getToolIcon("tool")
+                  }
+                  if (segment.type === "compaction") {
+                    return <FoldVertical class="message-timeline-icon" aria-hidden="true" />
+                  }
+                  if (segment.type === "user") {
+                    return <UserIcon class="message-timeline-icon" aria-hidden="true" />
+                  }
+                  return <BotIcon class="message-timeline-icon" aria-hidden="true" />
+                }
+
+                return (
+                  <button
+                    ref={(el) => registerButtonRef(segment.id, el)}
+                    type="button"
+                    data-variant={segment.variant}
+                    class={`message-timeline-segment message-timeline-${segment.type} ${hasActivePermission() ? "message-timeline-segment-permission" : ""} ${segment.type === "compaction" ? `message-timeline-compaction-${segment.variant ?? "manual"}` : ""} ${isActive() ? "message-timeline-segment-active" : ""} ${isHidden() ? "message-timeline-segment-hidden" : ""} ${isSelected() ? "message-timeline-segment-selected" : ""} ${isDeleteSelected() ? "message-timeline-segment-delete-selected" : ""} ${groupRole() !== "none" ? `message-timeline-group-${groupRole()}` : ""} ${isGroupStart() ? "message-timeline-group-start" : ""}`}
+                    data-delete-hover={isDeleteHovered() || isDeleteSelected() || isSelected() ? "true" : undefined}
+                    aria-current={isActive() ? "true" : undefined}
+                    aria-hidden={isHidden() ? "true" : undefined}
+                    onClick={(event) => {
+                      if (wasLongPress) {
+                        wasLongPress = false
+                        return
+                      }
+
+                      const btn = buttonRefs.get(segment.id)
+                      let anchorOffset: number | null = null
+                      if (btn && scrollContainerRef) {
+                        anchorOffset = btn.offsetTop - scrollContainerRef.scrollTop
+                      }
+
+                      const isMultiSelectActive = (props.selectedIds?.().size ?? 0) > 0
+
+                      if (event.shiftKey) {
+                        props.onSelectRange?.(segment.id)
+                      } else if (event.ctrlKey || event.metaKey) {
+                        props.onToggleSelection?.(segment.id)
+                      } else if (isMultiSelectActive) {
+                        props.onSegmentClick?.(segment)
+                      } else {
+                        props.onSegmentClick?.(segment)
+                      }
+
+                      if (anchorOffset !== null && btn && scrollContainerRef) {
+                        const desired = btn.offsetTop - anchorOffset
+                        if (Math.abs(scrollContainerRef.scrollTop - desired) > 1) {
+                          scrollContainerRef.scrollTop = desired
+                        }
+                      }
+                    }}
+                    onPointerDown={(e) => handlePointerDown(segment, e)}
+                    onPointerUp={handlePointerUp}
+                    onPointerCancel={handlePointerUp}
+                    onPointerMove={handlePointerMove}
+                    onContextMenu={handleContextMenu}
+                    onMouseEnter={(event) => handleMouseEnter(segment, event)}
+                    onMouseLeave={handleMouseLeave}
+                  >
+                    <span class="message-timeline-label message-timeline-label-full">{segment.label}</span>
+                    <span class="message-timeline-label message-timeline-label-short">{shortLabelContent()}</span>
+                  </button>
+                )
+              }}
+            </For>
+          )}
+        >
+          <Virtualizer ref={setVirtualizerHandle} data={props.segments} scrollRef={scrollElement()} bufferSize={TIMELINE_VIRTUALIZER_BUFFER_PX}>
+            {(segment, index) => {
+              const segIndex = () => index()
             onCleanup(() => buttonRefs.delete(segment.id))
             const isActive = () => props.activeSegmentId === segment.id
             const isSelected = () => props.selectedIds?.().has(segment.id)
@@ -769,8 +926,8 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
                return <BotIcon class="message-timeline-icon" aria-hidden="true" />
              }
 
-            return (
-              <button
+             return (
+               <button
                   ref={(el) => registerButtonRef(segment.id, el)}
                   type="button"
                   data-variant={segment.variant}
@@ -828,10 +985,11 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
               >
                 <span class="message-timeline-label message-timeline-label-full">{segment.label}</span>
                 <span class="message-timeline-label message-timeline-label-short">{shortLabelContent()}</span>
-              </button>
-            )
-          }}
-        </For>
+               </button>
+             )
+            }}
+          </Virtualizer>
+        </Show>
         <Show when={previewData()}>
           {(data) => {
             onCleanup(() => setTooltipElement(null))

--- a/packages/ui/src/components/message-timeline.tsx
+++ b/packages/ui/src/components/message-timeline.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createEffect, createMemo, createSignal, onCleanup, on, untrack, type Component, type Accessor, type JSX } from "solid-js"
+import { For, Show, createEffect, createMemo, createSignal, onCleanup, on, untrack, type Component, type Accessor } from "solid-js"
 import { Virtualizer, type VirtualizerHandle } from "virtua/solid"
 import MessagePreview from "./message-preview"
 import { messageStoreBus } from "../stores/message-v2/bus"
@@ -56,21 +56,6 @@ const JITTER_THRESHOLD = 10
 const ABSOLUTE_TOKEN_CAP = 10000
 const TIMELINE_VIRTUALIZER_BUFFER_PX = 240
 
-function TimelineVirtualItem(props: { style: JSX.CSSProperties; index: number; ref?: unknown; children: JSX.Element }) {
-  return (
-    <div
-      ref={props.ref as never}
-      class="message-timeline-virtual-item"
-      style={{
-        ...props.style,
-        "margin-top": props.index === 0 ? "0" : "var(--message-timeline-segment-gap)",
-      }}
-    >
-      {props.children}
-    </div>
-  )
-}
-
 type ToolCallPart = Extract<ClientPart, { type: "tool" }>
 
 interface PendingSegment {
@@ -80,6 +65,13 @@ interface PendingSegment {
   partIds: string[]
   totalChars: number
   hasPrimaryText: boolean
+}
+
+interface TimelineSegmentState {
+  deleteHovered: boolean
+  deleteSelected: boolean
+  hasActivePermission: boolean
+  hidden: boolean
 }
 
 function truncateText(value: string): string {
@@ -732,12 +724,114 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
     return map
   })
 
-  const followsGroupParent = (index: number, segment: TimelineSegment): boolean => {
-    if (segment.type !== "user" && segment.type !== "compaction") return false
-    if (index <= 0) return false
-    const previous = props.segments[index - 1]
-    return previous?.type === "assistant" && messagesWithTools().has(previous.messageId)
+  const segmentStates = createMemo(() => {
+    const hover = deleteHover()
+    const selectedMessages = props.selectedMessageIds?.()
+    const expandedMessages = props.expandedMessageIds?.()
+    const resolvedStore = store()
+    const indexMap = messageIdToSessionIndex()
+    const selectionActive = isSelectionActive()
+    const result = new Map<string, TimelineSegmentState>()
+
+    for (const segment of props.segments) {
+      let deleteHovered = false
+      if (hover.kind === "message") {
+        deleteHovered = hover.messageId === segment.messageId
+      } else if (hover.kind === "deleteUpTo") {
+        const targetIndex = indexMap.get(hover.messageId)
+        const segmentIndex = indexMap.get(segment.messageId)
+        deleteHovered = targetIndex !== undefined && segmentIndex !== undefined && segmentIndex >= targetIndex
+      }
+
+      const deleteSelected = selectedMessages?.has(segment.messageId) ?? false
+
+      let hasActivePermission = false
+      if (segment.type === "tool") {
+        const partIds = segment.toolPartIds ?? []
+        for (const partId of partIds) {
+          const permissionState = resolvedStore.getPermissionState(segment.messageId, partId)
+          if (permissionState?.active) {
+            hasActivePermission = true
+            break
+          }
+        }
+      }
+
+      const hidden = segment.type === "tool" && !(
+        showTools()
+        || expandedMessages?.has(segment.messageId)
+        || selectionActive
+        || props.activeSegmentId === segment.id
+        || hasActivePermission
+        || deleteHovered
+        || deleteSelected
+      )
+
+      result.set(segment.id, {
+        deleteHovered,
+        deleteSelected,
+        hasActivePermission,
+        hidden,
+      })
+    }
+
+    return result
+  })
+
+  const segmentStateFor = (segmentId: string): TimelineSegmentState => {
+    return segmentStates().get(segmentId) ?? {
+      deleteHovered: false,
+      deleteSelected: false,
+      hasActivePermission: false,
+      hidden: false,
+    }
   }
+
+  const segmentSpacerHeights = createMemo(() => {
+    const states = segmentStates()
+    const result = new Map<string, string>()
+    let previousVisible: TimelineSegment | null = null
+
+    for (let index = 0; index < props.segments.length; index += 1) {
+      const segment = props.segments[index]
+      const state = states.get(segment.id)
+
+      if (state?.hidden) {
+        result.set(segment.id, "0")
+        continue
+      }
+
+      if (!previousVisible) {
+        result.set(segment.id, "0")
+        previousVisible = segment
+        continue
+      }
+
+      const previousRaw = index > 0 ? props.segments[index - 1] : null
+      const startsVisibleToolGroup = segment.type === "tool"
+        && (previousVisible.type !== "tool" || previousVisible.messageId !== segment.messageId)
+      const startsCollapsedToolGroup = segment.type === "assistant"
+        && previousVisible.messageId !== segment.messageId
+        && messagesWithTools().has(segment.messageId)
+        && previousRaw?.type === "tool"
+        && previousRaw.messageId === segment.messageId
+      const followsVisibleGroupParent = (segment.type === "user" || segment.type === "compaction")
+        && previousVisible.type === "assistant"
+        && messagesWithTools().has(previousVisible.messageId)
+
+      const gapUnits = 1 + (startsVisibleToolGroup || startsCollapsedToolGroup || followsVisibleGroupParent ? 1 : 0)
+      result.set(
+        segment.id,
+        gapUnits === 1
+          ? "var(--message-timeline-segment-gap)"
+          : "calc(var(--message-timeline-segment-gap) * 2)",
+      )
+
+      previousVisible = segment
+    }
+
+    return result
+  })
 
   return (
     <div class="message-timeline-container">
@@ -746,7 +840,7 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
           scrollContainerRef = element
           setScrollElement(element)
         }}
-        class={`message-timeline${isSelectionActive() ? " message-timeline--selection-active" : ""}${renderVirtualizedTimeline() ? " message-timeline--virtualized" : ""}`}
+        class={`message-timeline${isSelectionActive() ? " message-timeline--selection-active" : ""}`}
         role="navigation"
         aria-label={t("messageTimeline.ariaLabel")}
         onScroll={handleScroll}
@@ -759,57 +853,16 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
                 onCleanup(() => buttonRefs.delete(segment.id))
                 const isActive = () => props.activeSegmentId === segment.id
                 const isSelected = () => props.selectedIds?.().has(segment.id)
-
-                const isDeleteHovered = () => {
-                  const hover = deleteHover() as DeleteHoverState
-                  if (hover.kind === "message") {
-                    return hover.messageId === segment.messageId
-                  }
-
-                  if (hover.kind === "deleteUpTo") {
-                    const indexMap = messageIdToSessionIndex()
-                    const targetIndex = indexMap.get(hover.messageId)
-                    if (targetIndex === undefined) return false
-                    const segmentIndex = indexMap.get(segment.messageId)
-                    if (segmentIndex === undefined) return false
-                    return segmentIndex >= targetIndex
-                  }
-
-                  return false
-                }
-
-                const isDeleteSelected = () => {
-                  const selected = props.selectedMessageIds?.()
-                  if (!selected) return false
-                  return selected.has(segment.messageId)
-                }
-
-                const hasActivePermission = () => {
-                  if (segment.type !== "tool") return false
-                  const partIds = segment.toolPartIds ?? []
-                  if (partIds.length === 0) return false
-                  for (const partId of partIds) {
-                    const permissionState = store().getPermissionState(segment.messageId, partId)
-                    if (permissionState?.active) return true
-                  }
-                  return false
-                }
-
-                const isExpanded = () => props.expandedMessageIds?.().has(segment.messageId) ?? false
-                const isHidden = () =>
-                  segment.type === "tool" &&
-                  !(showTools() || isExpanded() || isSelectionActive() || isActive() || hasActivePermission() || isDeleteHovered() || isDeleteSelected())
+                const state = () => segmentStateFor(segment.id)
+                const isDeleteHovered = () => state().deleteHovered
+                const isDeleteSelected = () => state().deleteSelected
+                const hasActivePermission = () => state().hasActivePermission
+                const isHidden = () => state().hidden
 
                 const groupRole = (): "child" | "parent" | "none" => {
                   if (segment.type === "tool") return "child"
                   if (segment.type === "assistant" && messagesWithTools().has(segment.messageId)) return "parent"
                   return "none"
-                }
-                const isGroupStart = () => {
-                  if (segment.type !== "tool") return false
-                  const idx = segIndex()
-                  const prev = idx > 0 ? props.segments[idx - 1] : null
-                  return !prev || prev.type !== "tool" || prev.messageId !== segment.messageId
                 }
 
                 const shortLabelContent = () => {
@@ -829,107 +882,75 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
                 }
 
                 return (
-                  <button
-                    ref={(el) => registerButtonRef(segment.id, el)}
-                    type="button"
-                    data-variant={segment.variant}
-                    class={`message-timeline-segment message-timeline-${segment.type} ${hasActivePermission() ? "message-timeline-segment-permission" : ""} ${segment.type === "compaction" ? `message-timeline-compaction-${segment.variant ?? "manual"}` : ""} ${isActive() ? "message-timeline-segment-active" : ""} ${isHidden() ? "message-timeline-segment-hidden" : ""} ${isSelected() ? "message-timeline-segment-selected" : ""} ${isDeleteSelected() ? "message-timeline-segment-delete-selected" : ""} ${groupRole() !== "none" ? `message-timeline-group-${groupRole()}` : ""} ${isGroupStart() ? "message-timeline-group-start" : ""} ${followsGroupParent(segIndex(), segment) ? "message-timeline-after-group-parent" : ""}`}
-                    data-delete-hover={isDeleteHovered() || isDeleteSelected() || isSelected() ? "true" : undefined}
-                    aria-current={isActive() ? "true" : undefined}
-                    aria-hidden={isHidden() ? "true" : undefined}
-                    onClick={(event) => {
-                    if (wasLongPress) {
-                      wasLongPress = false
-                      return
-                    }
+                  <div class="message-timeline-item">
+                    <div aria-hidden="true" class="message-timeline-item-spacer" style={{ height: segmentSpacerHeights().get(segment.id) ?? "0" }} />
+                    <button
+                      ref={(el) => registerButtonRef(segment.id, el)}
+                      type="button"
+                      data-variant={segment.variant}
+                      class={`message-timeline-segment message-timeline-${segment.type} ${hasActivePermission() ? "message-timeline-segment-permission" : ""} ${segment.type === "compaction" ? `message-timeline-compaction-${segment.variant ?? "manual"}` : ""} ${isActive() ? "message-timeline-segment-active" : ""} ${isHidden() ? "message-timeline-segment-hidden" : ""} ${isSelected() ? "message-timeline-segment-selected" : ""} ${isDeleteSelected() ? "message-timeline-segment-delete-selected" : ""} ${groupRole() !== "none" ? `message-timeline-group-${groupRole()}` : ""}`}
+                      data-delete-hover={isDeleteHovered() || isDeleteSelected() || isSelected() ? "true" : undefined}
+                      aria-current={isActive() ? "true" : undefined}
+                      aria-hidden={isHidden() ? "true" : undefined}
+                      onClick={(event) => {
+                        if (wasLongPress) {
+                          wasLongPress = false
+                          return
+                        }
 
-                    const btn = buttonRefs.get(segment.id)
-                    const stableBtn = renderVirtualizedTimeline() ? null : btn
-                    let anchorOffset: number | null = null
-                    if (stableBtn && scrollContainerRef) {
-                      anchorOffset = stableBtn.offsetTop - scrollContainerRef.scrollTop
-                    }
+                        const btn = buttonRefs.get(segment.id)
+                        const stableBtn = renderVirtualizedTimeline() ? null : btn
+                        let anchorOffset: number | null = null
+                        if (stableBtn && scrollContainerRef) {
+                          anchorOffset = stableBtn.offsetTop - scrollContainerRef.scrollTop
+                        }
 
-                      const isMultiSelectActive = (props.selectedIds?.().size ?? 0) > 0
+                        const isMultiSelectActive = (props.selectedIds?.().size ?? 0) > 0
 
-                      if (event.shiftKey) {
-                        props.onSelectRange?.(segment.id)
-                      } else if (event.ctrlKey || event.metaKey) {
-                        props.onToggleSelection?.(segment.id)
-                      } else if (isMultiSelectActive) {
-                        props.onSegmentClick?.(segment)
-                      } else {
-                        props.onSegmentClick?.(segment)
-                      }
+                        if (event.shiftKey) {
+                          props.onSelectRange?.(segment.id)
+                        } else if (event.ctrlKey || event.metaKey) {
+                          props.onToggleSelection?.(segment.id)
+                        } else if (isMultiSelectActive) {
+                          props.onSegmentClick?.(segment)
+                        } else {
+                          props.onSegmentClick?.(segment)
+                        }
 
-                    if (anchorOffset !== null && stableBtn && scrollContainerRef) {
-                      const desired = stableBtn.offsetTop - anchorOffset
-                      if (Math.abs(scrollContainerRef.scrollTop - desired) > 1) {
-                        scrollContainerRef.scrollTop = desired
-                      }
-                      }
-                    }}
-                    onPointerDown={(e) => handlePointerDown(segment, e)}
-                    onPointerUp={handlePointerUp}
-                    onPointerCancel={handlePointerUp}
-                    onPointerMove={handlePointerMove}
-                    onContextMenu={handleContextMenu}
-                    onMouseEnter={(event) => handleMouseEnter(segment, event)}
-                    onMouseLeave={handleMouseLeave}
-                  >
-                    <span class="message-timeline-label message-timeline-label-full">{segment.label}</span>
-                    <span class="message-timeline-label message-timeline-label-short">{shortLabelContent()}</span>
-                  </button>
+                        if (anchorOffset !== null && stableBtn && scrollContainerRef) {
+                          const desired = stableBtn.offsetTop - anchorOffset
+                          if (Math.abs(scrollContainerRef.scrollTop - desired) > 1) {
+                            scrollContainerRef.scrollTop = desired
+                          }
+                        }
+                      }}
+                      onPointerDown={(e) => handlePointerDown(segment, e)}
+                      onPointerUp={handlePointerUp}
+                      onPointerCancel={handlePointerUp}
+                      onPointerMove={handlePointerMove}
+                      onContextMenu={handleContextMenu}
+                      onMouseEnter={(event) => handleMouseEnter(segment, event)}
+                      onMouseLeave={handleMouseLeave}
+                    >
+                      <span class="message-timeline-label message-timeline-label-full">{segment.label}</span>
+                      <span class="message-timeline-label message-timeline-label-short">{shortLabelContent()}</span>
+                    </button>
+                  </div>
                 )
               }}
             </For>
           )}
         >
-          <Virtualizer ref={setVirtualizerHandle} data={props.segments} item={TimelineVirtualItem} scrollRef={scrollElement()} bufferSize={TIMELINE_VIRTUALIZER_BUFFER_PX}>
+          <Virtualizer ref={setVirtualizerHandle} data={props.segments} scrollRef={scrollElement()} bufferSize={TIMELINE_VIRTUALIZER_BUFFER_PX}>
             {(segment, index) => {
               const segIndex = () => index()
             const isActive = () => props.activeSegmentId === segment.id
             const isSelected = () => props.selectedIds?.().has(segment.id)
-
-            const isDeleteHovered = () => {
-              const hover = deleteHover() as DeleteHoverState
-              if (hover.kind === "message") {
-                return hover.messageId === segment.messageId
-              }
-
-              if (hover.kind === "deleteUpTo") {
-                const indexMap = messageIdToSessionIndex()
-                const targetIndex = indexMap.get(hover.messageId)
-                if (targetIndex === undefined) return false
-                const segmentIndex = indexMap.get(segment.messageId)
-                if (segmentIndex === undefined) return false
-                return segmentIndex >= targetIndex
-              }
-
-              return false
-            }
-
-            const isDeleteSelected = () => {
-              const selected = props.selectedMessageIds?.()
-              if (!selected) return false
-              return selected.has(segment.messageId)
-            }
-
-            const hasActivePermission = () => {
-              if (segment.type !== "tool") return false
-              const partIds = segment.toolPartIds ?? []
-              if (partIds.length === 0) return false
-              for (const partId of partIds) {
-                const permissionState = store().getPermissionState(segment.messageId, partId)
-                if (permissionState?.active) return true
-              }
-              return false
-            }
-
-            const isExpanded = () => props.expandedMessageIds?.().has(segment.messageId) ?? false
-            const isHidden = () =>
-              segment.type === "tool" &&
-              !(showTools() || isExpanded() || isSelectionActive() || isActive() || hasActivePermission() || isDeleteHovered() || isDeleteSelected())
+            const state = () => segmentStateFor(segment.id)
+            const isDeleteHovered = () => state().deleteHovered
+            const isDeleteSelected = () => state().deleteSelected
+            const hasActivePermission = () => state().hasActivePermission
+            const isHidden = () => state().hidden
 
             // Group visual indicators: tools belong to the same message as their
             // assistant.  Uses messageId for correctness (not positional adjacency).
@@ -938,18 +959,10 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
               if (segment.type === "assistant" && messagesWithTools().has(segment.messageId)) return "parent"
               return "none"
             }
-            const isGroupStart = () => {
-              if (segment.type !== "tool") return false
-              const idx = segIndex()
-              const prev = idx > 0 ? props.segments[idx - 1] : null
-              // First tool in the message's run: either nothing before, or previous
-              // segment is from a different message or is not a tool.
-              return !prev || prev.type !== "tool" || prev.messageId !== segment.messageId
-            }
 
              const shortLabelContent = () => {
                if (segment.type === "tool") {
-                 if (hasActivePermission()) {
+                  if (hasActivePermission()) {
                    return <ShieldAlert class="message-timeline-icon" aria-hidden="true" />
                  }
                  return segment.shortLabel ?? getToolIcon("tool")
@@ -959,69 +972,64 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
                }
                if (segment.type === "user") {
                  return <UserIcon class="message-timeline-icon" aria-hidden="true" />
-               }
-               return <BotIcon class="message-timeline-icon" aria-hidden="true" />
-             }
+                }
+                return <BotIcon class="message-timeline-icon" aria-hidden="true" />
+              }
 
-             return (
-               <button
-                  type="button"
-                  data-variant={segment.variant}
-                   class={`message-timeline-segment message-timeline-${segment.type} ${hasActivePermission() ? "message-timeline-segment-permission" : ""} ${segment.type === "compaction" ? `message-timeline-compaction-${segment.variant ?? "manual"}` : ""} ${isActive() ? "message-timeline-segment-active" : ""} ${isHidden() ? "message-timeline-segment-hidden" : ""} ${isSelected() ? "message-timeline-segment-selected" : ""} ${isDeleteSelected() ? "message-timeline-segment-delete-selected" : ""} ${groupRole() !== "none" ? `message-timeline-group-${groupRole()}` : ""} ${isGroupStart() ? "message-timeline-group-start" : ""} ${followsGroupParent(segIndex(), segment) ? "message-timeline-after-group-parent" : ""}`}
-
-                  data-delete-hover={isDeleteHovered() || isDeleteSelected() || isSelected() ? "true" : undefined}
-
-                 aria-current={isActive() ? "true" : undefined}
-                 aria-hidden={isHidden() ? "true" : undefined}
-                 onClick={(event) => {
-                   if (wasLongPress) {
-                     wasLongPress = false
-                     return
-                   }
-
-                   // Capture scroll anchor before selection changes may toggle
-                   // tool segment visibility, which shifts timeline layout.
-                   const btn = buttonRefs.get(segment.id)
-                   let anchorOffset: number | null = null
-                   if (btn && scrollContainerRef) {
-                     anchorOffset = btn.offsetTop - scrollContainerRef.scrollTop
-                   }
-
-                   const isMultiSelectActive = (props.selectedIds?.().size ?? 0) > 0
-
-                   if (event.shiftKey) {
-                     props.onSelectRange?.(segment.id)
-                   } else if (event.ctrlKey || event.metaKey) {
-                     props.onToggleSelection?.(segment.id)
-                   } else if (isMultiSelectActive) {
-                     // In selection mode, plain click scrolls to the message
-                     // instead of clearing. Selection is cleared by clicking
-                     // anywhere inside the chat container or pressing Esc.
-                     props.onSegmentClick?.(segment)
-                   } else {
-                     props.onSegmentClick?.(segment)
-                   }
-
-                   // Restore scroll anchor: keep the clicked badge at the same
-                   // visual position after hidden tools appear or disappear.
-                   if (anchorOffset !== null && btn && scrollContainerRef) {
-                     const desired = btn.offsetTop - anchorOffset
-                     if (Math.abs(scrollContainerRef.scrollTop - desired) > 1) {
-                       scrollContainerRef.scrollTop = desired
+              return (
+               <div class="message-timeline-item">
+                  <div aria-hidden="true" class="message-timeline-item-spacer" style={{ height: segmentSpacerHeights().get(segment.id) ?? "0" }} />
+                  <button
+                    type="button"
+                    data-variant={segment.variant}
+                   class={`message-timeline-segment message-timeline-${segment.type} ${hasActivePermission() ? "message-timeline-segment-permission" : ""} ${segment.type === "compaction" ? `message-timeline-compaction-${segment.variant ?? "manual"}` : ""} ${isActive() ? "message-timeline-segment-active" : ""} ${isHidden() ? "message-timeline-segment-hidden" : ""} ${isSelected() ? "message-timeline-segment-selected" : ""} ${isDeleteSelected() ? "message-timeline-segment-delete-selected" : ""} ${groupRole() !== "none" ? `message-timeline-group-${groupRole()}` : ""}`}
+                   data-delete-hover={isDeleteHovered() || isDeleteSelected() || isSelected() ? "true" : undefined}
+                   aria-current={isActive() ? "true" : undefined}
+                   aria-hidden={isHidden() ? "true" : undefined}
+                   onClick={(event) => {
+                     if (wasLongPress) {
+                       wasLongPress = false
+                       return
                      }
-                   }
-                 }}
-                onPointerDown={(e) => handlePointerDown(segment, e)}
-                 onPointerUp={handlePointerUp}
-                 onPointerCancel={handlePointerUp}
-                 onPointerMove={handlePointerMove}
-                 onContextMenu={handleContextMenu}
-                 onMouseEnter={(event) => handleMouseEnter(segment, event)}
-                 onMouseLeave={handleMouseLeave}
-              >
-                <span class="message-timeline-label message-timeline-label-full">{segment.label}</span>
-                <span class="message-timeline-label message-timeline-label-short">{shortLabelContent()}</span>
-               </button>
+
+                     const btn = buttonRefs.get(segment.id)
+                     const stableBtn = renderVirtualizedTimeline() ? null : btn
+                     let anchorOffset: number | null = null
+                     if (stableBtn && scrollContainerRef) {
+                       anchorOffset = stableBtn.offsetTop - scrollContainerRef.scrollTop
+                     }
+
+                     const isMultiSelectActive = (props.selectedIds?.().size ?? 0) > 0
+
+                     if (event.shiftKey) {
+                       props.onSelectRange?.(segment.id)
+                     } else if (event.ctrlKey || event.metaKey) {
+                       props.onToggleSelection?.(segment.id)
+                     } else if (isMultiSelectActive) {
+                       props.onSegmentClick?.(segment)
+                     } else {
+                       props.onSegmentClick?.(segment)
+                     }
+
+                     if (anchorOffset !== null && stableBtn && scrollContainerRef) {
+                       const desired = stableBtn.offsetTop - anchorOffset
+                       if (Math.abs(scrollContainerRef.scrollTop - desired) > 1) {
+                         scrollContainerRef.scrollTop = desired
+                       }
+                     }
+                   }}
+                   onPointerDown={(e) => handlePointerDown(segment, e)}
+                   onPointerUp={handlePointerUp}
+                   onPointerCancel={handlePointerUp}
+                   onPointerMove={handlePointerMove}
+                   onContextMenu={handleContextMenu}
+                   onMouseEnter={(event) => handleMouseEnter(segment, event)}
+                   onMouseLeave={handleMouseLeave}
+                 >
+                   <span class="message-timeline-label message-timeline-label-full">{segment.label}</span>
+                   <span class="message-timeline-label message-timeline-label-short">{shortLabelContent()}</span>
+                 </button>
+               </div>
              )
             }}
           </Virtualizer>

--- a/packages/ui/src/components/message-timeline.tsx
+++ b/packages/ui/src/components/message-timeline.tsx
@@ -717,6 +717,13 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
     return map
   })
 
+  const followsGroupParent = (index: number, segment: TimelineSegment): boolean => {
+    if (segment.type !== "user" && segment.type !== "compaction") return false
+    if (index <= 0) return false
+    const previous = props.segments[index - 1]
+    return previous?.type === "assistant" && messagesWithTools().has(previous.messageId)
+  }
+
   return (
     <div class="message-timeline-container">
       <div
@@ -811,7 +818,7 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
                     ref={(el) => registerButtonRef(segment.id, el)}
                     type="button"
                     data-variant={segment.variant}
-                    class={`message-timeline-segment message-timeline-${segment.type} ${hasActivePermission() ? "message-timeline-segment-permission" : ""} ${segment.type === "compaction" ? `message-timeline-compaction-${segment.variant ?? "manual"}` : ""} ${isActive() ? "message-timeline-segment-active" : ""} ${isHidden() ? "message-timeline-segment-hidden" : ""} ${isSelected() ? "message-timeline-segment-selected" : ""} ${isDeleteSelected() ? "message-timeline-segment-delete-selected" : ""} ${groupRole() !== "none" ? `message-timeline-group-${groupRole()}` : ""} ${isGroupStart() ? "message-timeline-group-start" : ""}`}
+                    class={`message-timeline-segment message-timeline-${segment.type} ${hasActivePermission() ? "message-timeline-segment-permission" : ""} ${segment.type === "compaction" ? `message-timeline-compaction-${segment.variant ?? "manual"}` : ""} ${isActive() ? "message-timeline-segment-active" : ""} ${isHidden() ? "message-timeline-segment-hidden" : ""} ${isSelected() ? "message-timeline-segment-selected" : ""} ${isDeleteSelected() ? "message-timeline-segment-delete-selected" : ""} ${groupRole() !== "none" ? `message-timeline-group-${groupRole()}` : ""} ${isGroupStart() ? "message-timeline-group-start" : ""} ${followsGroupParent(segIndex(), segment) ? "message-timeline-after-group-parent" : ""}`}
                     data-delete-hover={isDeleteHovered() || isDeleteSelected() || isSelected() ? "true" : undefined}
                     aria-current={isActive() ? "true" : undefined}
                     aria-hidden={isHidden() ? "true" : undefined}
@@ -945,7 +952,7 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
                <button
                   type="button"
                   data-variant={segment.variant}
-                  class={`message-timeline-segment message-timeline-${segment.type} ${hasActivePermission() ? "message-timeline-segment-permission" : ""} ${segment.type === "compaction" ? `message-timeline-compaction-${segment.variant ?? "manual"}` : ""} ${isActive() ? "message-timeline-segment-active" : ""} ${isHidden() ? "message-timeline-segment-hidden" : ""} ${isSelected() ? "message-timeline-segment-selected" : ""} ${isDeleteSelected() ? "message-timeline-segment-delete-selected" : ""} ${groupRole() !== "none" ? `message-timeline-group-${groupRole()}` : ""} ${isGroupStart() ? "message-timeline-group-start" : ""}`}
+                   class={`message-timeline-segment message-timeline-${segment.type} ${hasActivePermission() ? "message-timeline-segment-permission" : ""} ${segment.type === "compaction" ? `message-timeline-compaction-${segment.variant ?? "manual"}` : ""} ${isActive() ? "message-timeline-segment-active" : ""} ${isHidden() ? "message-timeline-segment-hidden" : ""} ${isSelected() ? "message-timeline-segment-selected" : ""} ${isDeleteSelected() ? "message-timeline-segment-delete-selected" : ""} ${groupRole() !== "none" ? `message-timeline-group-${groupRole()}` : ""} ${isGroupStart() ? "message-timeline-group-start" : ""} ${followsGroupParent(segIndex(), segment) ? "message-timeline-after-group-parent" : ""}`}
 
                   data-delete-hover={isDeleteHovered() || isDeleteSelected() || isSelected() ? "true" : undefined}
 

--- a/packages/ui/src/components/message-timeline.tsx
+++ b/packages/ui/src/components/message-timeline.tsx
@@ -351,6 +351,13 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
     }
   }
 
+  const clearHoverPreview = () => {
+    clearHoverTimer()
+    clearCloseTimer()
+    setHoveredSegment(null)
+    setHoverAnchorRect(null)
+  }
+
   const scheduleClose = () => {
     if (typeof window === "undefined") return
     clearHoverTimer()
@@ -358,8 +365,7 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
     // Small delay so the pointer can travel from the segment to the tooltip.
     closeTimer = window.setTimeout(() => {
       closeTimer = null
-      setHoveredSegment(null)
-      setHoverAnchorRect(null)
+      clearHoverPreview()
     }, 160)
   }
 
@@ -399,8 +405,7 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
   })
 
   onCleanup(() => {
-    clearHoverTimer()
-    clearCloseTimer()
+    clearHoverPreview()
   })
 
   // --- Selection & histogram rib state ---
@@ -451,6 +456,12 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
   }
 
   const handleScroll = () => {
+    if (renderVirtualizedTimeline()) {
+      if (hoveredSegment()) {
+        clearHoverPreview()
+      }
+      return
+    }
     if (!isSelectionActive()) return
     if (!scrollContainerRef || !xrayOverlayRef) return
     xrayOverlayRef.style.setProperty("--xray-scroll-y", `${-scrollContainerRef.scrollTop}px`)
@@ -480,6 +491,10 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
   })
 
   const renderVirtualizedTimeline = createMemo(() => !isSelectionActive())
+
+  createEffect(on(renderVirtualizedTimeline, () => {
+    clearHoverPreview()
+  }))
 
   const maxRibWidth = createMemo(() => Math.round(windowWidth() * 0.5))
 
@@ -583,7 +598,7 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
         wasLongPress = true
 
         // Scroll anchoring: preserve visual position of the pressed badge.
-        const btn = buttonRefs.get(segment.id)
+        const btn = renderVirtualizedTimeline() ? null : buttonRefs.get(segment.id)
         let anchorOffset: number | null = null
         if (btn && scrollContainerRef) {
           anchorOffset = btn.offsetTop - scrollContainerRef.scrollTop
@@ -801,16 +816,17 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
                     aria-current={isActive() ? "true" : undefined}
                     aria-hidden={isHidden() ? "true" : undefined}
                     onClick={(event) => {
-                      if (wasLongPress) {
-                        wasLongPress = false
-                        return
-                      }
+                    if (wasLongPress) {
+                      wasLongPress = false
+                      return
+                    }
 
-                      const btn = buttonRefs.get(segment.id)
-                      let anchorOffset: number | null = null
-                      if (btn && scrollContainerRef) {
-                        anchorOffset = btn.offsetTop - scrollContainerRef.scrollTop
-                      }
+                    const btn = buttonRefs.get(segment.id)
+                    const stableBtn = renderVirtualizedTimeline() ? null : btn
+                    let anchorOffset: number | null = null
+                    if (stableBtn && scrollContainerRef) {
+                      anchorOffset = stableBtn.offsetTop - scrollContainerRef.scrollTop
+                    }
 
                       const isMultiSelectActive = (props.selectedIds?.().size ?? 0) > 0
 
@@ -824,11 +840,11 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
                         props.onSegmentClick?.(segment)
                       }
 
-                      if (anchorOffset !== null && btn && scrollContainerRef) {
-                        const desired = btn.offsetTop - anchorOffset
-                        if (Math.abs(scrollContainerRef.scrollTop - desired) > 1) {
-                          scrollContainerRef.scrollTop = desired
-                        }
+                    if (anchorOffset !== null && stableBtn && scrollContainerRef) {
+                      const desired = stableBtn.offsetTop - anchorOffset
+                      if (Math.abs(scrollContainerRef.scrollTop - desired) > 1) {
+                        scrollContainerRef.scrollTop = desired
+                      }
                       }
                     }}
                     onPointerDown={(e) => handlePointerDown(segment, e)}
@@ -850,7 +866,6 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
           <Virtualizer ref={setVirtualizerHandle} data={props.segments} scrollRef={scrollElement()} bufferSize={TIMELINE_VIRTUALIZER_BUFFER_PX}>
             {(segment, index) => {
               const segIndex = () => index()
-            onCleanup(() => buttonRefs.delete(segment.id))
             const isActive = () => props.activeSegmentId === segment.id
             const isSelected = () => props.selectedIds?.().has(segment.id)
 
@@ -928,7 +943,6 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
 
              return (
                <button
-                  ref={(el) => registerButtonRef(segment.id, el)}
                   type="button"
                   data-variant={segment.variant}
                   class={`message-timeline-segment message-timeline-${segment.type} ${hasActivePermission() ? "message-timeline-segment-permission" : ""} ${segment.type === "compaction" ? `message-timeline-compaction-${segment.variant ?? "manual"}` : ""} ${isActive() ? "message-timeline-segment-active" : ""} ${isHidden() ? "message-timeline-segment-hidden" : ""} ${isSelected() ? "message-timeline-segment-selected" : ""} ${isDeleteSelected() ? "message-timeline-segment-delete-selected" : ""} ${groupRole() !== "none" ? `message-timeline-group-${groupRole()}` : ""} ${isGroupStart() ? "message-timeline-group-start" : ""}`}

--- a/packages/ui/src/components/message-timeline.tsx
+++ b/packages/ui/src/components/message-timeline.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createEffect, createMemo, createSignal, onCleanup, on, untrack, type Component, type Accessor } from "solid-js"
+import { For, Show, createEffect, createMemo, createSignal, onCleanup, on, untrack, type Component, type Accessor, type JSX } from "solid-js"
 import { Virtualizer, type VirtualizerHandle } from "virtua/solid"
 import MessagePreview from "./message-preview"
 import { messageStoreBus } from "../stores/message-v2/bus"
@@ -55,6 +55,21 @@ const LONG_PRESS_MS = 500
 const JITTER_THRESHOLD = 10
 const ABSOLUTE_TOKEN_CAP = 10000
 const TIMELINE_VIRTUALIZER_BUFFER_PX = 240
+
+function TimelineVirtualItem(props: { style: JSX.CSSProperties; index: number; ref?: unknown; children: JSX.Element }) {
+  return (
+    <div
+      ref={props.ref as never}
+      class="message-timeline-virtual-item"
+      style={{
+        ...props.style,
+        "margin-top": props.index === 0 ? "0" : "var(--message-timeline-segment-gap)",
+      }}
+    >
+      {props.children}
+    </div>
+  )
+}
 
 type ToolCallPart = Extract<ClientPart, { type: "tool" }>
 
@@ -731,7 +746,7 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
           scrollContainerRef = element
           setScrollElement(element)
         }}
-        class={`message-timeline${isSelectionActive() ? " message-timeline--selection-active" : ""}`}
+        class={`message-timeline${isSelectionActive() ? " message-timeline--selection-active" : ""}${renderVirtualizedTimeline() ? " message-timeline--virtualized" : ""}`}
         role="navigation"
         aria-label={t("messageTimeline.ariaLabel")}
         onScroll={handleScroll}
@@ -870,7 +885,7 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
             </For>
           )}
         >
-          <Virtualizer ref={setVirtualizerHandle} data={props.segments} scrollRef={scrollElement()} bufferSize={TIMELINE_VIRTUALIZER_BUFFER_PX}>
+          <Virtualizer ref={setVirtualizerHandle} data={props.segments} item={TimelineVirtualItem} scrollRef={scrollElement()} bufferSize={TIMELINE_VIRTUALIZER_BUFFER_PX}>
             {(segment, index) => {
               const segIndex = () => index()
             const isActive = () => props.activeSegmentId === segment.id

--- a/packages/ui/src/styles/messaging/message-timeline.css
+++ b/packages/ui/src/styles/messaging/message-timeline.css
@@ -326,7 +326,9 @@
 }
 
 /* Subtle extra spacing after the group parent (assistant) to separate
-   from the next user badge below. Uses adjacent sibling targeting. */
+   from the next user badge below. Use an explicit class so this also works
+   in the virtualized path where items are wrapped. */
+.message-timeline-after-group-parent,
 .message-timeline-group-parent + .message-timeline-user,
 .message-timeline-group-parent + .message-timeline-compaction {
   margin-top: 0.35rem;

--- a/packages/ui/src/styles/messaging/message-timeline.css
+++ b/packages/ui/src/styles/messaging/message-timeline.css
@@ -66,16 +66,21 @@
 }
 
 .message-timeline {
+  --message-timeline-segment-gap: 0.35rem;
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: var(--message-timeline-segment-gap);
   padding: 0.25rem;
   overflow-y: auto;
   overflow-x: visible;
   border-radius: 8px;
   background-color: var(--surface-base);
   box-shadow: var(--panel-shadow);
+}
+
+.message-timeline--virtualized {
+  gap: 0;
 }
 
 .message-timeline--selection-active {
@@ -322,7 +327,7 @@
 /* Extra spacing before the first tool in a group to separate from the
    preceding user/assistant badge. */
 .message-timeline-group-start {
-  margin-top: 0.35rem;
+  margin-top: var(--message-timeline-segment-gap);
 }
 
 /* Subtle extra spacing after the group parent (assistant) to separate
@@ -331,7 +336,7 @@
 .message-timeline-after-group-parent,
 .message-timeline-group-parent + .message-timeline-user,
 .message-timeline-group-parent + .message-timeline-compaction {
-  margin-top: 0.35rem;
+  margin-top: var(--message-timeline-segment-gap);
 }
 
 .message-timeline-container {

--- a/packages/ui/src/styles/messaging/message-timeline.css
+++ b/packages/ui/src/styles/messaging/message-timeline.css
@@ -70,17 +70,13 @@
   flex: 1 1 auto;
   display: flex;
   flex-direction: column;
-  gap: var(--message-timeline-segment-gap);
+  gap: 0;
   padding: 0.25rem;
   overflow-y: auto;
   overflow-x: visible;
   border-radius: 8px;
   background-color: var(--surface-base);
   box-shadow: var(--panel-shadow);
-}
-
-.message-timeline--virtualized {
-  gap: 0;
 }
 
 .message-timeline--selection-active {
@@ -117,6 +113,17 @@
   -webkit-user-select: none;
   touch-action: manipulation;
   -webkit-touch-callout: none;
+}
+
+.message-timeline-item {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.message-timeline-item-spacer {
+  flex: none;
+  width: 100%;
 }
 
 .message-timeline-segment[data-delete-hover="true"]::before {
@@ -324,20 +331,7 @@
   border-inline-start: 3px solid color-mix(in oklab, var(--accent-primary) 35%, transparent);
 }
 
-/* Extra spacing before the first tool in a group to separate from the
-   preceding user/assistant badge. */
-.message-timeline-group-start {
-  margin-top: var(--message-timeline-segment-gap);
-}
-
-/* Subtle extra spacing after the group parent (assistant) to separate
-   from the next user badge below. Use an explicit class so this also works
-   in the virtualized path where items are wrapped. */
-.message-timeline-after-group-parent,
-.message-timeline-group-parent + .message-timeline-user,
-.message-timeline-group-parent + .message-timeline-compaction {
-  margin-top: var(--message-timeline-segment-gap);
-}
+/* Spacing is rendered by the measured item wrapper so virtua can account for it. */
 
 .message-timeline-container {
   position: relative;


### PR DESCRIPTION
## Summary
- virtualize MessageTimeline so large session histories stop rendering the full timeline sidebar at once.
- keep the existing full render path in selection mode so xray/selection behavior stays intact.
- route active-segment scrolling through the virtualizer so timeline navigation still follows the selected message.

## Benefit
- prompt field was very laggy in cession with big history and timeline had many bugs, this is fixed.
- the session with big history now load as fast as a new session .