### PR TITLE
fix(ui): show pending tool prompts

### DIFF
--- a/packages/ui/src/components/message-timeline.tsx
+++ b/packages/ui/src/components/message-timeline.tsx
@@ -73,6 +73,7 @@ interface TimelineSegmentState {
   deleteHovered: boolean
   deleteSelected: boolean
   hasActivePermission: boolean
+  hasPendingInterruption: boolean
   hidden: boolean
 }
 
@@ -749,12 +750,24 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
       const deleteSelected = selectedMessages?.has(segment.messageId) ?? false
 
       let hasActivePermission = false
+      let hasPendingInterruption = false
       if (segment.type === "tool") {
         const partIds = segment.toolPartIds ?? []
         for (const partId of partIds) {
           const permissionState = resolvedStore.getPermissionState(segment.messageId, partId)
+          if (permissionState?.entry?.permission) {
+            hasPendingInterruption = true
+          }
           if (permissionState?.active) {
             hasActivePermission = true
+          }
+
+          const questionState = resolvedStore.getQuestionState(segment.messageId, partId)
+          if (questionState?.entry?.request) {
+            hasPendingInterruption = true
+          }
+
+          if (hasActivePermission && hasPendingInterruption) {
             break
           }
         }
@@ -765,7 +778,7 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
         || expandedMessages?.has(segment.messageId)
         || selectionActive
         || props.activeSegmentId === segment.id
-        || hasActivePermission
+        || hasPendingInterruption
         || deleteHovered
         || deleteSelected
       )
@@ -774,6 +787,7 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
         deleteHovered,
         deleteSelected,
         hasActivePermission,
+        hasPendingInterruption,
         hidden,
       })
     }
@@ -786,6 +800,7 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
       deleteHovered: false,
       deleteSelected: false,
       hasActivePermission: false,
+      hasPendingInterruption: false,
       hidden: false,
     }
   }

