### PR TITLE
fix(desktop): align Electron package and runtime app ids

### DIFF
--- a/packages/electron-app/package.json
+++ b/packages/electron-app/package.json
@@ -62,7 +62,7 @@
     "vite-plugin-solid": "^2.10.0"
   },
   "build": {
-    "appId": "ai.opencode.client",
+    "appId": "ai.neuralnomads.codenomad.client",
     "productName": "CodeNomad",
     "directories": {
       "output": "release",


### PR DESCRIPTION
Follow-up from #334

## Summary
- align the Electron package `build.appId` with the runtime identifier already used in `app.setAppUserModelId(...)`
- remove the mismatch between packaged desktop identity and runtime desktop identity
- keep the change narrowly scoped to identifier consistency only

## Validation
- verified the previous mismatch in `packages/electron-app/package.json` vs `packages/electron-app/electron/main/main.ts`
- updated the packaging id to match the runtime id exactly