### PR TITLE
feat(server): expose opencode server proxy url env

### DIFF
--- a/packages/server/src/workspaces/__tests__/spawn.test.ts
+++ b/packages/server/src/workspaces/__tests__/spawn.test.ts
@@ -56,9 +56,10 @@ describe("buildWindowsSpawnSpec", () => {
         env: {
           OPENCODE_CONFIG_DIR: String.raw`C:\Users\dev\AppData\Roaming\CodeNomad\opencode-config`,
           CODENOMAD_INSTANCE_ID: "workspace-123",
+          OPENCODE_SERVER_BASE_URL: "https://127.0.0.1:4321/workspaces/workspace-123/worktrees/root/instance",
           OPENCODE_SERVER_PASSWORD: "secret",
         },
-        propagateEnvKeys: ["OPENCODE_CONFIG_DIR", "CODENOMAD_INSTANCE_ID", "OPENCODE_SERVER_PASSWORD"],
+        propagateEnvKeys: ["OPENCODE_CONFIG_DIR", "CODENOMAD_INSTANCE_ID", "OPENCODE_SERVER_BASE_URL", "OPENCODE_SERVER_PASSWORD"],
       },
     )
 
@@ -75,7 +76,7 @@ describe("buildWindowsSpawnSpec", () => {
       "0",
     ])
     assert.equal(spec.cwd, undefined)
-    assert.equal(spec.env?.WSLENV, "OPENCODE_CONFIG_DIR/p:CODENOMAD_INSTANCE_ID:OPENCODE_SERVER_PASSWORD")
+    assert.equal(spec.env?.WSLENV, "OPENCODE_CONFIG_DIR/p:CODENOMAD_INSTANCE_ID:OPENCODE_SERVER_BASE_URL:OPENCODE_SERVER_PASSWORD")
   })
 
   it("upgrades existing WSLENV path entries to include /p", () => {

--- a/packages/server/src/workspaces/manager.ts
+++ b/packages/server/src/workspaces/manager.ts
@@ -12,6 +12,7 @@ import { WorkspaceRuntime, ProcessExitInfo } from "./runtime"
 import { Logger } from "../logger"
 import { getOpencodeConfigDir } from "../opencode-config.js"
 import {
+  OPENCODE_SERVER_BASE_URL_ENV,
   buildOpencodeBasicAuthHeader,
   OPENCODE_SERVER_PASSWORD_ENV,
   OPENCODE_SERVER_USERNAME_ENV,
@@ -122,6 +123,8 @@ export class WorkspaceManager {
     const serverConfig = this.options.settings.getOwner("config", "server")
     const envVars = (serverConfig as any)?.environmentVariables
     const userEnvironment = envVars && typeof envVars === "object" && !Array.isArray(envVars) ? (envVars as any) : {}
+    const serverBaseUrl = this.options.getServerBaseUrl()
+    const normalizedServerBaseUrl = serverBaseUrl.replace(/\/+$/, "")
 
     const { username: opencodeUsername, password: opencodePassword } = resolveOpencodeServerAuth({
       userEnvironment,
@@ -137,8 +140,9 @@ export class WorkspaceManager {
       ...userEnvironment,
       OPENCODE_CONFIG_DIR: this.opencodeConfigDir,
       CODENOMAD_INSTANCE_ID: id,
-      CODENOMAD_BASE_URL: this.options.getServerBaseUrl(),
+      CODENOMAD_BASE_URL: serverBaseUrl,
       ...(this.options.nodeExtraCaCertsPath ? { NODE_EXTRA_CA_CERTS: this.options.nodeExtraCaCertsPath } : {}),
+      [OPENCODE_SERVER_BASE_URL_ENV]: `${normalizedServerBaseUrl}${proxyPath}`,
       [OPENCODE_SERVER_USERNAME_ENV]: opencodeUsername,
       [OPENCODE_SERVER_PASSWORD_ENV]: opencodePassword,
     }

--- a/packages/server/src/workspaces/opencode-auth.ts
+++ b/packages/server/src/workspaces/opencode-auth.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto"
 
 export const OPENCODE_SERVER_USERNAME_ENV = "OPENCODE_SERVER_USERNAME" as const
 export const OPENCODE_SERVER_PASSWORD_ENV = "OPENCODE_SERVER_PASSWORD" as const
+export const OPENCODE_SERVER_BASE_URL_ENV = "OPENCODE_SERVER_BASE_URL" as const
 
 export const DEFAULT_OPENCODE_USERNAME = "codenomad" as const
 


### PR DESCRIPTION
Fixes #321

## Summary
- expose OPENCODE_SERVER_BASE_URL in the spawned OpenCode workspace environment
- point it at the current workspace's stable CodeNomad proxy URL
- propagate the new variable through WSL launches alongside the existing auth env vars

## Why
Tools and plugins already receive the auth credentials needed to call the current workspace instance, but they still need an extra lookup to discover the correct URL.

The proxy URL is already known before runtime startup, so exposing it directly removes that lookup without changing OpenCode's port selection flow.

## What Changed
- packages/server/src/workspaces/opencode-auth.ts: added the OPENCODE_SERVER_BASE_URL env var constant
- packages/server/src/workspaces/manager.ts: injects OPENCODE_SERVER_BASE_URL into the workspace runtime environment using CODENOMAD_BASE_URL + proxyPath
- packages/server/src/workspaces/__tests__/spawn.test.ts: updates WSL env propagation coverage for the new variable

## Validation
- npx tsx --test "packages/server/src/workspaces/__tests__/spawn.test.ts"