### PR TITLE
fix(ui): render patch message parts

### DIFF
--- a/packages/ui/src/components/message-block.tsx
+++ b/packages/ui/src/components/message-block.tsx
@@ -223,12 +223,11 @@ interface MessageContentItemProps {
 
 function isSupportedPartType(part: unknown): boolean {
   const type = (part as any)?.type
-  // Ignore part types the UI does not support rendering yet.
-  return !(typeof type === "string" && type === "patch")
+  return typeof type === "string" && type.length > 0
 }
 
 function isContentPartType(type: unknown): boolean {
-  return type === "text" || type === "file"
+  return type === "text" || type === "file" || type === "patch"
 }
 
 function isVisibleContentPart(part: ClientPart): boolean {

--- a/packages/ui/src/components/message-item.tsx
+++ b/packages/ui/src/components/message-item.tsx
@@ -2,7 +2,7 @@ import { For, Show, createEffect, createSignal, onCleanup } from "solid-js"
 import { Portal } from "solid-js/web"
 import { Copy, ListStart, Split, Trash, Undo } from "lucide-solid"
 import type { MessageInfo, ClientPart, SDKAssistantMessageV2 } from "../types/message"
-import { isHiddenSyntheticTextPart, partHasRenderableText } from "../types/message"
+import { getPatchPartFiles, isHiddenSyntheticTextPart, partHasRenderableText } from "../types/message"
 import type { MessageRecord } from "../stores/message-v2/types"
 import MessagePart from "./message-part"
 import { copyToClipboard } from "../lib/clipboard"
@@ -290,8 +290,19 @@ export default function MessageItem(props: MessageItemProps) {
 
   const getRawContent = () => {
     return props.parts
-      .filter((part) => part.type === "text" && !isHiddenSyntheticTextPart(part))
-      .map((part) => (part as { text?: string }).text || "")
+      .map((part) => {
+        if (part.type === "text" && !isHiddenSyntheticTextPart(part)) {
+          return (part as { text?: string }).text || ""
+        }
+
+        if (part.type === "patch") {
+          const files = getPatchPartFiles(part)
+          if (files.length === 0) return ""
+          return [t("instanceShell.sessionChanges.filesChanged", { count: files.length }), ...files.map((file) => `- ${file}`)].join("\n")
+        }
+
+        return ""
+      })
       .filter((text) => text.trim().length > 0)
       .join("\n\n")
   }

--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -2,7 +2,8 @@ import { Match, Show, Suspense, Switch, lazy } from "solid-js"
 import { isItemExpanded, toggleItemExpanded } from "../stores/tool-call-state"
 import { Markdown } from "./markdown"
 import { useTheme } from "../lib/theme"
-import { partHasRenderableText, SDKPart, TextPart, ClientPart } from "../types/message"
+import { getPatchPartFiles, partHasRenderableText, SDKPart, TextPart, ClientPart } from "../types/message"
+import { useI18n } from "../lib/i18n"
 
 type ToolCallPart = Extract<ClientPart, { type: "tool" }>
 
@@ -21,6 +22,7 @@ interface MessagePartProps {
 
 export default function MessagePart(props: MessagePartProps) {
 
+  const { t } = useI18n()
   const { isDark } = useTheme()
   const partType = () => props.part?.type || ""
   const reasoningId = () => `reasoning-${props.part?.id || ""}`
@@ -83,6 +85,8 @@ export default function MessagePart(props: MessagePartProps) {
     }
     return false
   }
+
+  const patchFiles = () => getPatchPartFiles(props.part)
 
   const createTextPartForMarkdown = (): TextPart => {
     const part = props.part
@@ -151,6 +155,21 @@ export default function MessagePart(props: MessagePartProps) {
             sessionId={props.sessionId}
           />
         </Suspense>
+      </Match>
+
+      <Match when={partType() === "patch"}>
+        <Show when={patchFiles().length > 0}>
+          <div class="rounded border border-base bg-surface-secondary px-2 py-1.5 text-xs" data-part-type="patch">
+            <div class="font-medium text-primary">
+              {t("instanceShell.sessionChanges.filesChanged", { count: patchFiles().length })}
+            </div>
+            <ul class="mt-1 space-y-0.5 text-secondary">
+              {patchFiles().map((file) => (
+                <li class="truncate" title={file}>{file}</li>
+              ))}
+            </ul>
+          </div>
+        </Show>
       </Match>
 
 

--- a/packages/ui/src/types/message.test.ts
+++ b/packages/ui/src/types/message.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { getPatchPartFiles, partHasRenderableText, type ClientPart } from "./message.ts"
+
+describe("message parts", () => {
+  it("treats patch parts with files as renderable content", () => {
+    const part = {
+      id: "patch-1",
+      type: "patch",
+      sessionID: "session-1",
+      messageID: "message-1",
+      hash: "abc",
+      files: ["src/app.ts"],
+    } as ClientPart
+
+    assert.deepEqual(getPatchPartFiles(part), ["src/app.ts"])
+    assert.equal(partHasRenderableText(part), true)
+  })
+
+  it("ignores empty patch file lists", () => {
+    const part = {
+      id: "patch-1",
+      type: "patch",
+      sessionID: "session-1",
+      messageID: "message-1",
+      hash: "abc",
+      files: [],
+    } as ClientPart
+
+    assert.deepEqual(getPatchPartFiles(part), [])
+    assert.equal(partHasRenderableText(part), false)
+  })
+})

--- a/packages/ui/src/types/message.ts
+++ b/packages/ui/src/types/message.ts
@@ -78,6 +78,13 @@ export interface TextPart {
 
 export type MessageInfo = SDKMessage
 
+export function getPatchPartFiles(part: ClientPart): string[] {
+  if (!part || part.type !== "patch") return []
+  const files = (part as { files?: unknown }).files
+  if (!Array.isArray(files)) return []
+  return files.filter((file): file is string => typeof file === "string" && file.trim().length > 0)
+}
+
 export function isHiddenSyntheticTextPart(part: ClientPart): boolean {
   return Boolean(part && part.type === "text" && part.synthetic)
 }
@@ -115,6 +122,10 @@ export function partHasRenderableText(part: ClientPart): boolean {
 
   if (typedPart.type === "tool") {
     return true // Tool parts are always renderable
+  }
+
+  if (typedPart.type === "patch" && getPatchPartFiles(part).length > 0) {
+    return true
   }
 
   if (typedPart.type === "reasoning" && hasTextSegment(typedPart.text)) {


### PR DESCRIPTION
Fixes #316

## Summary
- treat assistant `patch` parts as renderable content instead of dropping them from the message stream
- render a compact changed-files card for patch-only assistant responses so file-change replies do not fall back to the thinking placeholder
- add focused tests for patch part renderability

## Testing
- `node --experimental-strip-types --test "packages/ui/src/types/message.test.ts"`
- `npm run typecheck --workspace @codenomad/ui`
- `npm run build --workspace @codenomad/ui`