### PR TITLE
Fix(ui): Support Markdown Math Rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8539,6 +8539,16 @@
         "node": ">= 18"
       }
     },
+    "node_modules/marked-katex-extension": {
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/marked-katex-extension/-/marked-katex-extension-5.1.8.tgz",
+      "integrity": "sha512-TsV9OCHHDjVBf4IH0RSjLs4Eqsjj8HGfmVCKlimrS391EtBBxzXj2gBYdF9tY7f7oXu9tb1kHV86ExJsG3iMhw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "katex": ">=0.16 <0.17",
+        "marked": ">=4 <19"
+      }
+    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "dev": true,
@@ -13337,6 +13347,7 @@
         "katex": "^0.16.45",
         "lucide-solid": "^0.300.0",
         "marked": "^12.0.0",
+        "marked-katex-extension": "^5.1.8",
         "monaco-editor": "^0.52.2",
         "qrcode": "^1.5.3",
         "shiki": "^3.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8306,6 +8306,31 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "dev": true,
@@ -13309,6 +13334,7 @@
         "ansi-sequence-parser": "^1.1.3",
         "debug": "^4.4.3",
         "github-markdown-css": "^5.8.1",
+        "katex": "^0.16.45",
         "lucide-solid": "^0.300.0",
         "marked": "^12.0.0",
         "monaco-editor": "^0.52.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -25,6 +25,7 @@
     "ansi-sequence-parser": "^1.1.3",
     "debug": "^4.4.3",
     "github-markdown-css": "^5.8.1",
+    "katex": "^0.16.45",
     "lucide-solid": "^0.300.0",
     "marked": "^12.0.0",
     "monaco-editor": "^0.52.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -28,6 +28,7 @@
     "katex": "^0.16.45",
     "lucide-solid": "^0.300.0",
     "marked": "^12.0.0",
+    "marked-katex-extension": "^5.1.8",
     "monaco-editor": "^0.52.2",
     "qrcode": "^1.5.3",
     "shiki": "^3.13.0",

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -4,7 +4,6 @@ import type { TextPart, RenderCache } from "../types/message"
 import { getLogger } from "../lib/logger"
 import { copyToClipboard } from "../lib/clipboard"
 import { useI18n } from "../lib/i18n"
-import "katex/dist/katex.min.css"
 
 const log = getLogger("session")
 

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -4,10 +4,23 @@ import type { TextPart, RenderCache } from "../types/message"
 import { getLogger } from "../lib/logger"
 import { copyToClipboard } from "../lib/clipboard"
 import { useI18n } from "../lib/i18n"
+import "katex/dist/katex.min.css"
 
 const log = getLogger("session")
 
 type MarkdownModule = typeof import("../lib/markdown")
+
+interface ResolvedMarkdownSnapshot {
+  part: TextPart
+  text: string
+  themeKey: string
+  highlightEnabled: boolean
+  escapeRawHtml: boolean
+  partId: string | undefined
+  cacheId: string
+  version: string
+  requestKey: string
+}
 
 let markdownModulePromise: Promise<MarkdownModule> | null = null
 
