### PR TITLE
fix(ui): scope session list by workspace folder

### DIFF
--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -123,8 +123,8 @@ async function fetchSessions(instanceId: string): Promise<void> {
   })
 
   try {
-    log.info("session.list", { instanceId })
-    const response = await rootClient.session.list()
+    log.info("session.list", { instanceId, directory: instance.folder })
+    const response = await rootClient.session.list({ directory: instance.folder })
 
     const sessionMap = new Map<string, Session>()
 

--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -123,8 +123,14 @@ async function fetchSessions(instanceId: string): Promise<void> {
   })
 
   try {
-    log.info("session.list", { instanceId, directory: instance.folder })
-    const response = await rootClient.session.list({ directory: instance.folder })
+    const projectResponse = await rootClient.project.current()
+    const projectId = projectResponse.data?.id
+    const sessionListOptions = projectId === "global" ? { directory: instance.folder } : undefined
+
+    log.info("session.list", { instanceId, projectId, directory: sessionListOptions?.directory })
+    const response = sessionListOptions
+      ? await rootClient.session.list(sessionListOptions)
+      : await rootClient.session.list()
 
     const sessionMap = new Map<string, Session>()
 


### PR DESCRIPTION
## Summary

- Scope session listing requests to the current workspace folder by passing `directory: instance.folder` to OpenCode.
- Prevent non-git workspace sessions from leaking across projects when OpenCode stores them under the shared `global` project.
- Include the scoped directory in session list logs for easier debugging.

## Why

OpenCode groups non-git folders under the shared `global` project. CodeNomad previously called `session.list()` without a directory filter, so fresh non-git folders could show sessions from unrelated folders.

## Testing

- `npm ci`
- `npm run typecheck --workspace @codenomad/ui`