--- a/packages/ui/src/components/message-timeline.tsx
+++ b/packages/ui/src/components/message-timeline.tsx
@@ -754,17 +754,12 @@ const MessageTimeline: Component<MessageTimelineProps> = (props) => {
       if (segment.type === "tool") {
         const partIds = segment.toolPartIds ?? []
         for (const partId of partIds) {
-          const permissionState = resolvedStore.getPermissionState(segment.messageId, partId)
-          if (permissionState?.entry?.permission) {
+          const interruptionState = resolvedStore.getToolInterruptionState(segment.messageId, partId)
+          if (interruptionState.hasPendingInterruption) {
             hasPendingInterruption = true
           }
-          if (permissionState?.active) {
+          if (interruptionState.hasActivePermission) {
             hasActivePermission = true
-          }
-
-          const questionState = resolvedStore.getQuestionState(segment.messageId, partId)
-          if (questionState?.entry?.request) {
-            hasPendingInterruption = true
           }
 
           if (hasActivePermission && hasPendingInterruption) {

--- a/packages/ui/src/components/tool-call.tsx
+++ b/packages/ui/src/components/tool-call.tsx
@@ -511,7 +511,7 @@ function ToolCallDetails(props: {
             {renderToolBody()}
             {renderError()}
 
-            <Show when={status() === "pending" && !props.pendingPermission()}>
+            <Show when={status() === "pending" && !hasPendingInterruption()}>
               <div class="tool-call-pending-message">
                 <span class="spinner-small"></span>
                 <span>{props.t("toolCall.pending.waitingToRun")}</span>
@@ -547,7 +547,7 @@ function ToolCallDetails(props: {
                 {renderToolBody()}
                 {renderError()}
 
-                <Show when={status() === "pending" && !props.pendingPermission()}>
+                <Show when={status() === "pending" && !hasPendingInterruption()}>
                   <div class="tool-call-pending-message">
                     <span class="spinner-small"></span>
                     <span>{props.t("toolCall.pending.waitingToRun")}</span>

--- a/packages/ui/src/components/tool-call.tsx
+++ b/packages/ui/src/components/tool-call.tsx
@@ -657,8 +657,10 @@ export default function ToolCall(props: ToolCallProps) {
     return active?.kind === "question" && active.id === pending.request.id
   })
 
+  const hasPendingInterruption = createMemo(() => Boolean(pendingPermission()?.permission || pendingQuestion()?.request))
+
   const expanded = () => {
-    if (isPermissionActive() || isQuestionActive()) return true
+    if (hasPendingInterruption()) return true
     const override = userExpanded()
     if (override !== null) return override
     return defaultExpandedForTool()
@@ -679,7 +681,7 @@ export default function ToolCall(props: ToolCallProps) {
   const [diagnosticsOverride, setDiagnosticsOverride] = createSignal<boolean | undefined>(undefined)
 
   const diagnosticsExpanded = () => {
-    if (isPermissionActive() || isQuestionActive()) return true
+    if (hasPendingInterruption()) return true
     const override = diagnosticsOverride()
     if (override !== undefined) return override
     return diagnosticsDefaultExpanded()
@@ -714,8 +716,7 @@ export default function ToolCall(props: ToolCallProps) {
   }
 
   function toggle() {
-    const permission = pendingPermission()
-    if (permission?.active) {
+    if (hasPendingInterruption()) {
       return
     }
     setUserExpanded((prev) => {

--- a/packages/ui/src/components/tool-call.tsx
+++ b/packages/ui/src/components/tool-call.tsx
@@ -120,6 +120,7 @@ function ToolCallDetails(props: {
   store: () => ReturnType<typeof messageStoreBus.getOrCreate>
   pendingPermission: () => { permission: PermissionRequestLike; active: boolean } | undefined
   pendingQuestion: () => { request: QuestionRequest; active: boolean } | undefined
+  hasPendingInterruption: () => boolean
   isPermissionActive: () => boolean
   isQuestionActive: () => boolean
   hasToolInput: () => boolean
@@ -511,7 +512,7 @@ function ToolCallDetails(props: {
             {renderToolBody()}
             {renderError()}
 
-            <Show when={status() === "pending" && !hasPendingInterruption()}>
+            <Show when={status() === "pending" && !props.hasPendingInterruption()}>
               <div class="tool-call-pending-message">
                 <span class="spinner-small"></span>
                 <span>{props.t("toolCall.pending.waitingToRun")}</span>
@@ -547,7 +548,7 @@ function ToolCallDetails(props: {
                 {renderToolBody()}
                 {renderError()}
 
-                <Show when={status() === "pending" && !hasPendingInterruption()}>
+                <Show when={status() === "pending" && !props.hasPendingInterruption()}>
                   <div class="tool-call-pending-message">
                     <span class="spinner-small"></span>
                     <span>{props.t("toolCall.pending.waitingToRun")}</span>
@@ -587,7 +588,8 @@ export default function ToolCall(props: ToolCallProps) {
   const store = createMemo(() => messageStoreBus.getOrCreate(props.instanceId))
   const activeRequest = createMemo(() => activeInterruption().get(props.instanceId) ?? null)
 
-  const permissionState = createMemo(() => store().getPermissionState(props.messageId, toolCallIdentifier()))
+  const interruptionState = createMemo(() => store().getToolInterruptionState(props.messageId, toolCallIdentifier()))
+  const permissionState = createMemo(() => interruptionState().permission)
   const pendingPermission = createMemo(() => {
     const state = permissionState()
     if (state) {
@@ -596,7 +598,7 @@ export default function ToolCall(props: ToolCallProps) {
     return toolCallMemo()?.pendingPermission
   })
 
-  const questionState = createMemo(() => store().getQuestionState(props.messageId, toolCallIdentifier()))
+  const questionState = createMemo(() => interruptionState().question)
   const pendingQuestion = createMemo(() => {
     const state = questionState()
     if (state) {
@@ -909,6 +911,7 @@ export default function ToolCall(props: ToolCallProps) {
           store={store}
           pendingPermission={pendingPermission}
           pendingQuestion={pendingQuestion}
+          hasPendingInterruption={hasPendingInterruption}
           isPermissionActive={isPermissionActive}
           isQuestionActive={isQuestionActive}
           hasToolInput={hasToolInput}

--- a/packages/ui/src/stores/message-v2/instance-store.ts
+++ b/packages/ui/src/stores/message-v2/instance-store.ts
@@ -3,6 +3,8 @@ import { createStore, produce, reconcile } from "solid-js/store"
 import type { SetStoreFunction } from "solid-js/store"
 import { getLogger } from "../../lib/logger"
 import type { ClientPart, MessageInfo } from "../../types/message"
+import { getPermissionCallId, getPermissionMessageId } from "../../types/permission"
+import { getQuestionCallId, getQuestionMessageId } from "../../types/question"
 import { clearRecordDisplayCacheForMessages } from "./record-display-cache"
 import type {
   InstanceMessageState,
@@ -25,6 +27,16 @@ const storeLog = getLogger("session")
 
 interface MessageStoreHooks {
   onSessionCleared?: (instanceId: string, sessionId: string) => void
+}
+
+type PermissionInterruptionState = { entry: PermissionEntry; active: boolean }
+type QuestionInterruptionState = { entry: QuestionEntry; active: boolean }
+
+interface ToolInterruptionState {
+  permission: PermissionInterruptionState | null
+  question: QuestionInterruptionState | null
+  hasPendingInterruption: boolean
+  hasActivePermission: boolean
 }
 
 function createInitialState(instanceId: string): InstanceMessageState {
@@ -211,6 +223,7 @@ export interface InstanceMessageStore {
   upsertQuestion: (entry: QuestionEntry) => void
   removeQuestion: (requestId: string) => void
   getQuestionState: (messageId?: string, partId?: string) => { entry: QuestionEntry; active: boolean } | null
+  getToolInterruptionState: (messageId?: string, partId?: string) => ToolInterruptionState
   setSessionRevert: (sessionId: string, revert?: SessionRecord["revert"] | null) => void
   getSessionRevert: (sessionId: string) => SessionRecord["revert"] | undefined | null
   rebuildUsage: (sessionId: string, infos: Iterable<MessageInfo>) => void
@@ -558,17 +571,28 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     })
   }
 
-  function rebindPermissionForPart(messageId: string, partId: string, part: ClientPart) {
-    if (!messageId || !partId || part.type !== "tool") {
-      return
-    }
-
-    const toolCallId =
+  function getToolCallId(part: ClientPart | null | undefined): string | undefined {
+    if (!part || part.type !== "tool") return undefined
+    return (
       (part as any).callID ??
       (part as any).callId ??
       (part as any).toolCallID ??
       (part as any).toolCallId ??
       undefined
+    )
+  }
+
+  function getToolPartCallId(messageId?: string, partId?: string): string | undefined {
+    if (!messageId || !partId) return undefined
+    return getToolCallId(state.messages[messageId]?.parts[partId]?.data)
+  }
+
+  function rebindPermissionForPart(messageId: string, partId: string, part: ClientPart) {
+    if (!messageId || !partId || part.type !== "tool") {
+      return
+    }
+
+    const toolCallId = getToolCallId(part)
     if (!toolCallId) {
       return
     }
@@ -582,16 +606,7 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
         const existing = draft[partId]
         for (const [key, entry] of Object.entries(draft)) {
           if (!entry || entry.partId) continue
-          const permissionCallId =
-            (entry.permission as any).tool?.callID ??
-            (entry.permission as any).tool?.callId ??
-            (entry.permission as any).callID ??
-            (entry.permission as any).callId ??
-            (entry.permission as any).toolCallID ??
-            (entry.permission as any).toolCallId ??
-            (entry.permission as any).metadata?.callID ??
-            (entry.permission as any).metadata?.callId ??
-            undefined
+          const permissionCallId = getPermissionCallId(entry.permission)
           if (permissionCallId !== toolCallId) continue
           if (!existing || existing.permission.id === entry.permission.id) {
             entry.partId = partId
@@ -958,6 +973,25 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     return { entry, active }
   }
 
+  function getPermissionStateForTool(messageId?: string, partId?: string): PermissionInterruptionState | null {
+    const direct = getPermissionState(messageId, partId)
+    if (direct) return direct
+
+    const toolCallId = getToolPartCallId(messageId, partId)
+    if (!messageId || !partId || !toolCallId) return null
+
+    const entry = state.permissions.queue.find((item) => {
+      if (!item?.permission) return false
+      if (item.partId && item.partId !== partId) return false
+      const itemMessageId = item.messageId ?? getPermissionMessageId(item.permission)
+      if (itemMessageId && itemMessageId !== messageId) return false
+      return getPermissionCallId(item.permission) === toolCallId
+    })
+    if (!entry) return null
+    const active = state.permissions.active?.permission.id === entry.permission.id
+    return { entry, active }
+  }
+
   function upsertQuestion(entry: QuestionEntry) {
     const messageKey = entry.messageId ?? "__global__"
     const partKey = entry.partId ?? entry.request?.id ?? "__global__"
@@ -1010,6 +1044,37 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     if (!entry) return null
     const active = state.questions.active?.request.id === entry.request.id
     return { entry, active }
+  }
+
+  function getQuestionStateForTool(messageId?: string, partId?: string): QuestionInterruptionState | null {
+    const direct = getQuestionState(messageId, partId)
+    if (direct) return direct
+
+    const toolCallId = getToolPartCallId(messageId, partId)
+    if (!messageId || !partId || !toolCallId) return null
+
+    const entry = state.questions.queue.find((item) => {
+      if (!item?.request) return false
+      if (item.partId && item.partId !== partId) return false
+      const itemMessageId = item.messageId ?? getQuestionMessageId(item.request)
+      if (itemMessageId && itemMessageId !== messageId) return false
+      return getQuestionCallId(item.request) === toolCallId
+    })
+    if (!entry) return null
+    const active = state.questions.active?.request.id === entry.request.id
+    return { entry, active }
+  }
+
+  function getToolInterruptionState(messageId?: string, partId?: string): ToolInterruptionState {
+    const permission = getPermissionStateForTool(messageId, partId)
+    const question = getQuestionStateForTool(messageId, partId)
+
+    return {
+      permission,
+      question,
+      hasPendingInterruption: Boolean(permission?.entry.permission || question?.entry.request),
+      hasActivePermission: Boolean(permission?.active),
+    }
   }
 
   function pruneMessagesAfterRevert(sessionId: string, revertMessageId: string) {
@@ -1222,6 +1287,7 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
       upsertQuestion,
       removeQuestion,
       getQuestionState,
+      getToolInterruptionState,
 
      setSessionRevert,
      getSessionRevert,


### PR DESCRIPTION
Fixes #290

## Summary
- keep tool calls expanded while a permission or question is attached, even before active interruption reconciliation catches up
- use the same pending-interruption rule for diagnostics expansion and manual toggle guards
- make permission asks more reliably visible in the message stream when tool calls are normally collapsed

## Testing
- `npm run typecheck --workspace @codenomad/ui`
- `npm run build --workspace @codenomad/ui`