### PR TITLE
fix(ui): restore agent switch affordance

### DIFF
--- a/packages/ui/src/components/message-item.tsx
+++ b/packages/ui/src/components/message-item.tsx
@@ -14,16 +14,7 @@ import type { DeleteHoverState } from "../types/delete-hover"
 import { useSpeech } from "../lib/hooks/use-speech"
 import SpeechActionButton from "./speech-action-button"
 import { agents, sessions, updateSessionAgent } from "../stores/sessions"
-
-function extractMentionTokens(text: string): string[] {
-  const matches = text.matchAll(/@(\S+)/g)
-  const tokens: string[] = []
-  for (const match of matches) {
-    const value = match[1]?.replace(/[),.:;!?\]\}"']+$/g, "")
-    if (value) tokens.push(value)
-  }
-  return tokens
-}
+import { findMentionedVisibleAgents } from "./prompt-input/attachmentPlaceholders"
 
 function DeleteUpToIcon() {
   return (
@@ -319,21 +310,9 @@ export default function MessageItem(props: MessageItemProps) {
     if (!isUser()) return []
     const text = getRawContent()
     if (!text) return []
-    const mentionTokens = new Set(extractMentionTokens(text).map((token) => token.toLowerCase()))
     const availableAgents = agents().get(props.instanceId) || []
     const currentSessionAgent = sessions().get(props.instanceId)?.get(props.sessionId)?.agent || ""
-    const matches: string[] = []
-
-    for (const agent of availableAgents) {
-      const name = agent?.name?.trim()
-      if (!name || agent.hidden || name === currentSessionAgent) continue
-      if (!mentionTokens.has(name.toLowerCase())) continue
-      if (!matches.includes(name)) {
-        matches.push(name)
-      }
-    }
-
-    return matches
+    return findMentionedVisibleAgents(text, availableAgents, currentSessionAgent)
   }
 
   const handleCopy = async () => {

--- a/packages/ui/src/components/message-item.tsx
+++ b/packages/ui/src/components/message-item.tsx
@@ -13,6 +13,11 @@ import { isTauriHost } from "../lib/runtime-env"
 import type { DeleteHoverState } from "../types/delete-hover"
 import { useSpeech } from "../lib/hooks/use-speech"
 import SpeechActionButton from "./speech-action-button"
+import { agents, sessions, updateSessionAgent } from "../stores/sessions"
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
 
 function DeleteUpToIcon() {
   return (
@@ -45,6 +50,7 @@ export default function MessageItem(props: MessageItemProps) {
   const [copied, setCopied] = createSignal(false)
   const [deletingMessage, setDeletingMessage] = createSignal(false)
   const [deletingUpTo, setDeletingUpTo] = createSignal(false)
+  const [switchingAgent, setSwitchingAgent] = createSignal<string | null>(null)
 
   type ImagePreviewState = {
     url: string
@@ -303,6 +309,27 @@ export default function MessageItem(props: MessageItemProps) {
 
   const canSpeakMessage = () => getRawContent().trim().length > 0 && speech.canUseSpeech()
 
+  const mentionedAgents = () => {
+    if (!isUser()) return []
+    const text = getRawContent()
+    if (!text) return []
+    const availableAgents = agents().get(props.instanceId) || []
+    const currentSessionAgent = sessions().get(props.instanceId)?.get(props.sessionId)?.agent || ""
+    const matches: string[] = []
+
+    for (const agent of availableAgents) {
+      const name = agent?.name?.trim()
+      if (!name || name === currentSessionAgent) continue
+      const pattern = new RegExp(`(^|\\s)@${escapeRegExp(name)}(?=\\s|$)`, "i")
+      if (!pattern.test(text)) continue
+      if (!matches.includes(name)) {
+        matches.push(name)
+      }
+    }
+
+    return matches
+  }
+
   const handleCopy = async () => {
     const content = getRawContent()
     if (!content) return
@@ -335,6 +362,21 @@ export default function MessageItem(props: MessageItemProps) {
       await props.onDeleteMessagesUpTo(props.record.id)
     } finally {
       setDeletingUpTo(false)
+    }
+  }
+
+  const handleSwitchAgent = async (agent: string) => {
+    if (!agent || switchingAgent()) return
+    setSwitchingAgent(agent)
+    try {
+      await updateSessionAgent(props.instanceId, props.sessionId, agent)
+    } catch (error) {
+      showAlertDialog(error instanceof Error ? error.message : String(error), {
+        title: t("messageItem.agentMention.switchToAgent", { agent }),
+        variant: "error",
+      })
+    } finally {
+      setSwitchingAgent(null)
     }
   }
 
@@ -652,6 +694,25 @@ export default function MessageItem(props: MessageItemProps) {
                   </div>
                 )
               }}
+            </For>
+          </div>
+        </Show>
+
+        <Show when={mentionedAgents().length > 0}>
+          <div class="message-attachments mt-1">
+            <For each={mentionedAgents()}>
+              {(agent) => (
+                <button
+                  type="button"
+                  class="attachment-chip"
+                  onClick={() => void handleSwitchAgent(agent)}
+                  disabled={switchingAgent() === agent}
+                  title={t("messageItem.agentMention.switchToAgent", { agent })}
+                  aria-label={t("messageItem.agentMention.switchToAgent", { agent })}
+                >
+                  {t("messageItem.agentMention.switchToAgent", { agent })}
+                </button>
+              )}
             </For>
           </div>
         </Show>

--- a/packages/ui/src/components/message-item.tsx
+++ b/packages/ui/src/components/message-item.tsx
@@ -15,8 +15,14 @@ import { useSpeech } from "../lib/hooks/use-speech"
 import SpeechActionButton from "./speech-action-button"
 import { agents, sessions, updateSessionAgent } from "../stores/sessions"
 
-function escapeRegExp(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+function extractMentionTokens(text: string): string[] {
+  const matches = text.matchAll(/@(\S+)/g)
+  const tokens: string[] = []
+  for (const match of matches) {
+    const value = match[1]?.replace(/[),.:;!?\]\}"']+$/g, "")
+    if (value) tokens.push(value)
+  }
+  return tokens
 }
 
 function DeleteUpToIcon() {
@@ -313,15 +319,15 @@ export default function MessageItem(props: MessageItemProps) {
     if (!isUser()) return []
     const text = getRawContent()
     if (!text) return []
+    const mentionTokens = new Set(extractMentionTokens(text).map((token) => token.toLowerCase()))
     const availableAgents = agents().get(props.instanceId) || []
     const currentSessionAgent = sessions().get(props.instanceId)?.get(props.sessionId)?.agent || ""
     const matches: string[] = []
 
     for (const agent of availableAgents) {
       const name = agent?.name?.trim()
-      if (!name || name === currentSessionAgent) continue
-      const pattern = new RegExp(`(^|\\s)@${escapeRegExp(name)}(?=\\s|$)`, "i")
-      if (!pattern.test(text)) continue
+      if (!name || agent.hidden || name === currentSessionAgent) continue
+      if (!mentionTokens.has(name.toLowerCase())) continue
       if (!matches.includes(name)) {
         matches.push(name)
       }

--- a/packages/ui/src/components/prompt-input/attachmentPlaceholders.test.ts
+++ b/packages/ui/src/components/prompt-input/attachmentPlaceholders.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 
-import { extractMentionTokens, findMentionedVisibleAgents } from "./attachmentPlaceholders"
+import { extractMentionTokens, findMentionedVisibleAgents } from "./attachmentPlaceholders.ts"
 
 describe("extractMentionTokens", () => {
   it("keeps punctuation-delimited mentions usable", () => {

--- a/packages/ui/src/components/prompt-input/attachmentPlaceholders.test.ts
+++ b/packages/ui/src/components/prompt-input/attachmentPlaceholders.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { extractMentionTokens, findMentionedVisibleAgents } from "./attachmentPlaceholders"
+
+describe("extractMentionTokens", () => {
+  it("keeps punctuation-delimited mentions usable", () => {
+    assert.deepEqual(extractMentionTokens("Use @reviewer, then ask (@planner) and finally @writer:"), ["reviewer", "planner", "writer"])
+  })
+})
+
+describe("findMentionedVisibleAgents", () => {
+  it("ignores hidden agents, the current agent, and duplicates", () => {
+    const result = findMentionedVisibleAgents(
+      "Try @reviewer, then @reviewer again, skip @hidden-agent, and maybe @active-agent.",
+      [
+        { name: "reviewer", description: "", mode: "primary" },
+        { name: "hidden-agent", description: "", mode: "primary", hidden: true },
+        { name: "active-agent", description: "", mode: "primary" },
+      ],
+      "active-agent",
+    )
+
+    assert.deepEqual(result, ["reviewer"])
+  })
+})

--- a/packages/ui/src/components/prompt-input/attachmentPlaceholders.ts
+++ b/packages/ui/src/components/prompt-input/attachmentPlaceholders.ts
@@ -1,3 +1,5 @@
+import type { Agent } from "../../types/session"
+
 export function formatPastedPlaceholder(value: string | number) {
   return `[pasted #${value}]`
 }
@@ -16,6 +18,36 @@ export function createImagePlaceholderRegex() {
 
 export function createMentionRegex() {
   return /@(\S+)/g
+}
+
+export function normalizeMentionToken(value: string) {
+  return value.replace(/[),.:;!?\]\}"']+$/g, "")
+}
+
+export function extractMentionTokens(text: string): string[] {
+  const matches = text.matchAll(createMentionRegex())
+  const tokens: string[] = []
+  for (const match of matches) {
+    const normalized = normalizeMentionToken(match[1] ?? "")
+    if (normalized) tokens.push(normalized)
+  }
+  return tokens
+}
+
+export function findMentionedVisibleAgents(text: string, availableAgents: Agent[], currentAgent: string): string[] {
+  const mentionTokens = new Set(extractMentionTokens(text).map((token) => token.toLowerCase()))
+  const matches: string[] = []
+
+  for (const agent of availableAgents) {
+    const name = agent?.name?.trim()
+    if (!name || agent.hidden || name === currentAgent) continue
+    if (!mentionTokens.has(name.toLowerCase())) continue
+    if (!matches.includes(name)) {
+      matches.push(name)
+    }
+  }
+
+  return matches
 }
 
 export const pastedDisplayCounterRegex = /pasted #(\d+)/i

--- a/packages/ui/src/lib/i18n/messages/en/messaging.ts
+++ b/packages/ui/src/lib/i18n/messages/en/messaging.ts
@@ -118,6 +118,7 @@ export const messagingMessages = {
   "messageItem.attachment.downloadAriaLabel": "Download {name}",
   "messageItem.agentMeta.agentLabel": "Agent: {agent}",
   "messageItem.agentMeta.modelLabel": "Model: {model}",
+  "messageItem.agentMention.switchToAgent": "Switch to {agent}",
   "messageItem.errors.authenticationFallback": "Authentication error",
   "messageItem.errors.outputLengthExceeded": "Message output length exceeded",
   "messageItem.errors.requestAborted": "Request was aborted",

--- a/packages/ui/src/lib/i18n/messages/es/messaging.ts
+++ b/packages/ui/src/lib/i18n/messages/es/messaging.ts
@@ -120,6 +120,7 @@ export const messagingMessages = {
   "messageItem.attachment.downloadAriaLabel": "Descargar {name}",
   "messageItem.agentMeta.agentLabel": "Agente: {agent}",
   "messageItem.agentMeta.modelLabel": "Modelo: {model}",
+  "messageItem.agentMention.switchToAgent": "Cambiar a {agent}",
   "messageItem.errors.authenticationFallback": "Error de autenticación",
   "messageItem.errors.outputLengthExceeded": "Se excedió la longitud de salida del mensaje",
   "messageItem.errors.requestAborted": "La solicitud fue abortada",

--- a/packages/ui/src/lib/i18n/messages/fr/messaging.ts
+++ b/packages/ui/src/lib/i18n/messages/fr/messaging.ts
@@ -120,6 +120,7 @@ export const messagingMessages = {
   "messageItem.attachment.downloadAriaLabel": "Télécharger {name}",
   "messageItem.agentMeta.agentLabel": "Agent : {agent}",
   "messageItem.agentMeta.modelLabel": "Modèle : {model}",
+  "messageItem.agentMention.switchToAgent": "Basculer vers {agent}",
   "messageItem.errors.authenticationFallback": "Erreur d'authentification",
   "messageItem.errors.outputLengthExceeded": "Longueur de sortie du message dépassée",
   "messageItem.errors.requestAborted": "La requête a été annulée",

--- a/packages/ui/src/lib/i18n/messages/he/messaging.ts
+++ b/packages/ui/src/lib/i18n/messages/he/messaging.ts
@@ -118,6 +118,7 @@ export const messagingMessages = {
   "messageItem.attachment.downloadAriaLabel": "הורד {name}",
   "messageItem.agentMeta.agentLabel": "סוכן: {agent}",
   "messageItem.agentMeta.modelLabel": "מודל: {model}",
+  "messageItem.agentMention.switchToAgent": "עבור אל {agent}",
   "messageItem.errors.authenticationFallback": "שגיאת אימות",
   "messageItem.errors.outputLengthExceeded": "אורך פלט ההודעה חרג מהמגבלה",
   "messageItem.errors.requestAborted": "הבקשה בוטלה",

--- a/packages/ui/src/lib/i18n/messages/ja/messaging.ts
+++ b/packages/ui/src/lib/i18n/messages/ja/messaging.ts
@@ -120,6 +120,7 @@ export const messagingMessages = {
   "messageItem.attachment.downloadAriaLabel": "{name} をダウンロード",
   "messageItem.agentMeta.agentLabel": "エージェント: {agent}",
   "messageItem.agentMeta.modelLabel": "モデル: {model}",
+  "messageItem.agentMention.switchToAgent": "{agent} に切り替え",
   "messageItem.errors.authenticationFallback": "認証エラー",
   "messageItem.errors.outputLengthExceeded": "メッセージ出力が長すぎます",
   "messageItem.errors.requestAborted": "リクエストが中断されました",

--- a/packages/ui/src/lib/i18n/messages/ru/messaging.ts
+++ b/packages/ui/src/lib/i18n/messages/ru/messaging.ts
@@ -120,6 +120,7 @@ export const messagingMessages = {
   "messageItem.attachment.downloadAriaLabel": "Скачать {name}",
   "messageItem.agentMeta.agentLabel": "Агент: {agent}",
   "messageItem.agentMeta.modelLabel": "Модель: {model}",
+  "messageItem.agentMention.switchToAgent": "Переключиться на {agent}",
   "messageItem.errors.authenticationFallback": "Ошибка аутентификации",
   "messageItem.errors.outputLengthExceeded": "Превышена длина вывода сообщения",
   "messageItem.errors.requestAborted": "Запрос был прерван",

--- a/packages/ui/src/lib/i18n/messages/zh-Hans/messaging.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-Hans/messaging.ts
@@ -120,6 +120,7 @@ export const messagingMessages = {
   "messageItem.attachment.downloadAriaLabel": "下载 {name}",
   "messageItem.agentMeta.agentLabel": "智能体：{agent}",
   "messageItem.agentMeta.modelLabel": "模型：{model}",
+  "messageItem.agentMention.switchToAgent": "切换到 {agent}",
   "messageItem.errors.authenticationFallback": "认证错误",
   "messageItem.errors.outputLengthExceeded": "消息输出长度超限",
   "messageItem.errors.requestAborted": "请求已中止",


### PR DESCRIPTION
Fixes #292

## Summary
- detect visible `@agent` mentions in user messages
- render a direct `Switch to {agent}` action below those messages
- make mention detection tolerate common punctuation around the mention token

## Why
The prompt flow allows users to mention agents, but the message view was no longer surfacing a visible way to switch to the mentioned agent afterward.

This restores that affordance in the message stream itself.

## What Changed
- `packages/ui/src/components/message-item.tsx`
  - detect known agent mentions in user message text
  - ignore hidden agents and the current session agent
  - render a `Switch to {agent}` action for matching visible agents
  - wire the action to `updateSessionAgent()`
  - accept punctuation-delimited mentions like `@agent,` and `(@agent)`
- `packages/ui/src/lib/i18n/messages/*/messaging.ts`
  - added the localized switch-action label

## Validation
- `npm run build --workspace @codenomad/ui`