### PR TITLE
fix(ui): preserve manual scroll during streaming

### DIFF
--- a/packages/ui/src/components/virtual-follow-list.tsx
+++ b/packages/ui/src/components/virtual-follow-list.tsx
@@ -312,6 +312,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
   function scrollToBottom(immediate = true, options?: { suppressAutoAnchor?: boolean }) {
     const handle = virtuaHandle()
     if (!handle) return
+    clearPendingUpwardBreak()
     if (options?.suppressAutoAnchor ?? !immediate) {
       suppressAutoScrollOnce = true
     }
@@ -420,7 +421,13 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
         scrollToBottom(true)
       }
     },
-    setAutoScroll: (enabled) => setAutoScroll(Boolean(enabled)),
+    setAutoScroll: (enabled) => {
+      const nextEnabled = Boolean(enabled)
+      if (nextEnabled) {
+        clearPendingUpwardBreak()
+      }
+      setAutoScroll(nextEnabled)
+    },
     getAutoScroll: () => autoScroll(),
     getScrollElement: () => scrollElement(),
     getShellElement: () => shellElement(),

--- a/packages/ui/src/components/virtual-follow-list.tsx
+++ b/packages/ui/src/components/virtual-follow-list.tsx
@@ -190,6 +190,13 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
     userScrollIntentUntil = now + USER_SCROLL_INTENT_WINDOW_MS
     if (direction) {
       lastUserScrollIntentDirection = direction
+      if (direction === "up" && autoScroll() && activeHoldTargetKey() === null) {
+        // Streaming renders can re-pin before the scroll event is observed.
+        // Break follow immediately on an explicit upward user intent.
+        setAutoScroll(false)
+        lastObservedPinnedAtBottom = false
+        suppressAutoScrollOnce = true
+      }
     }
   }
 

--- a/packages/ui/src/components/virtual-follow-list.tsx
+++ b/packages/ui/src/components/virtual-follow-list.tsx
@@ -295,8 +295,11 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
     // Sync autoScroll state based on scroll position if it was a user scroll
     if (hasUserScrollIntent()) {
       clearAutoPinHold()
-      if (atBottom && !autoScroll()) {
-        setAutoScroll(true)
+      if (atBottom) {
+        clearPendingUpwardBreak()
+        if (!autoScroll()) {
+          setAutoScroll(true)
+        }
       } else if (!atBottom && autoScroll()) {
         setAutoScroll(false)
       }

--- a/packages/ui/src/components/virtual-follow-list.tsx
+++ b/packages/ui/src/components/virtual-follow-list.tsx
@@ -173,6 +173,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
   let detachScrollIntentListeners: (() => void) | undefined
   let lastResetKey: string | number | undefined
   let suppressAutoScrollOnce = false
+  let pendingUpwardBreakUntil = 0
   let pendingInitialScroll = true
   let lastObservedScrollOffset = 0
   let lastObservedPinnedAtBottom = false
@@ -192,9 +193,9 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
       lastUserScrollIntentDirection = direction
       if (direction === "up" && autoScroll() && activeHoldTargetKey() === null) {
         // Streaming renders can re-pin before the scroll event is observed.
-        // Break follow immediately on an explicit upward user intent.
-        setAutoScroll(false)
-        lastObservedPinnedAtBottom = false
+        // Suppress the next automatic bottom pin, but only break follow once a
+        // real upward movement away from bottom is confirmed.
+        pendingUpwardBreakUntil = now + USER_SCROLL_INTENT_WINDOW_MS
         suppressAutoScrollOnce = true
       }
     }
@@ -202,6 +203,14 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
 
   function hasUserScrollIntent() {
     return performance.now() <= userScrollIntentUntil
+  }
+
+  function hasPendingUpwardBreak() {
+    return performance.now() <= pendingUpwardBreakUntil
+  }
+
+  function clearPendingUpwardBreak() {
+    pendingUpwardBreakUntil = 0
   }
 
   function clearAutoPinHold(options?: { resumeBottom?: boolean }) {
@@ -276,8 +285,9 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
     // scrollbar). If follow mode stays enabled, the next render notification
     // snaps the list straight back to bottom. A real upward viewport move away
     // from bottom should always break follow unless a hold target is active.
-    if (wasPinnedAtBottom && scrolledUp && autoScroll() && !atBottom && activeHoldTargetKey() === null) {
+    if (wasPinnedAtBottom && scrolledUp && (autoScroll() || hasPendingUpwardBreak()) && !atBottom && activeHoldTargetKey() === null) {
       setAutoScroll(false)
+      clearPendingUpwardBreak()
       lastObservedPinnedAtBottom = false
       return
     }
@@ -290,6 +300,10 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
       } else if (!atBottom && autoScroll()) {
         setAutoScroll(false)
       }
+    }
+
+    if (atBottom && !hasUserScrollIntent()) {
+      clearPendingUpwardBreak()
     }
 
     lastObservedPinnedAtBottom = autoScroll() && atBottom
@@ -401,6 +415,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
     notifyContentRendered: () => {
       updateAutoPinHold()
       if (activeHoldTargetKey() !== null) return
+      if (hasPendingUpwardBreak()) return
       if (autoScroll() && !effectiveSuspendAutoPinToBottom()) {
         scrollToBottom(true)
       }
@@ -418,6 +433,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
     itemElements.clear()
     setActiveHoldTargetKey(null)
     setDidTriggerHoldForCurrentTarget(false)
+    clearPendingUpwardBreak()
     lastObservedScrollOffset = 0
     lastObservedPinnedAtBottom = false
   }))
@@ -433,7 +449,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
 
   // Handle autoScroll (Follow) on items change
   createEffect(on(() => props.items().length, (len, prevLen) => {
-    if (len > (prevLen ?? 0) && autoScroll() && !effectiveSuspendAutoPinToBottom() && !suppressAutoScrollOnce) {
+    if (len > (prevLen ?? 0) && autoScroll() && !effectiveSuspendAutoPinToBottom() && !suppressAutoScrollOnce && !hasPendingUpwardBreak()) {
       requestAnimationFrame(() => scrollToBottom(true))
     }
     suppressAutoScrollOnce = false
@@ -441,7 +457,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
 
   // Handle followToken change
   createEffect(on(() => props.followToken?.(), () => {
-    if (autoScroll() && !effectiveSuspendAutoPinToBottom()) {
+    if (autoScroll() && !effectiveSuspendAutoPinToBottom() && !hasPendingUpwardBreak()) {
       scrollToBottom(true)
     }
   }, { defer: true }))


### PR DESCRIPTION
Fixes #305

## Summary
- stop auto-follow as soon as the user expresses an explicit upward scroll intent while the assistant is still streaming
- keep the message list from snapping back to the bottom before that upward scroll can take effect

## Why
The message stream already tries to leave follow mode when the user scrolls up, but streaming renders can still re-pin the list before the upward movement is fully observed.

This makes scrolling upward feel broken while the agent is still responding.

## What Changed
- `packages/ui/src/components/virtual-follow-list.tsx`
  - break follow mode immediately on explicit upward scroll intent
  - suppress the next automatic bottom pin so the user's scroll-up wins over the active stream

## Validation
- `npm run build --workspace @codenomad/ui`