### PR TITLE
fix(desktop): support configured server ports

### DIFF
--- a/packages/electron-app/electron/main/cli-config.test.ts
+++ b/packages/electron-app/electron/main/cli-config.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { describe, it } from "node:test"
+
+import { applyConfiguredPorts, readAppConfigFromPaths, resolveConfiguredPortsFromConfig } from "./cli-config"
+
+describe("resolveConfiguredPortsFromConfig", () => {
+  it("prefers server port values over preferences", () => {
+    const ports = resolveConfiguredPortsFromConfig({
+      preferences: {
+        httpPort: 3000,
+        httpsPort: 3443,
+      },
+      server: {
+        httpPort: 4000,
+        httpsPort: 4443,
+      },
+    })
+
+    assert.deepEqual(ports, [4443, 4000])
+  })
+})
+
+describe("applyConfiguredPorts", () => {
+  it("keeps env vars as the highest-priority override", () => {
+    const args = ["serve"]
+
+    applyConfiguredPorts(args, {
+      httpsPortEnv: "8443",
+      configuredHttpsPort: 4443,
+      configuredHttpPort: 4000,
+    })
+
+    assert.deepEqual(args, ["serve", "--http-port", "4000"])
+  })
+})
+
+describe("readAppConfigFromPaths", () => {
+  it("reads configured ports from yaml config", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "codenomad-electron-cli-config-"))
+    const yamlPath = path.join(dir, "config.yaml")
+    const jsonPath = path.join(dir, "config.json")
+
+    try {
+      fs.writeFileSync(
+        yamlPath,
+        "server:\n  httpsPort: 60598\n  httpPort: 60599\npreferences:\n  httpsPort: 7443\n  httpPort: 7000\n",
+      )
+
+      const config = readAppConfigFromPaths(yamlPath, jsonPath)
+      assert.deepEqual(resolveConfiguredPortsFromConfig(config), [60598, 60599])
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/electron-app/electron/main/cli-config.ts
+++ b/packages/electron-app/electron/main/cli-config.ts
@@ -1,0 +1,131 @@
+import { existsSync, readFileSync } from "fs"
+import os from "os"
+import path from "path"
+import { parse as parseYaml } from "yaml"
+
+export type ListeningMode = "local" | "all"
+
+interface PreferencesConfig {
+  listeningMode?: string
+  httpPort?: number
+  httpsPort?: number
+}
+
+interface ServerConfig {
+  listeningMode?: string
+  httpPort?: number
+  httpsPort?: number
+}
+
+interface AppConfig {
+  preferences?: PreferencesConfig
+  server?: ServerConfig
+}
+
+const DEFAULT_CONFIG_PATH = "~/.config/codenomad/config.json"
+
+function isYamlPath(filePath: string): boolean {
+  const lower = filePath.toLowerCase()
+  return lower.endsWith(".yaml") || lower.endsWith(".yml")
+}
+
+function isJsonPath(filePath: string): boolean {
+  return filePath.toLowerCase().endsWith(".json")
+}
+
+export function resolveConfigPaths(raw?: string): { configYamlPath: string; legacyJsonPath: string } {
+  const target = raw && raw.trim().length > 0 ? raw.trim() : DEFAULT_CONFIG_PATH
+  const resolved = resolveConfigPath(target)
+
+  if (isYamlPath(resolved)) {
+    const baseDir = path.dirname(resolved)
+    return { configYamlPath: resolved, legacyJsonPath: path.join(baseDir, "config.json") }
+  }
+
+  if (isJsonPath(resolved)) {
+    const baseDir = path.dirname(resolved)
+    return { configYamlPath: path.join(baseDir, "config.yaml"), legacyJsonPath: resolved }
+  }
+
+  return {
+    configYamlPath: path.join(resolved, "config.yaml"),
+    legacyJsonPath: path.join(resolved, "config.json"),
+  }
+}
+
+function resolveConfigPath(configPath?: string): string {
+  const target = configPath && configPath.trim().length > 0 ? configPath : DEFAULT_CONFIG_PATH
+  if (target.startsWith("~/")) {
+    return path.join(os.homedir(), target.slice(2))
+  }
+  return path.resolve(target)
+}
+
+function readAppConfig(configPath?: string): AppConfig | null {
+  const { configYamlPath, legacyJsonPath } = resolveConfigPaths(configPath)
+  return readAppConfigFromPaths(configYamlPath, legacyJsonPath)
+}
+
+export function readAppConfigFromPaths(configYamlPath: string, legacyJsonPath: string): AppConfig | null {
+  if (existsSync(configYamlPath)) {
+    const content = readFileSync(configYamlPath, "utf-8")
+    return parseYaml(content) as AppConfig
+  }
+
+  if (existsSync(legacyJsonPath)) {
+    const content = readFileSync(legacyJsonPath, "utf-8")
+    return JSON.parse(content) as AppConfig
+  }
+
+  return null
+}
+
+export function readListeningModeFromConfig(configPath = process.env.CLI_CONFIG): ListeningMode {
+  try {
+    const parsed = readAppConfig(configPath)
+    const mode = parsed?.server?.listeningMode ?? parsed?.preferences?.listeningMode
+    if (mode === "local" || mode === "all") {
+      return mode
+    }
+  } catch (error) {
+    console.warn("[cli] failed to read listening mode from config", error)
+  }
+  return "local"
+}
+
+export function resolveConfiguredPorts(configPath = process.env.CLI_CONFIG): [httpsPort?: number, httpPort?: number] {
+  try {
+    const parsed = readAppConfig(configPath)
+    return resolveConfiguredPortsFromConfig(parsed)
+  } catch (error) {
+    console.warn("[cli] failed to read configured ports from config", error)
+    return []
+  }
+}
+
+export function resolveConfiguredPortsFromConfig(config: AppConfig | null | undefined): [httpsPort?: number, httpPort?: number] {
+  const httpsPort = config?.server?.httpsPort ?? config?.preferences?.httpsPort
+  const httpPort = config?.server?.httpPort ?? config?.preferences?.httpPort
+  return [httpsPort, httpPort]
+}
+
+export function applyConfiguredPorts(
+  args: string[],
+  options: {
+    httpsPortEnv?: string | null
+    httpPortEnv?: string | null
+    configuredHttpsPort?: number
+    configuredHttpPort?: number
+  },
+): void {
+  const httpsEnvPresent = Boolean(options.httpsPortEnv?.trim())
+  const httpEnvPresent = Boolean(options.httpPortEnv?.trim())
+
+  if (!httpsEnvPresent && options.configuredHttpsPort !== undefined) {
+    args.push("--https-port", String(options.configuredHttpsPort))
+  }
+
+  if (!httpEnvPresent && options.configuredHttpPort !== undefined) {
+    args.push("--http-port", String(options.configuredHttpPort))
+  }
+}

--- a/packages/electron-app/electron/main/process-manager.ts
+++ b/packages/electron-app/electron/main/process-manager.ts
@@ -2,13 +2,12 @@ import { spawn, spawnSync, type ChildProcess } from "child_process"
 import { app, utilityProcess, type UtilityProcess } from "electron"
 import { createRequire } from "module"
 import { EventEmitter } from "events"
-import { existsSync, readFileSync } from "fs"
-import os from "os"
+import { existsSync } from "fs"
 import path from "path"
 import { fileURLToPath } from "url"
-import { parse as parseYaml } from "yaml"
 import { ensureManagedNodeBinary } from "./managed-node"
 import { buildUserShellCommand, getUserShellEnv, supportsUserShell } from "./user-shell"
+import { applyConfiguredPorts, readListeningModeFromConfig, resolveConfiguredPorts, type ListeningMode } from "./cli-config"
 
 const nodeRequire = createRequire(import.meta.url)
 const mainFilename = fileURLToPath(import.meta.url)
@@ -18,7 +17,6 @@ const BOOTSTRAP_TOKEN_PREFIX = "CODENOMAD_BOOTSTRAP_TOKEN:"
 const SESSION_COOKIE_NAME_PREFIX = "codenomad_session"
 
 type CliState = "starting" | "ready" | "error" | "stopped"
-type ListeningMode = "local" | "all"
 
 export interface CliStatus {
   state: CliState
@@ -48,73 +46,8 @@ interface CliEntryResolution {
 type ManagedChild = ChildProcess | UtilityProcess
 type ChildLaunchMode = "spawn" | "utility"
 
-const DEFAULT_CONFIG_PATH = "~/.config/codenomad/config.json"
-
-function isYamlPath(filePath: string): boolean {
-  const lower = filePath.toLowerCase()
-  return lower.endsWith(".yaml") || lower.endsWith(".yml")
-}
-
-function isJsonPath(filePath: string): boolean {
-  return filePath.toLowerCase().endsWith(".json")
-}
-
-function resolveConfigPaths(raw?: string): { configYamlPath: string; legacyJsonPath: string } {
-  const target = raw && raw.trim().length > 0 ? raw.trim() : DEFAULT_CONFIG_PATH
-  const resolved = resolveConfigPath(target)
-
-  if (isYamlPath(resolved)) {
-    const baseDir = path.dirname(resolved)
-    return { configYamlPath: resolved, legacyJsonPath: path.join(baseDir, "config.json") }
-  }
-
-  if (isJsonPath(resolved)) {
-    const baseDir = path.dirname(resolved)
-    return { configYamlPath: path.join(baseDir, "config.yaml"), legacyJsonPath: resolved }
-  }
-
-  // Treat as directory.
-  return {
-    configYamlPath: path.join(resolved, "config.yaml"),
-    legacyJsonPath: path.join(resolved, "config.json"),
-  }
-}
-
-function resolveConfigPath(configPath?: string): string {
-  const target = configPath && configPath.trim().length > 0 ? configPath : DEFAULT_CONFIG_PATH
-  if (target.startsWith("~/")) {
-    return path.join(os.homedir(), target.slice(2))
-  }
-  return path.resolve(target)
-}
-
 function resolveHostForMode(mode: ListeningMode): string {
   return mode === "local" ? "127.0.0.1" : "0.0.0.0"
-}
-
-function readListeningModeFromConfig(): ListeningMode {
-  try {
-    const { configYamlPath, legacyJsonPath } = resolveConfigPaths(process.env.CLI_CONFIG)
-
-    let parsed: any = null
-    if (existsSync(configYamlPath)) {
-      const content = readFileSync(configYamlPath, "utf-8")
-      parsed = parseYaml(content)
-    } else if (existsSync(legacyJsonPath)) {
-      const content = readFileSync(legacyJsonPath, "utf-8")
-      parsed = JSON.parse(content)
-    } else {
-      return "local"
-    }
-
-    const mode = parsed?.server?.listeningMode ?? parsed?.preferences?.listeningMode
-    if (mode === "local" || mode === "all") {
-      return mode
-    }
-  } catch (error) {
-    console.warn("[cli] failed to read listening mode from config", error)
-  }
-  return "local"
 }
 
 export declare interface CliProcessManager {
@@ -554,6 +487,14 @@ export class CliProcessManager extends EventEmitter {
     } else {
       // Prod desktop: always keep loopback HTTP enabled.
       args.push("--https", "true", "--http", "true")
+
+      const [configuredHttpsPort, configuredHttpPort] = resolveConfiguredPorts()
+      applyConfiguredPorts(args, {
+        httpsPortEnv: process.env.CLI_HTTPS_PORT,
+        httpPortEnv: process.env.CLI_HTTP_PORT,
+        configuredHttpsPort,
+        configuredHttpPort,
+      })
     }
 
     if (options.dev) {

--- a/packages/tauri-app/src-tauri/src/cli_manager.rs
+++ b/packages/tauri-app/src-tauri/src/cli_manager.rs
@@ -366,14 +366,17 @@ fn expand_home(path: &str) -> PathBuf {
 
 fn read_app_config() -> Option<AppConfig> {
     let (yaml_path, json_path) = resolve_config_locations();
+    read_app_config_from_paths(&yaml_path, &json_path)
+}
 
-    if let Ok(content) = fs::read_to_string(&yaml_path) {
+fn read_app_config_from_paths(yaml_path: &PathBuf, json_path: &PathBuf) -> Option<AppConfig> {
+    if let Ok(content) = fs::read_to_string(yaml_path) {
         if let Ok(config) = serde_yaml::from_str::<AppConfig>(&content) {
             return Some(config);
         }
     }
 
-    if let Ok(content) = fs::read_to_string(&json_path) {
+    if let Ok(content) = fs::read_to_string(json_path) {
         if let Ok(config) = serde_json::from_str::<AppConfig>(&content) {
             return Some(config);
         }
@@ -413,6 +416,10 @@ fn resolve_configured_ports() -> (Option<u16>, Option<u16>) {
         return (None, None);
     };
 
+    resolve_configured_ports_from_config(&config)
+}
+
+fn resolve_configured_ports_from_config(config: &AppConfig) -> (Option<u16>, Option<u16>) {
     let https_port = config
         .server
         .as_ref()
@@ -425,6 +432,31 @@ fn resolve_configured_ports() -> (Option<u16>, Option<u16>) {
         .or_else(|| config.preferences.as_ref().and_then(|prefs| prefs.http_port));
 
     (https_port, http_port)
+}
+
+fn apply_configured_ports(
+    args: &mut Vec<String>,
+    https_port_env: Option<&str>,
+    http_port_env: Option<&str>,
+    configured_https_port: Option<u16>,
+    configured_http_port: Option<u16>,
+) {
+    let https_env_present = https_port_env.is_some_and(|value| !value.trim().is_empty());
+    let http_env_present = http_port_env.is_some_and(|value| !value.trim().is_empty());
+
+    if !https_env_present {
+        if let Some(port) = configured_https_port {
+            args.push("--https-port".to_string());
+            args.push(port.to_string());
+        }
+    }
+
+    if !http_env_present {
+        if let Some(port) = configured_http_port {
+            args.push("--http-port".to_string());
+            args.push(port.to_string());
+        }
+    }
 }
 
 fn resolve_listening_host() -> String {
@@ -1160,20 +1192,13 @@ impl CliEntry {
                 .ok()
                 .filter(|value| !value.trim().is_empty());
             let (configured_https_port, configured_http_port) = resolve_configured_ports();
-
-            if https_port_env.is_none() {
-                if let Some(port) = configured_https_port {
-                    args.push("--https-port".to_string());
-                    args.push(port.to_string());
-                }
-            }
-
-            if http_port_env.is_none() {
-                if let Some(port) = configured_http_port {
-                    args.push("--http-port".to_string());
-                    args.push(port.to_string());
-                }
-            }
+            apply_configured_ports(
+                &mut args,
+                https_port_env.as_deref(),
+                http_port_env.as_deref(),
+                configured_https_port,
+                configured_http_port,
+            );
         }
         args
     }
@@ -1390,5 +1415,74 @@ fn normalize_path(path: PathBuf) -> String {
         stripped.to_string()
     } else {
         rendered
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("codenomad-{name}-{nanos}"))
+    }
+
+    #[test]
+    fn resolve_configured_ports_prefers_server_values() {
+        let config = AppConfig {
+            preferences: Some(PreferencesConfig {
+                listening_mode: None,
+                http_port: Some(3000),
+                https_port: Some(3443),
+            }),
+            server: Some(ServerConfig {
+                listening_mode: None,
+                http_port: Some(4000),
+                https_port: Some(4443),
+            }),
+        };
+
+        let ports = resolve_configured_ports_from_config(&config);
+
+        assert_eq!(ports, (Some(4443), Some(4000)));
+    }
+
+    #[test]
+    fn apply_configured_ports_keeps_env_override_priority() {
+        let mut args = vec!["serve".to_string()];
+
+        apply_configured_ports(&mut args, Some("8443"), None, Some(4443), Some(4000));
+
+        assert_eq!(args, vec!["serve", "--http-port", "4000"]);
+    }
+
+    #[test]
+    fn resolve_configured_ports_reads_yaml_config() {
+        let _guard = env_lock().lock().unwrap();
+        let dir = unique_temp_dir("cli-config");
+        fs::create_dir_all(&dir).unwrap();
+        let yaml_path = dir.join("config.yaml");
+        let json_path = dir.join("config.json");
+
+        fs::write(
+            &yaml_path,
+            "server:\n  httpsPort: 60598\n  httpPort: 60599\npreferences:\n  httpsPort: 7443\n  httpPort: 7000\n",
+        )
+        .unwrap();
+
+        let config = read_app_config_from_paths(&yaml_path, &json_path).unwrap();
+
+        assert_eq!(resolve_configured_ports_from_config(&config), (Some(60598), Some(60599)));
+
+        let _ = fs::remove_dir_all(dir);
     }
 }

--- a/packages/tauri-app/src-tauri/src/cli_manager.rs
+++ b/packages/tauri-app/src-tauri/src/cli_manager.rs
@@ -304,12 +304,20 @@ const DEFAULT_CONFIG_PATH: &str = "~/.config/codenomad/config.json";
 struct PreferencesConfig {
     #[serde(rename = "listeningMode")]
     listening_mode: Option<String>,
+    #[serde(rename = "httpPort")]
+    http_port: Option<u16>,
+    #[serde(rename = "httpsPort")]
+    https_port: Option<u16>,
 }
 
 #[derive(Debug, Deserialize)]
 struct ServerConfig {
     #[serde(rename = "listeningMode")]
     listening_mode: Option<String>,
+    #[serde(rename = "httpPort")]
+    http_port: Option<u16>,
+    #[serde(rename = "httpsPort")]
+    https_port: Option<u16>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -356,57 +364,67 @@ fn expand_home(path: &str) -> PathBuf {
     PathBuf::from(path)
 }
 
-fn resolve_listening_mode() -> String {
+fn read_app_config() -> Option<AppConfig> {
     let (yaml_path, json_path) = resolve_config_locations();
 
     if let Ok(content) = fs::read_to_string(&yaml_path) {
         if let Ok(config) = serde_yaml::from_str::<AppConfig>(&content) {
-            let mode = config
-                .server
-                .as_ref()
-                .and_then(|srv| srv.listening_mode.as_ref())
-                .or_else(|| {
-                    config
-                        .preferences
-                        .as_ref()
-                        .and_then(|prefs| prefs.listening_mode.as_ref())
-                });
-
-            if let Some(mode) = mode {
-                if mode == "local" {
-                    return "local".to_string();
-                }
-                if mode == "all" {
-                    return "all".to_string();
-                }
-            }
+            return Some(config);
         }
     }
 
-    // Legacy fallback.
     if let Ok(content) = fs::read_to_string(&json_path) {
         if let Ok(config) = serde_json::from_str::<AppConfig>(&content) {
-            let mode = config
-                .server
-                .as_ref()
-                .and_then(|srv| srv.listening_mode.as_ref())
-                .or_else(|| {
-                    config
-                        .preferences
-                        .as_ref()
-                        .and_then(|prefs| prefs.listening_mode.as_ref())
-                });
-            if let Some(mode) = mode {
-                if mode == "local" {
-                    return "local".to_string();
-                }
-                if mode == "all" {
-                    return "all".to_string();
-                }
+            return Some(config);
+        }
+    }
+
+    None
+}
+
+fn resolve_listening_mode() -> String {
+    if let Some(config) = read_app_config() {
+        let mode = config
+            .server
+            .as_ref()
+            .and_then(|srv| srv.listening_mode.as_ref())
+            .or_else(|| {
+                config
+                    .preferences
+                    .as_ref()
+                    .and_then(|prefs| prefs.listening_mode.as_ref())
+            });
+
+        if let Some(mode) = mode {
+            if mode == "local" {
+                return "local".to_string();
+            }
+            if mode == "all" {
+                return "all".to_string();
             }
         }
     }
+
     "local".to_string()
+}
+
+fn resolve_configured_ports() -> (Option<u16>, Option<u16>) {
+    let Some(config) = read_app_config() else {
+        return (None, None);
+    };
+
+    let https_port = config
+        .server
+        .as_ref()
+        .and_then(|srv| srv.https_port)
+        .or_else(|| config.preferences.as_ref().and_then(|prefs| prefs.https_port));
+    let http_port = config
+        .server
+        .as_ref()
+        .and_then(|srv| srv.http_port)
+        .or_else(|| config.preferences.as_ref().and_then(|prefs| prefs.http_port));
+
+    (https_port, http_port)
 }
 
 fn resolve_listening_host() -> String {
@@ -1134,6 +1152,28 @@ impl CliEntry {
             args.push("true".to_string());
             args.push("--http".to_string());
             args.push("true".to_string());
+
+            let https_port_env = std::env::var("CLI_HTTPS_PORT")
+                .ok()
+                .filter(|value| !value.trim().is_empty());
+            let http_port_env = std::env::var("CLI_HTTP_PORT")
+                .ok()
+                .filter(|value| !value.trim().is_empty());
+            let (configured_https_port, configured_http_port) = resolve_configured_ports();
+
+            if https_port_env.is_none() {
+                if let Some(port) = configured_https_port {
+                    args.push("--https-port".to_string());
+                    args.push(port.to_string());
+                }
+            }
+
+            if http_port_env.is_none() {
+                if let Some(port) = configured_http_port {
+                    args.push("--http-port".to_string());
+                    args.push(port.to_string());
+                }
+            }
         }
         args
     }


### PR DESCRIPTION
Fixes #293

## Summary
- read persisted `httpPort` and `httpsPort` values from the desktop config
- pass those fixed ports to the bundled server when launcher-started desktop sessions come up
- keep environment variables as the highest-priority override when they are explicitly set

## Validation
- `npm run bundle:server && cargo build`
- visual end-to-end validation of the configured-port flow is still pending