### PR TITLE
feat(ui): allow free-text path input when selecting workspace folder

### DIFF
--- a/packages/server/src/api-types.ts
+++ b/packages/server/src/api-types.ts
@@ -141,9 +141,13 @@ export interface WorkspaceLogEntry {
 
 export interface FileSystemEntry {
   name: string
-  /** Path relative to the CLI server root ("." represents the root itself). */
+  /**
+   * Path identifier for the entry. Relative to the server root in restricted
+   * single-root listings ("." represents the root itself); absolute in
+   * unrestricted, drives, and multi-root top-level listings.
+   */
   path: string
-  /** Absolute path when available (unrestricted listings). */
+  /** Absolute path when available (unrestricted and multi-root listings). */
   absolutePath?: string
   type: "file" | "directory"
   size?: number
@@ -156,7 +160,13 @@ export type FileSystemPathKind = "relative" | "absolute" | "drives" | "roots"
 
 export interface FileSystemListingMetadata {
   scope: FileSystemScope
-  /** Canonical identifier of the current view ("." for restricted roots, absolute paths otherwise). */
+  /**
+   * Canonical identifier of the current view:
+   * - "." for restricted single-root listings
+   * - WINDOWS_DRIVES_ROOT for the Windows drives pseudo-root
+   * - MULTI_ROOTS_ROOT for the multi-root top-level pseudo-view
+   * - absolute path otherwise
+   */
   currentPath: string
   /** Optional parent path if navigation upward is allowed. */
   parentPath?: string
@@ -166,7 +176,7 @@ export interface FileSystemListingMetadata {
   homePath: string
   /** Human-friendly label for the current path. */
   displayPath: string
-  /** Indicates whether entry paths are relative, absolute, or represent drive roots. */
+  /** Indicates whether entry paths are relative, absolute, or represent drive/root pseudo-views. */
   pathKind: FileSystemPathKind
 }
 
@@ -188,7 +198,7 @@ export interface FileSystemCreateFolderRequest {
 export interface FileSystemCreateFolderResponse {
   /**
    * Path identifier that can be passed back to `/api/filesystem` to browse the new folder.
-   * Relative for restricted listings, absolute for unrestricted.
+   * Absolute for unrestricted, multi-root, and newly-created restricted folders.
    */
   path: string
   /** Absolute folder path on the server host. */

--- a/packages/server/src/api-types.ts
+++ b/packages/server/src/api-types.ts
@@ -152,7 +152,7 @@ export interface FileSystemEntry {
 }
 
 export type FileSystemScope = "restricted" | "unrestricted"
-export type FileSystemPathKind = "relative" | "absolute" | "drives"
+export type FileSystemPathKind = "relative" | "absolute" | "drives" | "roots"
 
 export interface FileSystemListingMetadata {
   scope: FileSystemScope
@@ -196,6 +196,7 @@ export interface FileSystemCreateFolderResponse {
 }
 
 export const WINDOWS_DRIVES_ROOT = "__drives__"
+export const MULTI_ROOTS_ROOT = "__roots__"
 
 export interface WorkspaceFileResponse {
   workspaceId: string

--- a/packages/server/src/filesystem/browser.ts
+++ b/packages/server/src/filesystem/browser.ts
@@ -6,11 +6,20 @@ import {
   FileSystemEntry,
   FileSystemListResponse,
   FileSystemListingMetadata,
+  MULTI_ROOTS_ROOT,
   WINDOWS_DRIVES_ROOT,
 } from "../api-types"
 
 interface FileSystemBrowserOptions {
   rootDir: string
+  /**
+   * Optional list of additional root directories. When set with 2+ entries,
+   * the browser operates in "multi-root" mode: the top-level listing is a
+   * virtual view of these roots, and every absolute path must fall under one
+   * of them. Single-root behaviour is strictly unchanged when this is omitted
+   * or has fewer than 2 entries.
+   */
+  rootDirs?: string[]
   unrestricted?: boolean
 }
 
@@ -24,12 +33,25 @@ const WINDOWS_DRIVE_LETTERS = Array.from({ length: 26 }, (_, i) => String.fromCh
 
 export class FileSystemBrowser {
   private readonly root: string
+  private readonly roots: string[]
+  private readonly multiRoot: boolean
   private readonly unrestricted: boolean
   private readonly homeDir: string
   private readonly isWindows: boolean
 
   constructor(options: FileSystemBrowserOptions) {
     this.root = path.resolve(options.rootDir)
+    const extra = (options.rootDirs ?? []).map((entry) => path.resolve(entry))
+    const combined = [this.root, ...extra]
+    // Deduplicate (case-insensitive on Windows) while preserving order.
+    const seen = new Set<string>()
+    this.roots = combined.filter((entry) => {
+      const key = process.platform === "win32" ? entry.toLowerCase() : entry
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+    this.multiRoot = this.roots.length > 1
     this.unrestricted = Boolean(options.unrestricted)
     this.homeDir = os.homedir()
     this.isWindows = process.platform === "win32"
@@ -54,6 +76,9 @@ export class FileSystemBrowser {
     if (this.unrestricted) {
       return this.listUnrestricted(targetPath, includeFiles)
     }
+    if (this.multiRoot) {
+      return this.listMultiRoot(targetPath, includeFiles)
+    }
     return this.listRestrictedWithMetadata(targetPath, includeFiles)
   }
 
@@ -67,6 +92,19 @@ export class FileSystemBrowser {
       }
       this.assertDirectoryExists(resolvedParent)
       const absolutePath = this.resolveAbsoluteChild(resolvedParent, name)
+      fs.mkdirSync(absolutePath)
+      return { path: absolutePath, absolutePath }
+    }
+
+    if (this.multiRoot) {
+      const resolvedParent = this.resolveMultiRootPath(parentPath)
+      if (resolvedParent === MULTI_ROOTS_ROOT) {
+        throw new Error("Cannot create folders at the workspace roots view")
+      }
+      this.assertWithinAnyRoot(resolvedParent)
+      this.assertDirectoryExists(resolvedParent)
+      const absolutePath = this.resolveAbsoluteChild(resolvedParent, name)
+      this.assertWithinAnyRoot(absolutePath)
       fs.mkdirSync(absolutePath)
       return { path: absolutePath, absolutePath }
     }
@@ -145,6 +183,106 @@ export class FileSystemBrowser {
     }
 
     return { entries, metadata }
+  }
+
+  private listMultiRoot(targetPath: string | undefined, includeFiles: boolean): FileSystemListResponse {
+    const resolvedPath = this.resolveMultiRootPath(targetPath)
+
+    if (resolvedPath === MULTI_ROOTS_ROOT) {
+      return this.listRootsView()
+    }
+
+    this.assertWithinAnyRoot(resolvedPath)
+
+    const entries = this.readDirectoryEntries(resolvedPath, {
+      includeFiles,
+      formatPath: (entryName) => this.resolveAbsoluteChild(resolvedPath, entryName),
+      formatAbsolutePath: (entryName) => this.resolveAbsoluteChild(resolvedPath, entryName),
+    })
+
+    const parentPath = this.getMultiRootParent(resolvedPath)
+
+    const metadata: FileSystemListingMetadata = {
+      scope: "restricted",
+      currentPath: resolvedPath,
+      parentPath,
+      rootPath: this.root,
+      homePath: this.homeDir,
+      displayPath: resolvedPath,
+      pathKind: "absolute",
+    }
+
+    return { entries, metadata }
+  }
+
+  private listRootsView(): FileSystemListResponse {
+    const entries: FileSystemEntry[] = this.roots.map((rootPath) => ({
+      name: path.basename(rootPath) || rootPath,
+      path: rootPath,
+      absolutePath: rootPath,
+      type: "directory",
+    }))
+
+    const metadata: FileSystemListingMetadata = {
+      scope: "restricted",
+      currentPath: MULTI_ROOTS_ROOT,
+      parentPath: undefined,
+      rootPath: this.root,
+      homePath: this.homeDir,
+      displayPath: "Workspace roots",
+      pathKind: "roots",
+    }
+
+    return { entries, metadata }
+  }
+
+  private resolveMultiRootPath(input: string | undefined): string {
+    if (!input || input === "." || input === "./" || input === MULTI_ROOTS_ROOT) {
+      return MULTI_ROOTS_ROOT
+    }
+    if (this.isWindows) {
+      const normalized = path.win32.normalize(input)
+      if (/^[a-zA-Z]:/.test(normalized) || normalized.startsWith("\\\\")) {
+        return normalized
+      }
+      // Relative input: interpret against the primary root.
+      return path.win32.resolve(this.root, normalized)
+    }
+    if (input.startsWith("/")) {
+      return path.posix.normalize(input)
+    }
+    return path.posix.resolve(this.root, input)
+  }
+
+  private isPathWithinRoot(absolutePath: string, rootPath: string): boolean {
+    if (absolutePath === rootPath) return true
+    const rel = path.relative(rootPath, absolutePath)
+    if (!rel || rel === "") return true
+    if (rel.startsWith("..")) return false
+    if (path.isAbsolute(rel)) return false
+    return true
+  }
+
+  private findContainingRoot(absolutePath: string): string | undefined {
+    return this.roots.find((rootPath) => this.isPathWithinRoot(absolutePath, rootPath))
+  }
+
+  private assertWithinAnyRoot(absolutePath: string) {
+    if (!this.findContainingRoot(absolutePath)) {
+      throw new Error("Access outside of configured workspace roots is not allowed")
+    }
+  }
+
+  private getMultiRootParent(currentPath: string): string | undefined {
+    // If we are exactly at one of the configured roots, parent is the virtual roots view.
+    if (this.roots.some((rootPath) => rootPath === currentPath)) {
+      return MULTI_ROOTS_ROOT
+    }
+    const parent = this.isWindows ? path.win32.dirname(currentPath) : path.posix.dirname(currentPath)
+    if (parent === currentPath) {
+      return MULTI_ROOTS_ROOT
+    }
+    return parent
   }
 
   private listWindowsDrives(): FileSystemListResponse {

--- a/packages/server/src/filesystem/browser.ts
+++ b/packages/server/src/filesystem/browser.ts
@@ -216,12 +216,24 @@ export class FileSystemBrowser {
   }
 
   private listRootsView(): FileSystemListResponse {
-    const entries: FileSystemEntry[] = this.roots.map((rootPath) => ({
-      name: path.basename(rootPath) || rootPath,
-      path: rootPath,
-      absolutePath: rootPath,
-      type: "directory",
-    }))
+    // Disambiguate labels only when two or more configured roots share the same basename.
+    // Single-basename cases keep the short label; colliding ones fall back to the full path.
+    const basenameCounts = new Map<string, number>()
+    for (const rootPath of this.roots) {
+      const base = path.basename(rootPath) || rootPath
+      basenameCounts.set(base, (basenameCounts.get(base) ?? 0) + 1)
+    }
+
+    const entries: FileSystemEntry[] = this.roots.map((rootPath) => {
+      const base = path.basename(rootPath) || rootPath
+      const collides = (basenameCounts.get(base) ?? 0) > 1
+      return {
+        name: collides ? rootPath : base,
+        path: rootPath,
+        absolutePath: rootPath,
+        type: "directory",
+      }
+    })
 
     const metadata: FileSystemListingMetadata = {
       scope: "restricted",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -176,6 +176,14 @@ function parseCliOptions(argv: string[]): CliOptions {
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0)
 
+  for (const entry of resolvedRootDirs) {
+    if (!path.isAbsolute(entry)) {
+      throw new InvalidArgumentError(
+        `--workspace-roots entries must be absolute paths; received "${entry}"`,
+      )
+    }
+  }
+
   const normalizedHost = resolveHost(parsed.host)
 
   const autoUpdateString = (parsed.uiAutoUpdate ?? "true").trim().toLowerCase()

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -49,6 +49,7 @@ interface CliOptions {
   tlsCaPath?: string
   tlsSANs?: string
   rootDir: string
+  rootDirs: string[]
   configPath: string
   unrestrictedRoot: boolean
   logLevel?: string
@@ -87,6 +88,12 @@ function parseCliOptions(argv: string[]): CliOptions {
     .addOption(new Option("--tlsSANs <list>", "Additional TLS SANs (comma-separated)").env("CLI_TLS_SANS"))
     .addOption(
       new Option("--workspace-root <path>", "Restricts root path where workspaces can be opened").env("CLI_WORKSPACE_ROOT").default(process.cwd()),
+    )
+    .addOption(
+      new Option(
+        "--workspace-roots <paths>",
+        "Additional workspace roots (comma-separated absolute paths). When 2+ roots are configured in total, the picker lists them as top-level entries.",
+      ).env("CLI_WORKSPACE_ROOTS"),
     )
     .addOption(new Option("--root <path>").env("CLI_ROOT").hideHelp(true))
     .addOption(new Option("--unrestricted-root", "Allow browsing the full filesystem").env("CLI_UNRESTRICTED_ROOT").default(false))
@@ -138,6 +145,7 @@ function parseCliOptions(argv: string[]): CliOptions {
     tlsCa?: string
     tlsSANs?: string
     workspaceRoot?: string
+    workspaceRoots?: string
     root?: string
     unrestrictedRoot?: boolean
     config: string
@@ -163,6 +171,11 @@ function parseCliOptions(argv: string[]): CliOptions {
 
   const resolvedRoot = parsed.workspaceRoot ?? parsed.root ?? process.cwd()
 
+  const resolvedRootDirs = (parsed.workspaceRoots ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+
   const normalizedHost = resolveHost(parsed.host)
 
   const autoUpdateString = (parsed.uiAutoUpdate ?? "true").trim().toLowerCase()
@@ -186,6 +199,7 @@ function parseCliOptions(argv: string[]): CliOptions {
     tlsCaPath: parsed.tlsCa,
     tlsSANs: parsed.tlsSANs,
     rootDir: resolvedRoot,
+    rootDirs: resolvedRootDirs,
     configPath: parsed.config,
     unrestrictedRoot: Boolean(parsed.unrestrictedRoot),
     logLevel: parsed.logLevel,
@@ -318,7 +332,11 @@ async function main() {
     getServerBaseUrl: () => serverMeta.localUrl,
     nodeExtraCaCertsPath,
   })
-  const fileSystemBrowser = new FileSystemBrowser({ rootDir: options.rootDir, unrestricted: options.unrestrictedRoot })
+  const fileSystemBrowser = new FileSystemBrowser({
+    rootDir: options.rootDir,
+    rootDirs: options.rootDirs,
+    unrestricted: options.unrestrictedRoot,
+  })
   const instanceStore = new InstanceStore(configLocation.instancesDir)
   const speechService = new SpeechService(settings, logger.child({ component: "speech" }))
   const sidecarManager = new SideCarManager({

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -92,7 +92,7 @@ function parseCliOptions(argv: string[]): CliOptions {
     .addOption(
       new Option(
         "--workspace-roots <paths>",
-        "Additional workspace roots (comma-separated absolute paths). When 2+ roots are configured in total, the picker lists them as top-level entries.",
+        "Extra workspace roots added alongside --workspace-root (comma-separated absolute paths). The picker lists all roots when 2+ are configured in total.",
       ).env("CLI_WORKSPACE_ROOTS"),
     )
     .addOption(new Option("--root <path>").env("CLI_ROOT").hideHelp(true))

--- a/packages/ui/src/components/directory-browser-dialog.tsx
+++ b/packages/ui/src/components/directory-browser-dialog.tsx
@@ -38,6 +38,7 @@ interface DirectoryBrowserDialogProps {
   open: boolean
   title: string
   description?: string
+  initialPath?: string
   onSelect: (absolutePath: string) => void
   onClose: () => void
 }
@@ -125,7 +126,8 @@ const DirectoryBrowserDialog: Component<DirectoryBrowserDialogProps> = (props) =
   async function initialize() {
     setLoading(true)
     try {
-      await navigateTo()
+      const startPath = props.initialPath?.trim()
+      await navigateTo(startPath || undefined)
     } finally {
       setLoading(false)
     }

--- a/packages/ui/src/components/directory-browser-dialog.tsx
+++ b/packages/ui/src/components/directory-browser-dialog.tsx
@@ -403,6 +403,8 @@ const DirectoryBrowserDialog: Component<DirectoryBrowserDialogProps> = (props) =
                         }
                       }}
                       spellcheck={false}
+                      placeholder={t("directoryBrowser.currentFolder.inputPlaceholder")}
+                      aria-label={t("directoryBrowser.currentFolder.inputAriaLabel")}
                       class="selector-input directory-browser-current-path"
                     />
                   </div>

--- a/packages/ui/src/components/directory-browser-dialog.tsx
+++ b/packages/ui/src/components/directory-browser-dialog.tsx
@@ -60,7 +60,7 @@ function resolveAbsolutePath(root: string, relativePath: string) {
 }
 
 function getAbsolutePathFromMetadata(metadata: FileSystemListingMetadata | null) {
-  if (!metadata || metadata.pathKind === "drives") {
+  if (!metadata || metadata.pathKind === "drives" || metadata.pathKind === "roots") {
     return ""
   }
   if (metadata.pathKind === "relative") {
@@ -314,7 +314,7 @@ const DirectoryBrowserDialog: Component<DirectoryBrowserDialogProps> = (props) =
     if (creatingFolder()) return
     const target = pathInput().trim()
     const metadata = target && target !== currentAbsolutePath() ? await navigateTo(target) : currentMetadata()
-    if (!metadata || metadata.pathKind === "drives") {
+    if (!metadata || metadata.pathKind === "drives" || metadata.pathKind === "roots") {
       return
     }
     setPathInputDirty(false)

--- a/packages/ui/src/components/directory-browser-dialog.tsx
+++ b/packages/ui/src/components/directory-browser-dialog.tsx
@@ -127,7 +127,16 @@ const DirectoryBrowserDialog: Component<DirectoryBrowserDialogProps> = (props) =
     setLoading(true)
     try {
       const startPath = props.initialPath?.trim()
-      await navigateTo(startPath || undefined)
+      if (startPath) {
+        const metadata = await navigateTo(startPath)
+        if (metadata) {
+          return
+        }
+        // initialPath was rejected (e.g. no longer under an allowed root);
+        // silently fall back to the default root so the dialog stays usable.
+        setError(null)
+      }
+      await navigateTo(undefined)
     } finally {
       setLoading(false)
     }

--- a/packages/ui/src/components/filesystem-browser-dialog.tsx
+++ b/packages/ui/src/components/filesystem-browser-dialog.tsx
@@ -9,23 +9,31 @@ const log = getLogger("actions")
 
 const MAX_RESULTS = 200
 
+function isAbsolutePathLike(input: string): boolean {
+  return input.startsWith("/") || /^[a-zA-Z]:/.test(input) || input.startsWith("\\\\")
+}
+
 function normalizeEntryPath(path: string | undefined): string {
   if (!path || path === "." || path === "./") {
     return "."
+  }
+  // Preserve absolute paths as-is (POSIX "/...", Windows "C:\..." or UNC "\\...").
+  // The server accepts absolute paths for unrestricted and multi-root listings,
+  // and stripping the leading "/" would make it resolve as relative to the root.
+  if (isAbsolutePathLike(path)) {
+    // Only collapse duplicate slashes in POSIX absolute paths; leave Windows
+    // and UNC separators untouched so the server can round-trip them.
+    if (path.startsWith("/")) {
+      return path.replace(/\/+/g, "/")
+    }
+    return path
   }
   let cleaned = path.replace(/\\/g, "/")
   if (cleaned.startsWith("./")) {
     cleaned = cleaned.replace(/^\.\/+/, "")
   }
-  if (cleaned.startsWith("/")) {
-    cleaned = cleaned.replace(/^\/+/, "")
-  }
   cleaned = cleaned.replace(/\/+/g, "/")
   return cleaned === "" ? "." : cleaned
-}
-
-function isAbsolutePathLike(input: string): boolean {
-  return input.startsWith("/") || /^[a-zA-Z]:/.test(input) || input.startsWith("\\\\")
 }
 
 function resolveAbsolutePath(root: string, relativePath: string): string {

--- a/packages/ui/src/components/filesystem-browser-dialog.tsx
+++ b/packages/ui/src/components/filesystem-browser-dialog.tsx
@@ -24,17 +24,30 @@ function normalizeEntryPath(path: string | undefined): string {
   return cleaned === "" ? "." : cleaned
 }
 
+function isAbsolutePathLike(input: string): boolean {
+  return input.startsWith("/") || /^[a-zA-Z]:/.test(input) || input.startsWith("\\\\")
+}
+
 function resolveAbsolutePath(root: string, relativePath: string): string {
-  if (!root) {
-    return relativePath
-  }
   if (!relativePath || relativePath === "." || relativePath === "./") {
     return root
+  }
+  if (isAbsolutePathLike(relativePath)) {
+    return relativePath
+  }
+  if (!root) {
+    return relativePath
   }
   const separator = root.includes("\\") ? "\\" : "/"
   const trimmedRoot = root.endsWith(separator) ? root : `${root}${separator}`
   const normalized = relativePath.replace(/[\\/]+/g, separator).replace(/^[\\/]+/, "")
   return `${trimmedRoot}${normalized}`
+}
+
+function entryAbsolutePath(root: string, entry: FileSystemEntry): string {
+  if (entry.absolutePath) return entry.absolutePath
+  if (isAbsolutePathLike(entry.path)) return entry.path
+  return resolveAbsolutePath(root, entry.path)
 }
 
 
@@ -158,6 +171,9 @@ const FileSystemBrowserDialog: Component<FileSystemBrowserDialogProps> = (props)
     if (!metadata) {
       return rootPath()
     }
+    if (metadata.pathKind === "drives" || metadata.pathKind === "roots") {
+      return ""
+    }
     if (metadata.pathKind === "relative") {
       return resolveAbsolutePath(rootPath(), metadata.currentPath)
     }
@@ -171,8 +187,7 @@ const FileSystemBrowserDialog: Component<FileSystemBrowserDialogProps> = (props)
   }
 
   function handleEntrySelect(entry: FileSystemEntry) {
-    const absolute = resolveAbsolutePath(rootPath(), entry.path)
-    props.onSelect(absolute)
+    props.onSelect(entryAbsolutePath(rootPath(), entry))
   }
 
   function handleNavigateTo(path: string) {
@@ -197,7 +212,7 @@ const FileSystemBrowserDialog: Component<FileSystemBrowserDialogProps> = (props)
       return subset
     }
     return subset.filter((entry) => {
-      const absolute = resolveAbsolutePath(rootPath(), entry.path)
+      const absolute = entryAbsolutePath(rootPath(), entry)
       return absolute.toLowerCase().includes(query) || entry.name.toLowerCase().includes(query)
     })
   })
@@ -325,7 +340,11 @@ const FileSystemBrowserDialog: Component<FileSystemBrowserDialogProps> = (props)
                   <button
                     type="button"
                     class="selector-button selector-button-secondary whitespace-nowrap"
-                    onClick={() => props.onSelect(currentAbsolutePath())}
+                    disabled={!currentAbsolutePath()}
+                    onClick={() => {
+                      const abs = currentAbsolutePath()
+                      if (abs) props.onSelect(abs)
+                    }}
                   >
                     {t("filesystemBrowser.currentFolder.selectCurrent")}
                   </button>
@@ -408,7 +427,7 @@ const FileSystemBrowserDialog: Component<FileSystemBrowserDialogProps> = (props)
                               <div class="directory-browser-row-text">
                                 <span class="directory-browser-row-name">{entry.name || entry.path}</span>
                                 <span class="directory-browser-row-sub">
-                                  {resolveAbsolutePath(rootPath(), entry.path)}
+                                  {entryAbsolutePath(rootPath(), entry)}
                                 </span>
                               </div>
                             </button>

--- a/packages/ui/src/components/folder-selection-view.tsx
+++ b/packages/ui/src/components/folder-selection-view.tsx
@@ -976,6 +976,7 @@ const FolderSelectionView: Component<FolderSelectionViewProps> = (props) => {
         open={isFolderBrowserOpen()}
         title={t("folderSelection.dialog.title")}
         description={t("folderSelection.dialog.description")}
+        initialPath={folders()[0]?.path}
         onClose={() => setIsFolderBrowserOpen(false)}
         onSelect={handleBrowserSelect}
       />

--- a/packages/ui/src/components/folder-selection-view.tsx
+++ b/packages/ui/src/components/folder-selection-view.tsx
@@ -400,6 +400,12 @@ const FolderSelectionView: Component<FolderSelectionViewProps> = (props) => {
     setIsFolderBrowserOpen(false)
     handleFolderSelect(path)
   }
+
+  function handleEnterPathManually() {
+    if (isLoading()) return
+    setFocusMode("new")
+    setIsFolderBrowserOpen(true)
+  }
  
   function handleRemove(path: string, e?: Event) {
     if (isLoading()) return
@@ -869,6 +875,15 @@ const FolderSelectionView: Component<FolderSelectionViewProps> = (props) => {
                       </span>
                     </div>
                     <Kbd shortcut="cmd+n" class="ml-2 kbd-hint" />
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={() => handleEnterPathManually()}
+                    disabled={props.isLoading}
+                    class="text-xs text-muted-foreground hover:text-foreground underline underline-offset-2 self-center disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {t("folderSelection.browse.enterPath")}
                   </button>
 
                   <button

--- a/packages/ui/src/lib/i18n/messages/en/filesystem.ts
+++ b/packages/ui/src/lib/i18n/messages/en/filesystem.ts
@@ -2,6 +2,8 @@ export const filesystemMessages = {
   "directoryBrowser.defaultDescription": "Browse folders under the configured workspace root.",
   "directoryBrowser.close": "Close",
   "directoryBrowser.currentFolder": "Current folder",
+  "directoryBrowser.currentFolder.inputAriaLabel": "Folder path",
+  "directoryBrowser.currentFolder.inputPlaceholder": "Type or paste an absolute path and press Enter",
   "directoryBrowser.selectCurrent": "Select Current",
   "directoryBrowser.newFolder": "New Folder",
   "directoryBrowser.creating": "Creating…",

--- a/packages/ui/src/lib/i18n/messages/en/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/en/folderSelection.ts
@@ -20,6 +20,7 @@ export const folderSelectionMessages = {
   "folderSelection.browse.subtitle": "Select any folder on your computer",
   "folderSelection.browse.button": "Browse Folders",
   "folderSelection.browse.buttonOpening": "Opening...",
+  "folderSelection.browse.enterPath": "Enter path manually",
   "folderSelection.actions.title": "Open Folder or Connect Server",
   "folderSelection.actions.subtitle": "Open local folder or connect to a CodeNomad server",
   "folderSelection.actions.connectButton": "Connect CodeNomad Server",

--- a/packages/ui/src/lib/i18n/messages/es/filesystem.ts
+++ b/packages/ui/src/lib/i18n/messages/es/filesystem.ts
@@ -2,6 +2,8 @@ export const filesystemMessages = {
   "directoryBrowser.defaultDescription": "Explora carpetas bajo la raíz del workspace configurado.",
   "directoryBrowser.close": "Cerrar",
   "directoryBrowser.currentFolder": "Carpeta actual",
+  "directoryBrowser.currentFolder.inputAriaLabel": "Ruta de la carpeta",
+  "directoryBrowser.currentFolder.inputPlaceholder": "Escribe o pega una ruta absoluta y presiona Enter",
   "directoryBrowser.selectCurrent": "Seleccionar actual",
   "directoryBrowser.newFolder": "Nueva carpeta",
   "directoryBrowser.creating": "Creando…",

--- a/packages/ui/src/lib/i18n/messages/es/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/es/folderSelection.ts
@@ -20,6 +20,7 @@ export const folderSelectionMessages = {
   "folderSelection.browse.subtitle": "Selecciona cualquier carpeta en tu ordenador",
   "folderSelection.browse.button": "Buscar carpetas",
   "folderSelection.browse.buttonOpening": "Abriendo...",
+  "folderSelection.browse.enterPath": "Introducir ruta manualmente",
   "folderSelection.actions.title": "Abrir carpeta o conectar servidor",
   "folderSelection.actions.subtitle": "Abre una carpeta local o conéctate a un servidor de CodeNomad",
   "folderSelection.actions.connectButton": "Conectar servidor CodeNomad",

--- a/packages/ui/src/lib/i18n/messages/fr/filesystem.ts
+++ b/packages/ui/src/lib/i18n/messages/fr/filesystem.ts
@@ -2,6 +2,8 @@ export const filesystemMessages = {
   "directoryBrowser.defaultDescription": "Parcourez les dossiers sous la racine d'espace de travail configurée.",
   "directoryBrowser.close": "Fermer",
   "directoryBrowser.currentFolder": "Dossier actuel",
+  "directoryBrowser.currentFolder.inputAriaLabel": "Chemin du dossier",
+  "directoryBrowser.currentFolder.inputPlaceholder": "Saisissez ou collez un chemin absolu, puis appuyez sur Entrée",
   "directoryBrowser.selectCurrent": "Sélectionner le dossier actuel",
   "directoryBrowser.newFolder": "Nouveau dossier",
   "directoryBrowser.creating": "Création…",

--- a/packages/ui/src/lib/i18n/messages/fr/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/fr/folderSelection.ts
@@ -20,6 +20,7 @@ export const folderSelectionMessages = {
   "folderSelection.browse.subtitle": "Sélectionnez n'importe quel dossier sur votre ordinateur",
   "folderSelection.browse.button": "Parcourir les dossiers",
   "folderSelection.browse.buttonOpening": "Ouverture...",
+  "folderSelection.browse.enterPath": "Saisir un chemin manuellement",
   "folderSelection.actions.title": "Ouvrir un dossier ou se connecter à un serveur",
   "folderSelection.actions.subtitle": "Ouvrez un dossier local ou connectez-vous à un serveur CodeNomad",
   "folderSelection.actions.connectButton": "Se connecter au serveur CodeNomad",

--- a/packages/ui/src/lib/i18n/messages/he/filesystem.ts
+++ b/packages/ui/src/lib/i18n/messages/he/filesystem.ts
@@ -2,6 +2,8 @@ export const filesystemMessages = {
   "directoryBrowser.defaultDescription": "עיון בתיקיות תחת שורש סביבת העבודה המוגדר.",
   "directoryBrowser.close": "סגור",
   "directoryBrowser.currentFolder": "תיקייה נוכחית",
+  "directoryBrowser.currentFolder.inputAriaLabel": "נתיב התיקייה",
+  "directoryBrowser.currentFolder.inputPlaceholder": "הקלד או הדבק נתיב מוחלט והקש Enter",
   "directoryBrowser.selectCurrent": "בחר נוכחית",
   "directoryBrowser.newFolder": "תיקייה חדשה",
   "directoryBrowser.creating": "יוצר…",

--- a/packages/ui/src/lib/i18n/messages/he/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/he/folderSelection.ts
@@ -20,6 +20,7 @@ export const folderSelectionMessages = {
   "folderSelection.browse.subtitle": "בחר כל תיקייה במחשב שלך",
   "folderSelection.browse.button": "עיון בתיקיות",
   "folderSelection.browse.buttonOpening": "פותח...",
+  "folderSelection.browse.enterPath": "הזן נתיב ידנית",
   "folderSelection.actions.title": "פתח תיקייה או התחבר לשרת",
   "folderSelection.actions.subtitle": "פתח תיקייה מקומית או התחבר לשרת CodeNomad",
   "folderSelection.actions.connectButton": "התחבר לשרת CodeNomad",

--- a/packages/ui/src/lib/i18n/messages/ja/filesystem.ts
+++ b/packages/ui/src/lib/i18n/messages/ja/filesystem.ts
@@ -2,6 +2,8 @@ export const filesystemMessages = {
   "directoryBrowser.defaultDescription": "設定された workspace ルート配下のフォルダを参照します。",
   "directoryBrowser.close": "閉じる",
   "directoryBrowser.currentFolder": "現在のフォルダ",
+  "directoryBrowser.currentFolder.inputAriaLabel": "フォルダのパス",
+  "directoryBrowser.currentFolder.inputPlaceholder": "絶対パスを入力または貼り付けて Enter を押してください",
   "directoryBrowser.selectCurrent": "現在のフォルダを選択",
   "directoryBrowser.newFolder": "新しいフォルダ",
   "directoryBrowser.creating": "作成中…",

--- a/packages/ui/src/lib/i18n/messages/ja/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/ja/folderSelection.ts
@@ -20,6 +20,7 @@ export const folderSelectionMessages = {
   "folderSelection.browse.subtitle": "コンピュータ上の任意のフォルダを選択",
   "folderSelection.browse.button": "フォルダを参照",
   "folderSelection.browse.buttonOpening": "開いています...",
+  "folderSelection.browse.enterPath": "パスを手動で入力",
   "folderSelection.actions.title": "フォルダを開くかサーバーに接続",
   "folderSelection.actions.subtitle": "ローカルフォルダを開くか CodeNomad サーバーに接続します",
   "folderSelection.actions.connectButton": "CodeNomad サーバーに接続",

--- a/packages/ui/src/lib/i18n/messages/ru/filesystem.ts
+++ b/packages/ui/src/lib/i18n/messages/ru/filesystem.ts
@@ -2,6 +2,8 @@ export const filesystemMessages = {
   "directoryBrowser.defaultDescription": "Просматривайте папки в пределах настроенного корня рабочего пространства.",
   "directoryBrowser.close": "Закрыть",
   "directoryBrowser.currentFolder": "Текущая папка",
+  "directoryBrowser.currentFolder.inputAriaLabel": "Путь к папке",
+  "directoryBrowser.currentFolder.inputPlaceholder": "Введите или вставьте абсолютный путь и нажмите Enter",
   "directoryBrowser.selectCurrent": "Выбрать текущую",
   "directoryBrowser.newFolder": "Новая папка",
   "directoryBrowser.creating": "Создание…",

--- a/packages/ui/src/lib/i18n/messages/ru/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/ru/folderSelection.ts
@@ -20,6 +20,7 @@ export const folderSelectionMessages = {
   "folderSelection.browse.subtitle": "Выберите любую папку на компьютере",
   "folderSelection.browse.button": "Обзор папок",
   "folderSelection.browse.buttonOpening": "Открытие…",
+  "folderSelection.browse.enterPath": "Ввести путь вручную",
   "folderSelection.actions.title": "Открыть папку или подключить сервер",
   "folderSelection.actions.subtitle": "Откройте локальную папку или подключитесь к серверу CodeNomad",
   "folderSelection.actions.connectButton": "Подключить сервер CodeNomad",

--- a/packages/ui/src/lib/i18n/messages/zh-Hans/filesystem.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-Hans/filesystem.ts
@@ -2,6 +2,8 @@ export const filesystemMessages = {
   "directoryBrowser.defaultDescription": "浏览已配置的工作区根目录下的文件夹。",
   "directoryBrowser.close": "关闭",
   "directoryBrowser.currentFolder": "当前文件夹",
+  "directoryBrowser.currentFolder.inputAriaLabel": "文件夹路径",
+  "directoryBrowser.currentFolder.inputPlaceholder": "输入或粘贴绝对路径后按回车",
   "directoryBrowser.selectCurrent": "选择当前",
   "directoryBrowser.newFolder": "新建文件夹",
   "directoryBrowser.creating": "正在创建…",

--- a/packages/ui/src/lib/i18n/messages/zh-Hans/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-Hans/folderSelection.ts
@@ -20,6 +20,7 @@ export const folderSelectionMessages = {
   "folderSelection.browse.subtitle": "选择你电脑上的任意文件夹",
   "folderSelection.browse.button": "浏览文件夹",
   "folderSelection.browse.buttonOpening": "正在打开...",
+  "folderSelection.browse.enterPath": "手动输入路径",
   "folderSelection.actions.title": "打开文件夹或连接服务器",
   "folderSelection.actions.subtitle": "打开本地文件夹或连接到 CodeNomad 服务器",
   "folderSelection.actions.connectButton": "连接 CodeNomad 服务器",


### PR DESCRIPTION
## Summary
- Make the existing path input in `DirectoryBrowserDialog` discoverable by adding a translated `placeholder` and `aria-label`.
- Add an *Enter path manually* link next to the Browse button on the folder selection view, so the in-app dialog is reachable on every platform.
- Open the dialog at the most recent folder instead of the server default, so users who work outside their home directory don't have to navigate back every time.
- Add the matching i18n keys across all 7 supported locales.
- Accept an optional comma-separated list in `--workspace-roots` so users with projects in several unrelated folders don't have to run multiple server instances.

## Why
The in-app `DirectoryBrowserDialog` already had a text field for the current path, but it was effectively unreachable and always started at the server's single root.

1. The input now has a placeholder + aria-label and is reachable via an *Enter path manually* link.
2. The dialog starts at the most recent folder.

## What changed

### UI
- `packages/ui/src/components/folder-selection-view.tsx`: added an *Enter path manually* link below the Browse button that opens `DirectoryBrowserDialog`, and passes `initialPath={folders()[0]?.path}` so the dialog opens on the most recent folder.
- `packages/ui/src/components/directory-browser-dialog.tsx`: new optional `initialPath` prop consumed by `initialize()`; the current-folder `<input>` now has `placeholder` and `aria-label` i18n strings.
- `packages/ui/src/lib/i18n/messages/*/filesystem.ts` / `folderSelection.ts`: 3 new keys across all 7 locales.

### Server
- `packages/server/src/filesystem/browser.ts` + `api-types.ts` + `index.ts`: `--workspace-roots` accepts multiple comma-separated paths. When more than one is given, the picker shows them side by side at the top level (same mechanism already used for Windows drives). Omitting the flag keeps the current single-root behaviour unchanged.

## Validation
- `npm run build --workspace @codenomad/ui` — typecheck + Vite build pass, PWA generated.
- `npm run build --workspace @neuralnomads/codenomad` — server build passes.

Closes #349
Closes #312
