### PR TITLE
fix(ui): stabilize timeline follow scroll from bottom

### DIFF
--- a/packages/ui/src/components/virtual-follow-list.tsx
+++ b/packages/ui/src/components/virtual-follow-list.tsx
@@ -175,6 +175,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
   let suppressAutoScrollOnce = false
   let pendingInitialScroll = true
   let lastObservedScrollOffset = 0
+  let lastObservedPinnedAtBottom = false
 
   const state: VirtualFollowListState = {
     autoScroll,
@@ -241,6 +242,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
 
     const offset = handle.scrollOffset
     const scrolledUp = offset < lastObservedScrollOffset - 1
+    const wasPinnedAtBottom = lastObservedPinnedAtBottom
     const scrollHeight = handle.scrollSize
     const clientHeight = element.clientHeight
     const atBottom = scrollHeight - (offset + clientHeight) <= (props.scrollSentinelMarginPx ?? DEFAULT_SCROLL_SENTINEL_MARGIN_PX)
@@ -256,8 +258,9 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
     // scrollbar). If follow mode stays enabled, the next render notification
     // snaps the list straight back to bottom. A real upward viewport move away
     // from bottom should always break follow unless a hold target is active.
-    if (scrolledUp && autoScroll() && !atBottom && heldItemCount() === null) {
+    if (wasPinnedAtBottom && scrolledUp && autoScroll() && !atBottom && heldItemCount() === null) {
       setAutoScroll(false)
+      lastObservedPinnedAtBottom = false
       return
     }
 
@@ -272,6 +275,8 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
         setAutoScroll(false)
       }
     }
+
+    lastObservedPinnedAtBottom = autoScroll() && atBottom
   }
 
   function scrollToBottom(immediate = true, options?: { suppressAutoAnchor?: boolean }) {
@@ -409,6 +414,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
     itemElements.clear()
     setHeldItemCount(null)
     lastObservedScrollOffset = 0
+    lastObservedPinnedAtBottom = false
   }))
 
   // Handle autoScroll (Follow) on items change

--- a/packages/ui/src/components/virtual-follow-list.tsx
+++ b/packages/ui/src/components/virtual-follow-list.tsx
@@ -175,7 +175,6 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
   let suppressAutoScrollOnce = false
   let pendingInitialScroll = true
   let lastObservedScrollOffset = 0
-  let pendingBottomPinFrame: number | null = null
 
   const state: VirtualFollowListState = {
     autoScroll,
@@ -283,28 +282,6 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
     }
     handle.scrollToIndex(props.items().length - 1, { align: "end", smooth: !immediate })
     setAutoScroll(true)