@@ -124,7 +137,7 @@ export function Markdown(props: MarkdownProps) {
   })
 
   const commitCacheEntry = (
-    snapshot: ReturnType<typeof resolved>,
+    snapshot: ResolvedMarkdownSnapshot,
     renderedHtml: string,
     options?: { cache?: boolean },
   ) => {
@@ -141,7 +154,7 @@ export function Markdown(props: MarkdownProps) {
     notifyRendered()
   }
 
-  const renderSnapshot = async (snapshot: ReturnType<typeof resolved>) => {
+  const renderSnapshot = async (snapshot: ResolvedMarkdownSnapshot): Promise<void> => {
     const markdown = await loadMarkdownModule()
     markdown.setMarkdownTheme(snapshot.themeKey === "dark")
     const rendered = await markdown.renderMarkdown(snapshot.text, {

--- a/packages/ui/src/lib/markdown.ts
+++ b/packages/ui/src/lib/markdown.ts
@@ -1,5 +1,5 @@
-import katex from "katex"
 import { marked } from "marked"
+import markedKatex from "marked-katex-extension"
 import { getLogger } from "./logger"
 import { tGlobal } from "./i18n"
 import type { Highlighter } from "shiki/bundle/full"
@@ -17,223 +17,10 @@ let rendererSetup = false
 let shikiModulePromise: Promise<typeof import("shiki/bundle/full")> | null = null
 let bundledLanguagesCache: typeof import("shiki/bundle/full")["bundledLanguages"] | null = null
 
-interface MathToken {
-  type: "blockMath" | "inlineMath"
-  raw: string
-  text: string
-  displayMode: boolean
-}
-
-interface InlineMathMatch {
-  raw: string
-  text: string
-}
-
-const blockMathPattern = /^\$\$([\s\S]+?)\$\$(?:\n+|$)/
-const bracketBlockMathPattern = /^\\\[([\s\S]+?)\\\](?:\n+|$)/
-const inlineParenMathPattern = /^\\\(([^\n]+?)\\\)/
-
-function normalizeMathContent(content: string): string {
-  return content.trim()
-}
-
-function canCloseInlineMath(raw: string): boolean {
-  if (raw.length < 2) {
-    return false
-  }
-
-  const content = raw.slice(1, -1)
-  if (!normalizeMathContent(content)) {
-    return false
-  }
-
-  return true
-}
-
-function canStartInlineMath(src: string): boolean {
-  const nextCharacter = src[1]
-  if (!nextCharacter) {
-    return false
-  }
-
-  if (nextCharacter === "$") {
-    return false
-  }
-
-  return true
-}
-
-function isInlineMathBoundaryCharacter(character: string | undefined): boolean {
-  if (!character) {
-    return true
-  }
-
-  return /[\s\p{P}]/u.test(character)
-}
-
-function hasInlineMathBoundaries(src: string, endIndex: number): boolean {
-  const nextCharacter = src[endIndex + 1]
-  return isInlineMathBoundaryCharacter(nextCharacter)
-}
-
-function matchDollarInlineMath(src: string): InlineMathMatch | undefined {
-  if (!src.startsWith("$") || src.startsWith("$$") || !canStartInlineMath(src)) {
-    return undefined
-  }
-
-  let isEscaped = false
-  for (let index = 1; index < src.length; index++) {
-    const character = src[index]
-    if (character === "\n") {
-      return undefined
-    }
-
-    if (character === "\\" && !isEscaped) {
-      isEscaped = true
-      continue
-    }
-
-    if (character === "$" && !isEscaped) {
-      const raw = src.slice(0, index + 1)
-      if (!canCloseInlineMath(raw)) {
-        return undefined
-      }
-
-      if (!hasInlineMathBoundaries(src, index)) {
-        return undefined
-      }
-
-      return {
-        raw,
-        text: raw.slice(1, -1),
-      }
-    }
-
-    isEscaped = false
-  }
-
-  return undefined
-}
-
-function renderMathToken(raw: string, content: string, displayMode: boolean): string {
-  const normalizedContent = normalizeMathContent(content)
-  if (!normalizedContent) {
-    return escapeHtml(raw)
-  }
-
-  try {
-    return katex.renderToString(normalizedContent, {
-      displayMode,
-      output: "html",
-      strict: "ignore",
-      throwOnError: false,
-    })
-  } catch {
-    return escapeHtml(raw)
-  }
-}
-
-function createBlockMathToken(raw: string, text: string): MathToken | undefined {
-  const normalizedText = normalizeMathContent(text)
-  if (!normalizedText) {
-    return undefined
-  }
-
-  return {
-    type: "blockMath",
-    raw,
-    text: normalizedText,
-    displayMode: true,
-  }
-}
-
-function createInlineMathToken(raw: string, text: string): MathToken | undefined {
-  if (!canCloseInlineMath(raw)) {
-    return undefined
-  }
-
-  return {
-    type: "inlineMath",
-    raw,
-    text,
-    displayMode: false,
-  }
-}
-
-function matchBlockMath(src: string): MathToken | undefined {
-  const dollarMatch = src.match(blockMathPattern)
-  if (dollarMatch) {
-    return createBlockMathToken(dollarMatch[0], dollarMatch[1] ?? "")
-  }
-
-  const bracketMatch = src.match(bracketBlockMathPattern)
-  if (bracketMatch) {
-    return createBlockMathToken(bracketMatch[0], bracketMatch[1] ?? "")
-  }
-
-  return undefined
-}
-
-function matchInlineMath(src: string): MathToken | undefined {
-  if (src.startsWith("\\(")) {
-    const parenMatch = src.match(inlineParenMathPattern)
-    if (!parenMatch) {
-      return undefined
-    }
-
-    return createInlineMathToken(parenMatch[0], parenMatch[1] ?? "")
-  }
-
-  const inlineMatch = matchDollarInlineMath(src)
-  if (!inlineMatch) {
-    return undefined
-  }
-
-  return createInlineMathToken(inlineMatch.raw, inlineMatch.text)
-}
-
-const mathMarkedExtensions = [
-  {
-    name: "blockMath",
-    level: "block" as const,
-    start(src: string): number | undefined {
-      const dollarIndex = src.indexOf("$$")
-      const bracketIndex = src.indexOf("\\[")
-      const indices = [dollarIndex, bracketIndex].filter((index) => index >= 0)
-      if (indices.length === 0) {
-        return undefined
-      }
-
-      return Math.min(...indices)
-    },
-    tokenizer(src: string): MathToken | undefined {
-      return matchBlockMath(src)
-    },
-    renderer(token: MathToken): string {
-      return renderMathToken(token.raw, token.text, token.displayMode)
-    },
-  },
-  {
-    name: "inlineMath",
-    level: "inline" as const,
-    start(src: string): number | undefined {
-      const dollarIndex = src.indexOf("$")
-      const parenIndex = src.indexOf("\\(")
-      const indices = [dollarIndex, parenIndex].filter((index) => index >= 0)
-      if (indices.length === 0) {
-        return undefined
-      }
-
-      return Math.min(...indices)
-    },
-    tokenizer(src: string): MathToken | undefined {
-      return matchInlineMath(src)
-    },
-    renderer(token: MathToken): string {
-      return renderMathToken(token.raw, token.text, token.displayMode)
-    },
-  },
-]
+// Math rendering is handled by marked-katex-extension (registered in setupRenderer).
+// Delimiter rules, boundaries, CJK punctuation, and block/inline rendering are
+// all delegated to the maintained extension so we avoid ~200 lines of fragile
+// hand-rolled tokenizer code.
 
 const ALLOWED_RAW_HTML_TAGS = new Set([
   "a",
@@ -593,9 +380,11 @@ function setupRenderer(isDark: boolean) {
     gfm: true,
   })
 
-  marked.use({
-    extensions: mathMarkedExtensions,
-  })
+  marked.use(markedKatex({
+    throwOnError: false,
+    nonStandard: true,
+    strict: "ignore",
+  }))
 
   const renderer = new marked.Renderer()
 

--- a/packages/ui/src/lib/markdown.ts
+++ b/packages/ui/src/lib/markdown.ts
@@ -31,15 +31,10 @@ interface InlineMathMatch {
 
 const blockMathPattern = /^\$\$([\s\S]+?)\$\$(?:\n+|$)/
 const bracketBlockMathPattern = /^\\\[([\s\S]+?)\\\](?:\n+|$)/
-const inlineParenMathPattern = /^\\\(([\s\S]+?)\\\)/
+const inlineParenMathPattern = /^\\\(([^\n]+?)\\\)/
 
 function normalizeMathContent(content: string): string {
   return content.trim()
-}
-
-function canOpenInlineMath(src: string): boolean {
-  const nextCharacter = src[1]
-  return Boolean(nextCharacter) && !/\s/.test(nextCharacter)
 }
 
 function canCloseInlineMath(raw: string): boolean {
@@ -48,15 +43,41 @@ function canCloseInlineMath(raw: string): boolean {
   }
 
   const content = raw.slice(1, -1)
-  if (!content || /\s$/.test(content)) {
+  if (!normalizeMathContent(content)) {
     return false
   }
 
   return true
 }
 
+function canStartInlineMath(src: string): boolean {
+  const nextCharacter = src[1]
+  if (!nextCharacter) {
+    return false
+  }
+
+  if (nextCharacter === "$") {
+    return false
+  }
+
+  return true
+}
+
+function isInlineMathBoundaryCharacter(character: string | undefined): boolean {
+  if (!character) {
+    return true
+  }
+
+  return /\s|[({\[<>'"“”‘’,;:!?)]/.test(character)
+}
+
+function hasInlineMathBoundaries(src: string, endIndex: number): boolean {
+  const nextCharacter = src[endIndex + 1]
+  return isInlineMathBoundaryCharacter(nextCharacter)
+}
+
 function matchDollarInlineMath(src: string): InlineMathMatch | undefined {
-  if (!src.startsWith("$") || src.startsWith("$$") || !canOpenInlineMath(src)) {
+  if (!src.startsWith("$") || src.startsWith("$$") || !canStartInlineMath(src)) {
     return undefined
   }
 
@@ -78,6 +99,10 @@ function matchDollarInlineMath(src: string): InlineMathMatch | undefined {
         return undefined
       }
 
+      if (!hasInlineMathBoundaries(src, index)) {
+        return undefined
+      }
+
       return {
         raw,
         text: raw.slice(1, -1),
@@ -90,10 +115,10 @@ function matchDollarInlineMath(src: string): InlineMathMatch | undefined {
   return undefined
 }
 
-function renderMathToken(content: string, displayMode: boolean): string {
+function renderMathToken(raw: string, content: string, displayMode: boolean): string {
   const normalizedContent = normalizeMathContent(content)
   if (!normalizedContent) {
-    return escapeHtml(content)
+    return escapeHtml(raw)
   }
 
   try {
@@ -104,7 +129,7 @@ function renderMathToken(content: string, displayMode: boolean): string {
       throwOnError: false,
     })
   } catch {
-    return escapeHtml(content)
+    return escapeHtml(raw)
   }
 }
 
@@ -185,7 +210,7 @@ const mathMarkedExtensions = [
       return matchBlockMath(src)
     },
     renderer(token: MathToken): string {
-      return renderMathToken(token.text, token.displayMode)
+      return renderMathToken(token.raw, token.text, token.displayMode)
     },
   },
   {
@@ -205,7 +230,7 @@ const mathMarkedExtensions = [
       return matchInlineMath(src)
     },
     renderer(token: MathToken): string {
-      return renderMathToken(token.text, token.displayMode)
+      return renderMathToken(token.raw, token.text, token.displayMode)
     },
   },
 ]

--- a/packages/ui/src/lib/markdown.ts
+++ b/packages/ui/src/lib/markdown.ts
@@ -68,7 +68,7 @@ function isInlineMathBoundaryCharacter(character: string | undefined): boolean {
     return true
   }
 
-  return /\s|[({\[<>'"“”‘’,;:!?)）】》」』、。，；：？！…—]/.test(character)
+  return /[\s\p{P}]/u.test(character)
 }
 
 function hasInlineMathBoundaries(src: string, endIndex: number): boolean {

--- a/packages/ui/src/lib/markdown.ts
+++ b/packages/ui/src/lib/markdown.ts
@@ -68,7 +68,7 @@ function isInlineMathBoundaryCharacter(character: string | undefined): boolean {
     return true
   }
 
-  return /\s|[({\[<>'"“”‘’,;:!?)]/.test(character)
+  return /\s|[({\[<>'"“”‘’,;:!?)）】》」』、。，；：？！…—]/.test(character)
 }
 
 function hasInlineMathBoundaries(src: string, endIndex: number): boolean {

--- a/packages/ui/src/lib/markdown.ts
+++ b/packages/ui/src/lib/markdown.ts
@@ -1,3 +1,4 @@
+import katex from "katex"
 import { marked } from "marked"
 import { getLogger } from "./logger"
 import { tGlobal } from "./i18n"
@@ -15,6 +16,199 @@ let escapeRawHtmlEnabled = false
 let rendererSetup = false
 let shikiModulePromise: Promise<typeof import("shiki/bundle/full")> | null = null
 let bundledLanguagesCache: typeof import("shiki/bundle/full")["bundledLanguages"] | null = null
+
+interface MathToken {
+  type: "blockMath" | "inlineMath"
+  raw: string
+  text: string
+  displayMode: boolean
+}
+
+interface InlineMathMatch {
+  raw: string
+  text: string
+}
+
+const blockMathPattern = /^\$\$([\s\S]+?)\$\$(?:\n+|$)/
+const bracketBlockMathPattern = /^\\\[([\s\S]+?)\\\](?:\n+|$)/
+const inlineParenMathPattern = /^\\\(([\s\S]+?)\\\)/
+
+function normalizeMathContent(content: string): string {
+  return content.trim()
+}
+
+function canOpenInlineMath(src: string): boolean {
+  const nextCharacter = src[1]
+  return Boolean(nextCharacter) && !/\s/.test(nextCharacter)
+}
+
+function canCloseInlineMath(raw: string): boolean {
+  if (raw.length < 2) {
+    return false
+  }
+
+  const content = raw.slice(1, -1)
+  if (!content || /\s$/.test(content)) {
+    return false
+  }
+
+  return true
+}
+
+function matchDollarInlineMath(src: string): InlineMathMatch | undefined {
+  if (!src.startsWith("$") || src.startsWith("$$") || !canOpenInlineMath(src)) {
+    return undefined
+  }
+
+  let isEscaped = false
+  for (let index = 1; index < src.length; index++) {
+    const character = src[index]
+    if (character === "\n") {
+      return undefined
+    }
+
+    if (character === "\\" && !isEscaped) {
+      isEscaped = true
+      continue
+    }
+
+    if (character === "$" && !isEscaped) {
+      const raw = src.slice(0, index + 1)
+      if (!canCloseInlineMath(raw)) {
+        return undefined
+      }
+
+      return {
+        raw,
+        text: raw.slice(1, -1),
+      }
+    }
+
+    isEscaped = false
+  }
+
+  return undefined
+}
+
+function renderMathToken(content: string, displayMode: boolean): string {
+  const normalizedContent = normalizeMathContent(content)
+  if (!normalizedContent) {
+    return escapeHtml(content)
+  }
+
+  try {
+    return katex.renderToString(normalizedContent, {
+      displayMode,
+      output: "html",
+      strict: "ignore",
+      throwOnError: false,
+    })
+  } catch {
+    return escapeHtml(content)
+  }
+}
+
+function createBlockMathToken(raw: string, text: string): MathToken | undefined {
+  const normalizedText = normalizeMathContent(text)
+  if (!normalizedText) {
+    return undefined
+  }
+
+  return {
+    type: "blockMath",
+    raw,
+    text: normalizedText,
+    displayMode: true,
+  }
+}
+
+function createInlineMathToken(raw: string, text: string): MathToken | undefined {
+  if (!canCloseInlineMath(raw)) {
+    return undefined
+  }
+
+  return {
+    type: "inlineMath",
+    raw,
+    text,
+    displayMode: false,
+  }
+}
+
+function matchBlockMath(src: string): MathToken | undefined {
+  const dollarMatch = src.match(blockMathPattern)
+  if (dollarMatch) {
+    return createBlockMathToken(dollarMatch[0], dollarMatch[1] ?? "")
+  }
+
+  const bracketMatch = src.match(bracketBlockMathPattern)
+  if (bracketMatch) {
+    return createBlockMathToken(bracketMatch[0], bracketMatch[1] ?? "")
+  }
+
+  return undefined
+}
+
+function matchInlineMath(src: string): MathToken | undefined {
+  if (src.startsWith("\\(")) {
+    const parenMatch = src.match(inlineParenMathPattern)
+    if (!parenMatch) {
+      return undefined
+    }
+
+    return createInlineMathToken(parenMatch[0], parenMatch[1] ?? "")
+  }
+
+  const inlineMatch = matchDollarInlineMath(src)
+  if (!inlineMatch) {
+    return undefined
+  }
+
+  return createInlineMathToken(inlineMatch.raw, inlineMatch.text)
+}
+
+const mathMarkedExtensions = [
+  {
+    name: "blockMath",
+    level: "block" as const,
+    start(src: string): number | undefined {
+      const dollarIndex = src.indexOf("$$")
+      const bracketIndex = src.indexOf("\\[")
+      const indices = [dollarIndex, bracketIndex].filter((index) => index >= 0)
+      if (indices.length === 0) {
+        return undefined
+      }
+
+      return Math.min(...indices)
+    },
+    tokenizer(src: string): MathToken | undefined {
+      return matchBlockMath(src)
+    },
+    renderer(token: MathToken): string {
+      return renderMathToken(token.text, token.displayMode)
+    },
+  },
+  {
+    name: "inlineMath",
+    level: "inline" as const,
+    start(src: string): number | undefined {
+      const dollarIndex = src.indexOf("$")
+      const parenIndex = src.indexOf("\\(")
+      const indices = [dollarIndex, parenIndex].filter((index) => index >= 0)
+      if (indices.length === 0) {
+        return undefined
+      }
+
+      return Math.min(...indices)
+    },
+    tokenizer(src: string): MathToken | undefined {
+      return matchInlineMath(src)
+    },
+    renderer(token: MathToken): string {
+      return renderMathToken(token.text, token.displayMode)
+    },
+  },
+]
 
 const ALLOWED_RAW_HTML_TAGS = new Set([
   "a",
@@ -372,6 +566,10 @@ function setupRenderer(isDark: boolean) {
   marked.setOptions({
     breaks: true,
     gfm: true,
+  })
+
+  marked.use({
+    extensions: mathMarkedExtensions,
   })
 
   const renderer = new marked.Renderer()

--- a/packages/ui/src/styles/markdown.css
+++ b/packages/ui/src/styles/markdown.css
@@ -1,4 +1,5 @@
-@import "github-markdown-css/github-markdown-light.css" layer(github-markdown-base);
+@import "github-markdown-css/github-markdown-light.css"
+  layer(github-markdown-base);
 @import "katex/dist/katex.min.css" layer(katex-base);
 
 @layer katex-overrides {
@@ -10,6 +11,11 @@
 
   .markdown-body .katex {
     font-size: 1.05em;
+  }
+
+  .markdown-body .katex .frac-line {
+    border-bottom-width: 0.1em !important;
+    border-color: currentColor !important;
   }
 }
 
@@ -252,7 +258,10 @@
     border-radius: 4px;
     cursor: pointer;
     color: var(--text-secondary);
-    transition: background-color 150ms ease, color 150ms ease, border-color 150ms ease;
+    transition:
+      background-color 150ms ease,
+      color 150ms ease,
+      border-color 150ms ease;
     margin-inline-start: auto;
     font-size: var(--font-size-sm);
   }

--- a/packages/ui/src/styles/markdown.css
+++ b/packages/ui/src/styles/markdown.css
@@ -1,6 +1,16 @@
 @import "github-markdown-css/github-markdown-light.css" layer(github-markdown-base);
 
 @layer components {
+  .markdown-body .katex-display {
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: 0.25rem 0;
+  }
+
+  .markdown-body .katex {
+    font-size: 1.05em;
+  }
+
   .markdown-body {
     max-width: none;
     background-color: transparent;

--- a/packages/ui/src/styles/markdown.css
+++ b/packages/ui/src/styles/markdown.css
@@ -1,6 +1,7 @@
 @import "github-markdown-css/github-markdown-light.css" layer(github-markdown-base);
+@import "katex/dist/katex.min.css" layer(katex-base);
 
-@layer components {
+@layer katex-overrides {
   .markdown-body .katex-display {
     overflow-x: auto;
     overflow-y: hidden;
@@ -10,7 +11,9 @@
   .markdown-body .katex {
     font-size: 1.05em;
   }
+}
 
+@layer components {
   .markdown-body {
     max-width: none;
     background-color: transparent;


### PR DESCRIPTION
Add `KaTeX` extension for math formula rendering

It solves the issue #379 .

Now the interface acts like this when processing formulas:

`$\mathbb{R}$`:
<img width="1016" height="83" alt="image" src="https://github.com/user-attachments/assets/7a7534c0-3128-4a98-a01f-336db42e0f26" />

`$$ \mathbb{R} $$`:
<img width="1016" height="89" alt="image" src="https://github.com/user-attachments/assets/9da7d2e4-06cc-41e8-b598-eab8b3be7677" />

```markdown
$$
\mathbb{R}
$$
```
:
<img width="1016" height="88" alt="image" src="https://github.com/user-attachments/assets/a1be91e3-7ff1-4cf9-8982-c2657348317d" />


Closes #379 