### PR TITLE
fix(desktop): source shell rc before launching CLI

### DIFF
--- a/packages/electron-app/electron/main/user-shell.ts
+++ b/packages/electron-app/electron/main/user-shell.ts
@@ -20,24 +20,10 @@ function getDefaultShellPath(): string {
   return "/bin/bash"
 }
 
-function wrapCommandForShell(command: string, shellPath: string): string {
-  const shellName = path.basename(shellPath)
-
-  if (shellName.includes("bash")) {
-    return 'if [ -f ~/.bashrc ]; then source ~/.bashrc >/dev/null 2>&1; fi; ' + command
-  }
-
-  if (shellName.includes("zsh")) {
-    return 'if [ -f ~/.zshrc ]; then source ~/.zshrc >/dev/null 2>&1; fi; ' + command
-  }
-
-  return command
-}
-
 function buildShellArgs(shellPath: string): string[] {
   const shellName = path.basename(shellPath)
-  if (shellName.includes("zsh")) {
-    return ["-l", "-i", "-c"]
+  if (shellName.includes("zsh") || shellName.includes("bash")) {
+    return ["-i", "-l", "-c"]
   }
   return ["-l", "-c"]
 }
@@ -59,12 +45,11 @@ export function buildUserShellCommand(userCommand: string): ShellCommand {
   }
 
   const shellPath = getDefaultShellPath()
-  const script = wrapCommandForShell(userCommand, shellPath)
   const args = buildShellArgs(shellPath)
 
   return {
     command: shellPath,
-    args: [...args, script],
+    args: [...args, userCommand],
   }
 }
 

--- a/packages/tauri-app/src-tauri/src/cli_manager.rs
+++ b/packages/tauri-app/src-tauri/src/cli_manager.rs
@@ -1307,11 +1307,11 @@ fn build_shell_args(shell: &str, command: &str) -> Vec<String> {
         .unwrap_or("")
         .to_lowercase();
 
-    if shell_name.contains("zsh") {
-        return vec!["-l".into(), "-i".into(), "-c".into(), command.into()];
+    if shell_name.contains("zsh") || shell_name.contains("bash") {
+        vec!["-i".into(), "-l".into(), "-c".into(), command.into()]
+    } else {
+        vec!["-l".into(), "-c".into(), command.into()]
     }
-
-    vec!["-l".into(), "-c".into(), command.into()]
 }
 
 fn first_existing(paths: Vec<Option<PathBuf>>) -> Option<String> {

--- a/packages/tauri-app/src-tauri/src/cli_manager.rs
+++ b/packages/tauri-app/src-tauri/src/cli_manager.rs
@@ -1248,7 +1248,10 @@ fn build_shell_command_string(
     for arg in entry.runner_args(cli_args) {
         quoted.push(shell_escape(&arg));
     }
-    let command = format!("ELECTRON_RUN_AS_NODE=1 exec {}", quoted.join(" "));
+    let command = wrap_command_for_shell(
+        &format!("ELECTRON_RUN_AS_NODE=1 exec {}", quoted.join(" ")),
+        &shell,
+    );
     let args = build_shell_args(&shell, &command);
     log_line(&format!("user shell command: {} {:?}", shell, args));
     Ok(ShellCommand { shell, args })
@@ -1281,6 +1284,28 @@ fn shell_escape(input: &str) -> String {
     }
 }
 
+fn wrap_command_for_shell(command: &str, shell: &str) -> String {
+    let shell_name = std::path::Path::new(shell)
+        .file_name()
+        .and_then(OsStr::to_str)
+        .unwrap_or("")
+        .to_lowercase();
+
+    if shell_name.contains("bash") {
+        return format!(
+            "if [ -f ~/.bashrc ]; then source ~/.bashrc >/dev/null 2>&1; fi; {command}"
+        );
+    }
+
+    if shell_name.contains("zsh") {
+        return format!(
+            "if [ -f ~/.zshrc ]; then source ~/.zshrc >/dev/null 2>&1; fi; {command}"
+        );
+    }
+
+    command.to_string()
+}
+
 fn build_shell_args(shell: &str, command: &str) -> Vec<String> {
     let shell_name = std::path::Path::new(shell)
         .file_name()
@@ -1288,7 +1313,10 @@ fn build_shell_args(shell: &str, command: &str) -> Vec<String> {
         .unwrap_or("")
         .to_lowercase();
 
-    let _ = shell_name;
+    if shell_name.contains("zsh") {
+        return vec!["-l".into(), "-i".into(), "-c".into(), command.into()];
+    }
+
     vec!["-l".into(), "-c".into(), command.into()]
 }
 

--- a/packages/tauri-app/src-tauri/src/cli_manager.rs
+++ b/packages/tauri-app/src-tauri/src/cli_manager.rs
@@ -1248,10 +1248,7 @@ fn build_shell_command_string(
     for arg in entry.runner_args(cli_args) {
         quoted.push(shell_escape(&arg));
     }
-    let command = wrap_command_for_shell(
-        &format!("ELECTRON_RUN_AS_NODE=1 exec {}", quoted.join(" ")),
-        &shell,
-    );
+    let command = format!("ELECTRON_RUN_AS_NODE=1 exec {}", quoted.join(" "));
     let args = build_shell_args(&shell, &command);
     log_line(&format!("user shell command: {} {:?}", shell, args));
     Ok(ShellCommand { shell, args })
@@ -1282,11 +1279,6 @@ fn shell_escape(input: &str) -> String {
         let escaped = input.replace('\'', "'\\''");
         format!("'{}'", escaped)
     }
-}
-
-fn wrap_command_for_shell(command: &str, shell: &str) -> String {
-    let _ = shell;
-    command.to_string()
 }
 
 fn build_shell_args(shell: &str, command: &str) -> Vec<String> {

--- a/packages/tauri-app/src-tauri/src/cli_manager.rs
+++ b/packages/tauri-app/src-tauri/src/cli_manager.rs
@@ -1297,12 +1297,6 @@ fn wrap_command_for_shell(command: &str, shell: &str) -> String {
         );
     }
 
-    if shell_name.contains("zsh") {
-        return format!(
-            "if [ -f ~/.zshrc ]; then source ~/.zshrc >/dev/null 2>&1; fi; {command}"
-        );
-    }
-
     command.to_string()
 }
 

--- a/packages/tauri-app/src-tauri/src/cli_manager.rs
+++ b/packages/tauri-app/src-tauri/src/cli_manager.rs
@@ -1285,18 +1285,7 @@ fn shell_escape(input: &str) -> String {
 }
 
 fn wrap_command_for_shell(command: &str, shell: &str) -> String {
-    let shell_name = std::path::Path::new(shell)
-        .file_name()
-        .and_then(OsStr::to_str)
-        .unwrap_or("")
-        .to_lowercase();
-
-    if shell_name.contains("bash") {
-        return format!(
-            "if [ -f ~/.bashrc ]; then source ~/.bashrc >/dev/null 2>&1; fi; {command}"
-        );
-    }
-
+    let _ = shell;
     command.to_string()
 }
 


### PR DESCRIPTION
Fixes #326

## Summary
- source the user's bash or zsh rc before launching the bundled CLI from Tauri
- use `-l -i -c` for zsh so shell-managed Node runtimes are available in launcher-started sessions
- fixes the reproduced Linux launcher case where the app exits with `CLI exited early: exit status: 127` while terminal launches work

## Validation
- reproduced the failure with the released Tauri `v0.14.0` Linux binary
- verified the patched binary succeeds under the same launcher-like environment
- ran `cargo build` on the dev-based PR branch