-
-    if (immediate) {
-      if (pendingBottomPinFrame !== null) {
-        cancelAnimationFrame(pendingBottomPinFrame)
-      }
-      pendingBottomPinFrame = requestAnimationFrame(() => {
-        pendingBottomPinFrame = requestAnimationFrame(() => {
-          pendingBottomPinFrame = null
-          if (!autoScroll() || effectiveSuspendAutoPinToBottom()) return
-          const element = scrollElement()
-          if (!element) return
-          const maxScrollTop = Math.max(0, element.scrollHeight - element.clientHeight)
-          if (Math.abs(element.scrollTop - maxScrollTop) <= 1) {
-            lastObservedScrollOffset = element.scrollTop
-            return
-          }
-          element.scrollTop = maxScrollTop
-          lastObservedScrollOffset = maxScrollTop
-          updateScrollButtons()
-        })
-      })
-    }
   }
 
   function scrollToTop(immediate = true) {
@@ -482,13 +459,6 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
     const handleResize = () => updateAutoPinHold()
     window.addEventListener("resize", handleResize)
     onCleanup(() => window.removeEventListener("resize", handleResize))
-  })
-
-  onCleanup(() => {
-    if (pendingBottomPinFrame !== null) {
-      cancelAnimationFrame(pendingBottomPinFrame)
-      pendingBottomPinFrame = null
-    }
   })
 
   return (

--- a/packages/ui/src/components/virtual-follow-list.tsx
+++ b/packages/ui/src/components/virtual-follow-list.tsx
@@ -174,6 +174,8 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
   let lastResetKey: string | number | undefined
   let suppressAutoScrollOnce = false
   let pendingInitialScroll = true
+  let lastObservedScrollOffset = 0
+  let pendingBottomPinFrame: number | null = null
 
   const state: VirtualFollowListState = {
     autoScroll,
@@ -239,14 +241,26 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
     if (!handle || !element) return
 
     const offset = handle.scrollOffset
+    const scrolledUp = offset < lastObservedScrollOffset - 1
     const scrollHeight = handle.scrollSize
     const clientHeight = element.clientHeight
     const atBottom = scrollHeight - (offset + clientHeight) <= (props.scrollSentinelMarginPx ?? DEFAULT_SCROLL_SENTINEL_MARGIN_PX)
     const atTop = offset <= (props.scrollSentinelMarginPx ?? DEFAULT_SCROLL_SENTINEL_MARGIN_PX)
+    lastObservedScrollOffset = offset
 
     const hasItems = props.items().length > 0
     setShowScrollBottomButton(hasItems && !atBottom)
     setShowScrollTopButton(hasItems && !atTop)
+
+    // Keyboard/PageUp scrolls can move the viewport without ever hitting our
+    // local key intent listeners (for example after dragging the native
+    // scrollbar). If follow mode stays enabled, the next render notification
+    // snaps the list straight back to bottom. A real upward viewport move away
+    // from bottom should always break follow unless a hold target is active.
+    if (scrolledUp && autoScroll() && !atBottom && heldItemCount() === null) {
+      setAutoScroll(false)
+      return
+    }
 
     // Sync autoScroll state based on scroll position if it was a user scroll
     if (hasUserScrollIntent()) {
@@ -269,6 +283,28 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
     }
     handle.scrollToIndex(props.items().length - 1, { align: "end", smooth: !immediate })
     setAutoScroll(true)
+
+    if (immediate) {
+      if (pendingBottomPinFrame !== null) {
+        cancelAnimationFrame(pendingBottomPinFrame)
+      }
+      pendingBottomPinFrame = requestAnimationFrame(() => {
+        pendingBottomPinFrame = requestAnimationFrame(() => {
+          pendingBottomPinFrame = null
+          if (!autoScroll() || effectiveSuspendAutoPinToBottom()) return
+          const element = scrollElement()
+          if (!element) return
+          const maxScrollTop = Math.max(0, element.scrollHeight - element.clientHeight)
+          if (Math.abs(element.scrollTop - maxScrollTop) <= 1) {
+            lastObservedScrollOffset = element.scrollTop
+            return
+          }
+          element.scrollTop = maxScrollTop
+          lastObservedScrollOffset = maxScrollTop
+          updateScrollButtons()
+        })
+      })
+    }
   }
 
   function scrollToTop(immediate = true) {
@@ -395,6 +431,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
   createEffect(on(() => props.resetKey?.(), () => {
     itemElements.clear()
     setHeldItemCount(null)
+    lastObservedScrollOffset = 0
   }))
 
   // Handle autoScroll (Follow) on items change
@@ -445,6 +482,13 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
     const handleResize = () => updateAutoPinHold()
     window.addEventListener("resize", handleResize)
     onCleanup(() => window.removeEventListener("resize", handleResize))
+  })
+
+  onCleanup(() => {
+    if (pendingBottomPinFrame !== null) {
+      cancelAnimationFrame(pendingBottomPinFrame)
+      pendingBottomPinFrame = null
+    }
   })
 
   return (


### PR DESCRIPTION
## Summary
- fix the sticky-bottom state where dragging the scrollbar to the bottom makes `PageUp` jump to the previous timeline block and then snap immediately back down
- keep the change scoped to `virtual-follow-list.tsx`, where follow mode, scroll intent, and bottom pinning are coordinated

## Root Cause
The list only disabled follow mode when it saw an explicit local "user intent" signal. After reaching the bottom through the native scrollbar, `PageUp` could move the viewport without tripping that path, so the next render notification re-enabled the bottom snap immediately.

## Validation
- `npx tsc --noEmit --project packages/ui/tsconfig.json`
- `npm run build --prefix packages/ui`
- manual desktop test: `PageUp` works again from the bottom sticky state