### PR TITLE
[Bug] Fix "Fail to Load Agent Properly When Opening"

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -322,6 +322,7 @@ async function main() {
   const binaryResolver = new BinaryResolver(settings)
   const workspaceManager = new WorkspaceManager({
     rootDir: options.rootDir,
+    configDir,
     settings,
     binaryResolver,
     eventBus,

--- a/packages/server/src/opencode-config.ts
+++ b/packages/server/src/opencode-config.ts
@@ -1,4 +1,5 @@
-import { existsSync } from "fs"
+import { cpSync, existsSync, mkdirSync, rmSync } from "fs"
+import os from "os"
 import path from "path"
 import { fileURLToPath } from "url"
 import { createLogger } from "./logger"
@@ -17,15 +18,37 @@ const isDevBuild = Boolean(process.env.CODENOMAD_DEV ?? process.env.CLI_UI_DEV_S
 const templateDir = isDevBuild
   ? devTemplateDir
   : prodTemplateDirs.find((dir) => existsSync(dir)) ?? prodTemplateDirs[0]
+const userConfigDir = path.join(os.homedir(), ".config", "opencode")
+const mergedConfigDir = path.join(os.homedir(), ".config", "codenomad", "opencode-config")
+
+function copyConfigDirectory(source: string, target: string): void {
+  cpSync(source, target, {
+    recursive: true,
+    force: true,
+    dereference: true,
+  })
+}
+
+function prepareMergedConfigDir(): string {
+  rmSync(mergedConfigDir, { recursive: true, force: true })
+  mkdirSync(mergedConfigDir, { recursive: true })
+
+  copyConfigDirectory(templateDir, mergedConfigDir)
+
+  if (existsSync(userConfigDir)) {
+    copyConfigDirectory(userConfigDir, mergedConfigDir)
+    log.debug({ templateDir, userConfigDir, mergedConfigDir }, "Using merged OpenCode config")
+  } else {
+    log.debug({ templateDir, mergedConfigDir }, "Using generated OpenCode config without user overlay")
+  }
+
+  return mergedConfigDir
+}
 
 export function getOpencodeConfigDir(): string {
   if (!existsSync(templateDir)) {
     throw new Error(`CodeNomad Opencode config template missing at ${templateDir}`)
   }
 
-  if (isDevBuild) {
-    log.debug({ templateDir }, "Using Opencode config template directly (dev mode)")
-  }
-
-  return templateDir
+  return prepareMergedConfigDir()
 }

--- a/packages/server/src/opencode-config.ts
+++ b/packages/server/src/opencode-config.ts
@@ -19,7 +19,6 @@ const templateDir = isDevBuild
   ? devTemplateDir
   : prodTemplateDirs.find((dir) => existsSync(dir)) ?? prodTemplateDirs[0]
 const userConfigDir = path.join(os.homedir(), ".config", "opencode")
-const mergedConfigDir = path.join(os.homedir(), ".config", "codenomad", "opencode-config")
 
 function copyConfigDirectory(source: string, target: string): void {
   cpSync(source, target, {
@@ -29,7 +28,16 @@ function copyConfigDirectory(source: string, target: string): void {
   })
 }
 
-function prepareMergedConfigDir(): string {
+function copyBridgePlugin(target: string): void {
+  const bridgePluginDir = path.join(templateDir, "plugin")
+  if (existsSync(bridgePluginDir)) {
+    copyConfigDirectory(bridgePluginDir, path.join(target, "plugin"))
+  }
+}
+
+function prepareMergedConfigDir(baseDir: string): string {
+  const mergedConfigDir = path.join(baseDir, "opencode-config")
+
   rmSync(mergedConfigDir, { recursive: true, force: true })
   mkdirSync(mergedConfigDir, { recursive: true })
 
@@ -37,6 +45,7 @@ function prepareMergedConfigDir(): string {
 
   if (existsSync(userConfigDir)) {
     copyConfigDirectory(userConfigDir, mergedConfigDir)
+    copyBridgePlugin(mergedConfigDir)
     log.debug({ templateDir, userConfigDir, mergedConfigDir }, "Using merged OpenCode config")
   } else {
     log.debug({ templateDir, mergedConfigDir }, "Using generated OpenCode config without user overlay")
@@ -45,10 +54,10 @@ function prepareMergedConfigDir(): string {
   return mergedConfigDir
 }
 
-export function getOpencodeConfigDir(): string {
+export function getOpencodeConfigDir(baseDir: string): string {
   if (!existsSync(templateDir)) {
     throw new Error(`CodeNomad Opencode config template missing at ${templateDir}`)
   }
 
-  return prepareMergedConfigDir()
+  return prepareMergedConfigDir(baseDir)
 }

--- a/packages/server/src/workspaces/manager.ts
+++ b/packages/server/src/workspaces/manager.ts
@@ -22,6 +22,7 @@ const STARTUP_STABILITY_DELAY_MS = 1500
 
 interface WorkspaceManagerOptions {
   rootDir: string
+  configDir: string
   settings: SettingsService
   binaryResolver: BinaryResolver
   eventBus: EventBus
@@ -41,7 +42,7 @@ export class WorkspaceManager {
 
   constructor(private readonly options: WorkspaceManagerOptions) {
     this.runtime = new WorkspaceRuntime(this.options.eventBus, this.options.logger)
-    this.opencodeConfigDir = getOpencodeConfigDir()
+    this.opencodeConfigDir = getOpencodeConfigDir(this.options.configDir)
   }
 
   list(): WorkspaceDescriptor[] {

--- a/packages/ui/src/components/agent-selector.tsx
+++ b/packages/ui/src/components/agent-selector.tsx
@@ -1,5 +1,5 @@
 import { Select } from "@kobalte/core/select"
-import { For, Show, createEffect, createMemo } from "solid-js"
+import { Show, createEffect, createMemo } from "solid-js"
 import { agents, fetchAgents, sessions } from "../stores/sessions"
 import { ChevronDown } from "lucide-solid"
 import { isSelectablePrimaryAgent, type Agent } from "../types/session"

--- a/packages/ui/src/components/agent-selector.tsx
+++ b/packages/ui/src/components/agent-selector.tsx
@@ -2,7 +2,7 @@ import { Select } from "@kobalte/core/select"
 import { For, Show, createEffect, createMemo } from "solid-js"
 import { agents, fetchAgents, sessions } from "../stores/sessions"
 import { ChevronDown } from "lucide-solid"
-import type { Agent } from "../types/session"
+import { isSelectablePrimaryAgent, type Agent } from "../types/session"
 import { useI18n } from "../lib/i18n"
 import { getLogger } from "../lib/logger"
 const log = getLogger("session")
@@ -34,14 +34,7 @@ export default function AgentSelector(props: AgentSelectorProps) {
       return allAgents.filter((agent) => !agent.hidden)
     }
 
-    const filtered = allAgents.filter((agent) => !agent.hidden && agent.mode !== "subagent")
-
-    const currentAgent = allAgents.find((a) => a.name === props.currentAgent)
-    if (currentAgent && !filtered.find((a) => a.name === props.currentAgent)) {
-      return [currentAgent, ...filtered]
-    }
-
-    return filtered
+    return allAgents.filter(isSelectablePrimaryAgent)
   })
 
   createEffect(() => {
@@ -57,7 +50,6 @@ export default function AgentSelector(props: AgentSelectorProps) {
       fetchAgents(props.instanceId).catch((error) => log.error("Failed to fetch agents", error))
     }
   })
-
 
   const handleChange = async (value: Agent | null) => {
     if (value && value.name !== props.currentAgent) {

--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -1,4 +1,4 @@
-import { mapSdkSessionRetry, mapSdkSessionStatus, type Session, type SessionStatus } from "../types/session"
+import { isSelectablePrimaryAgent, mapSdkSessionRetry, mapSdkSessionStatus, type Agent, type Session, type SessionStatus } from "../types/session"
 import type { Message } from "../types/message"
 import type { FileDiff } from "@opencode-ai/sdk/v2/client"
 
@@ -45,6 +45,50 @@ import {
 const log = getLogger("api")
 
 const pendingSessionDiffFetches = new Map<string, Promise<void>>()
+const AGENT_FETCH_RETRY_DELAYS_MS = [0, 500, 1000, 1000, 1000, 1000]
+const MIN_PLUGIN_AGENT_WAIT_MS = 2500
+
+type RootClient = ReturnType<typeof getRootClient>
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function mapAgents(agentList: Awaited<ReturnType<RootClient["app"]["agents"]>>["data"] = []): Agent[] {
+  return agentList.map((agent) => ({
+    name: agent.name,
+    description: agent.description || "",
+    mode: agent.mode,
+    native: agent.native,
+    hidden: agent.hidden,
+    model: agent.model?.modelID
+      ? {
+          providerId: agent.model.providerID || "",
+          modelId: agent.model.modelID,
+        }
+      : undefined,
+  }))
+}
+
+function agentSignature(agentList: Agent[]): string {
+  return agentList.map((agent) => `${agent.name}:${agent.mode}:${agent.hidden ? "1" : "0"}:${agent.native ? "1" : "0"}`).sort().join("|")
+}
+
+function hasExpectedOmoPrimaryAgents(agentList: Agent[]): boolean {
+  const names = new Set(agentList.map((agent) => agent.name.toLowerCase()))
+  return names.has("atlas") && names.has("sisyphus") && names.has("hephaestus")
+}
+
+async function getConfiguredPluginNames(rootClient: RootClient): Promise<string[]> {
+  try {
+    const response = await rootClient.config.get()
+    const config = response.data as { plugin?: unknown } | undefined
+    return Array.isArray(config?.plugin) ? config.plugin.filter((plugin): plugin is string => typeof plugin === "string") : []
+  } catch (error) {
+    log.warn("Failed to inspect configured plugins before fetching agents", error)
+    return []
+  }
+}
 
 async function loadSessionDiff(instanceId: string, sessionId: string, force = false): Promise<void> {
   if (!instanceId || !sessionId) return
@@ -236,8 +280,8 @@ async function createSession(instanceId: string, agent?: string): Promise<Sessio
   const client = getOrCreateWorktreeClient(instanceId, worktreeSlug)
 
   const instanceAgents = agents().get(instanceId) || []
-  const nonSubagents = instanceAgents.filter((a) => a.mode !== "subagent")
-  const selectedAgent = agent || (nonSubagents.length > 0 ? nonSubagents[0].name : "")
+  const primaryAgents = instanceAgents.filter(isSelectablePrimaryAgent)
+  const selectedAgent = agent || (primaryAgents.length > 0 ? primaryAgents[0].name : "")
 
   const defaultModel = await getDefaultModel(instanceId, selectedAgent)
 
@@ -524,20 +568,33 @@ async function fetchAgents(instanceId: string): Promise<void> {
   const rootClient = getRootClient(instanceId)
 
   try {
-    log.info(`[HTTP] GET /app.agents for instance ${instanceId}`)
-    const response = await rootClient.app.agents()
-    const agentList = (response.data ?? []).map((agent) => ({
-      name: agent.name,
-      description: agent.description || "",
-      mode: agent.mode,
-      hidden: agent.hidden,
-      model: agent.model?.modelID
-        ? {
-            providerId: agent.model.providerID || "",
-            modelId: agent.model.modelID,
-          }
-        : undefined,
-    }))
+    const pluginNames = await getConfiguredPluginNames(rootClient)
+    const waitsForOmoAgents = pluginNames.some((plugin) => plugin.includes("oh-my-openagent"))
+    const waitsForPluginAgents = pluginNames.length > 0
+
+    let agentList: Agent[] = []
+    let previousSignature = ""
+    let stableSamples = 0
+    let elapsed = 0
+
+    for (const delay of waitsForPluginAgents ? AGENT_FETCH_RETRY_DELAYS_MS : [0]) {
+      if (delay > 0) {
+        await sleep(delay)
+        elapsed += delay
+      }
+
+      log.info(`[HTTP] GET /app.agents for instance ${instanceId}`)
+      const response = await rootClient.app.agents()
+      agentList = mapAgents(response.data ?? [])
+
+      const signature = agentSignature(agentList)
+      stableSamples = signature === previousSignature ? stableSamples + 1 : 0
+      previousSignature = signature
+
+      if (!waitsForPluginAgents) break
+      if (waitsForOmoAgents && hasExpectedOmoPrimaryAgents(agentList)) break
+      if (elapsed >= MIN_PLUGIN_AGENT_WAIT_MS && stableSamples > 0) break
+    }
 
     setAgents((prev) => {
       const next = new Map(prev)

--- a/packages/ui/src/types/session.ts
+++ b/packages/ui/src/types/session.ts
@@ -94,8 +94,13 @@ export interface Agent {
   }
 }
 
+/**
+ * Matches OpenCode TUI's agent visibility rule: visible iff not a subagent and not hidden.
+ * Native/system agents like `build` are included so they appear when no plugin disables them,
+ * just as they do in OpenCode TUI.
+ */
 export function isSelectablePrimaryAgent(agent: Agent): boolean {
-  return !agent.hidden && !agent.native && agent.mode === "primary"
+  return !agent.hidden && agent.mode !== "subagent"
 }
 
 // Our client-specific Provider interface (simplified version of SDK Provider)

--- a/packages/ui/src/types/session.ts
+++ b/packages/ui/src/types/session.ts
@@ -86,11 +86,16 @@ export interface Agent {
   name: string
   description: string
   mode: string
+  native?: boolean
   hidden?: boolean
   model?: {
     providerId: string
     modelId: string
   }
+}
+
+export function isSelectablePrimaryAgent(agent: Agent): boolean {
+  return !agent.hidden && !agent.native && agent.mode === "primary"
 }
 
 // Our client-specific Provider interface (simplified version of SDK Provider)


### PR DESCRIPTION
## Summary

- Merge the user's OpenCode config into CodeNomad-launched OpenCode instances while preserving CodeNomad's bridge plugin.
- Stabilize agent fetching when plugins are configured.
- Restrict the bottom-left primary agent selector to valid selectable primary agents only.

## Problem

CodeNomad launches OpenCode with its own `OPENCODE_CONFIG_DIR`, so user-configured OpenCode plugins are not loaded. This makes plugin-provided primary agents, such as Sisyphus and Hephaestus from `oh-my-openagent`, unavailable in CodeNomad even though they work in OpenCode TUI.

After user agents are available, native/internal agents such as `build` can still be auto-selected or temporarily shown in the primary agent selector because the UI treats any non-subagent as selectable.

## Changes

- Generate a merged OpenCode config directory for workspaces:
  - Start from CodeNomad's packaged config so the bridge plugin remains available.
  - Overlay the user's `~/.config/opencode` config.
  - Use the merged directory as `OPENCODE_CONFIG_DIR`.
- Retry `/agent` briefly when plugins are configured so plugin agents have time to register.
- Preserve the SDK `native` field in the UI `Agent` type.
- Add `isSelectablePrimaryAgent(agent)`.
- Use the shared selectable-primary predicate for:
  - New session default agent selection.
  - Bottom-left parent-session agent selector options.
- Stop force-inserting invalid current agents such as `build` into the primary selector list.

## Validation

- `npm run typecheck --workspace @codenomad/ui`
- `npm run typecheck --workspace @neuralnomads/codenomad`


close issue #384 