### PR TITLE
feat(plugin): add session title rename tool

### DIFF
--- a/packages/opencode-config/plugin/codenomad.ts
+++ b/packages/opencode-config/plugin/codenomad.ts
@@ -1,6 +1,7 @@
 import type { PluginInput } from "@opencode-ai/plugin"
 import { createCodeNomadClient, getCodeNomadConfig } from "./lib/client"
 import { createBackgroundProcessTools } from "./lib/background-process"
+import { createSessionTools } from "./lib/session"
 
 let voiceModeEnabled = false
 
@@ -8,6 +9,7 @@ export async function CodeNomadPlugin(input: PluginInput) {
   const config = getCodeNomadConfig()
   const client = createCodeNomadClient(config)
   const backgroundProcessTools = createBackgroundProcessTools(config, { baseDir: input.directory })
+  const sessionTools = createSessionTools(config)
 
   await client.startEvents((event) => {
     if (event.type === "codenomad.ping") {
@@ -29,6 +31,7 @@ export async function CodeNomadPlugin(input: PluginInput) {
   return {
     tool: {
       ...backgroundProcessTools,
+      ...sessionTools,
     },
     async "chat.message"(_input: { sessionID: string }, output: { message: { system?: string } }) {
       if (!voiceModeEnabled) {

--- a/packages/opencode-config/plugin/lib/session.ts
+++ b/packages/opencode-config/plugin/lib/session.ts
@@ -1,0 +1,49 @@
+import { tool } from "@opencode-ai/plugin/tool"
+import { createCodeNomadRequester, type CodeNomadConfig } from "./request"
+
+type SessionRenameResponse = {
+  sessionID: string
+  title: string
+}
+
+export function createSessionTools(config: CodeNomadConfig) {
+  const requester = createCodeNomadRequester(config)
+
+  const request = async <T>(path: string, init?: RequestInit): Promise<T> => {
+    return requester.requestJson<T>(path, init)
+  }
+
+  return {
+    rename_session: tool({
+      description:
+        "Rename the current session when the user asks to change the chat title. Use a short descriptive title that reflects the current task.",
+      args: {
+        title: tool.schema
+          .string()
+          .describe("New session title, kept short and descriptive, for example 'Fix login bug' or 'Add session rename tool'"),
+      },
+      async execute(args, context) {
+        const sessionID = context.sessionID
+        if (!sessionID) {
+          return "Error: No active session is available for renaming."
+        }
+
+        const trimmedTitle = args.title.trim()
+        if (!trimmedTitle) {
+          return "Error: Session title cannot be empty."
+        }
+
+        const result = await request<SessionRenameResponse>("/session/title", {
+          method: "POST",
+          body: JSON.stringify({
+            sessionID,
+            directory: context.directory,
+            title: trimmedTitle,
+          }),
+        })
+
+        return `Renamed session ${result.sessionID} to \"${result.title}\".`
+      },
+    }),
+  }
+}

--- a/packages/server/src/server/routes/plugin.ts
+++ b/packages/server/src/server/routes/plugin.ts
@@ -27,6 +27,12 @@ const VoiceModeStateSchema = z.object({
   connectionId: z.string().trim().min(1),
 })
 
+const SessionTitleUpdateSchema = z.object({
+  sessionID: z.string().trim().min(1),
+  directory: z.string().trim().min(1).optional(),
+  title: z.string().trim().min(1),
+})
+
 export function registerPluginRoutes(app: FastifyInstance, deps: RouteDeps) {
   app.get<{ Params: { id: string } }>("/workspaces/:id/plugin/events", (request, reply) => {
     const workspace = deps.workspaceManager.get(request.params.id)
@@ -89,6 +95,49 @@ export function registerPluginRoutes(app: FastifyInstance, deps: RouteDeps) {
       const parsed = PluginEventSchema.parse(request.body ?? {})
       handlePluginEvent(workspaceId, parsed, { workspaceManager: deps.workspaceManager, eventBus: deps.eventBus, logger: deps.logger })
       reply.code(204).send()
+      return
+    }
+
+    if (normalized === "session/title" && request.method === "POST") {
+      const parsed = SessionTitleUpdateSchema.parse(request.body ?? {})
+      const port = deps.workspaceManager.getInstancePort(workspaceId)
+      if (!port) {
+        reply.code(502).send({ error: "Workspace instance is not ready" })
+        return
+      }
+
+      const params = new URLSearchParams()
+      if (parsed.directory) {
+        params.set("directory", parsed.directory)
+      }
+
+      const targetUrl = `http://127.0.0.1:${port}/session/${encodeURIComponent(parsed.sessionID)}${params.size > 0 ? `?${params.toString()}` : ""}`
+      const headers: Record<string, string> = {
+        "content-type": "application/json",
+      }
+
+      const authorization = deps.workspaceManager.getInstanceAuthorizationHeader(workspaceId)
+      if (authorization) {
+        headers.authorization = authorization
+      }
+
+      const response = await fetch(targetUrl, {
+        method: "PATCH",
+        headers,
+        body: JSON.stringify({ title: parsed.title }),
+      })
+
+      if (!response.ok) {
+        const message = await response.text().catch(() => "")
+        reply.code(response.status).send({ error: message || `Session update failed with ${response.status}` })
+        return
+      }
+
+      const payload = (await response.json().catch(() => null)) as { id?: string; title?: string } | null
+      reply.send({
+        sessionID: payload?.id ?? parsed.sessionID,
+        title: payload?.title ?? parsed.title,
+      })
       return
     }
 


### PR DESCRIPTION
Fixes #306

## Summary

This change adds a dedicated plugin tool for renaming the active session title and wires it through the existing CodeNomad plugin bridge to the correct OpenCode workspace instance.

The goal is to let the assistant perform the same session title rename operation that already exists in the UI, without introducing a separate metadata store or bundling in the still-unsettled description feature.
<img width="537" height="517" alt="image" src="https://github.com/user-attachments/assets/2150f93e-59ef-4375-b9a2-1d494565006a" />

## Why

Users can already rename sessions manually in the UI, but there was no supported end-to-end conversational path for the assistant to do the same thing.

That mismatch meant the assistant could acknowledge a rename request without having a repo-native implementation path to update the actual session title. This PR closes that gap with the smallest correct change and keeps the scope intentionally limited to title renaming only.

## What Changed

1. Added a new `rename_session` plugin tool in `packages/opencode-config/plugin/lib/session.ts`.
2. Registered the session tool set in `packages/opencode-config/plugin/codenomad.ts`.
3. Added a plugin server endpoint in `packages/server/src/server/routes/plugin.ts` that proxies title updates to the workspace OpenCode instance.
4. Forwarded the current tool execution `directory` so the rename follows the existing worktree-aware session targeting behavior.
5. Corrected the proxy implementation to use `PATCH`, matching the real OpenCode SDK `session.update` contract.

## Scope Boundaries

Included:

- Session title rename tool
- Plugin registration
- Server bridge for title updates
- Worktree-aware forwarding via directory context

Not included:

- Description persistence
- Description rendering in the UI
- Session tooltip changes
- Any broader session metadata model changes

## Technical Notes

The OpenCode SDK contract for session updates is not `POST`; it is `PATCH /session/{sessionID}` with a body containing the updatable fields such as `title`.

That detail matters because the first implementation path could appear successful while failing to apply the rename if the bridge used the wrong HTTP method. The final implementation aligns the server proxy with the generated SDK contract so the rename is applied by the actual OpenCode session update endpoint.

## Files Changed

- `packages/opencode-config/plugin/codenomad.ts`
- `packages/opencode-config/plugin/lib/session.ts`
- `packages/server/src/server/routes/plugin.ts`

## Verification

Performed:

1. Verified the generated OpenCode SDK contract for `session.update`.
2. Confirmed the plugin can call the new bridge endpoint.
3. Confirmed the feature works after switching the proxied request from `POST` to `PATCH`.
4. Rebuilt `packages/server` successfully.

Build note:

- The server build passes.
- The build still emits existing UI/Vite warnings unrelated to this change.

## Risks and Follow-up

1. Description handling remains intentionally postponed and should be handled as a separate follow-up once the storage and UX direction is settled.
2. If future session metadata tools are added, they should continue to reuse the same plugin bridge pattern instead of creating parallel storage behavior.