### PR TITLE
fix(tauri): refresh bundled resources on rebuild

### DIFF
--- a/packages/tauri-app/src-tauri/build.rs
+++ b/packages/tauri-app/src-tauri/build.rs
@@ -1,6 +1,25 @@
 fn main() {
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set by Cargo");
-    let resources_node = std::path::Path::new(&manifest_dir).join("resources/node");
-    std::fs::create_dir_all(resources_node).expect("create resources/node placeholder");
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR is set by Cargo");
+    let manifest_path = std::path::Path::new(&manifest_dir);
+    let bundled_resources = std::path::Path::new(&out_dir)
+        .ancestors()
+        .nth(3)
+        .expect("OUT_DIR points inside target/<profile>/build/<pkg>/out")
+        .join("resources");
+    let resources_root = manifest_path.join("resources");
+    let resources_node = resources_root.join("node");
+    std::fs::create_dir_all(&resources_node).expect("create resources/node placeholder");
+
+    // Tauri copies resources additively, so clear the old output first.
+    if bundled_resources.exists() {
+        std::fs::remove_dir_all(&bundled_resources).expect("clean bundled resources output");
+    }
+
+    println!("cargo:rerun-if-changed={}", manifest_path.join("tauri.conf.json").display());
+    println!("cargo:rerun-if-changed={}", resources_root.join("node").display());
+    println!("cargo:rerun-if-changed={}", resources_root.join("server").display());
+    println!("cargo:rerun-if-changed={}", resources_root.join("ui-loading").display());
+
     tauri_build::build()
 }


### PR DESCRIPTION
## Summary
- Re-run the Tauri build script when bundled desktop resources change.
- Clear stale `target/<profile>/resources` output before Tauri recopies resources.
- Keeps raw Tauri release builds from launching stale server/UI resources after `bundle:server`.

## Verification
- `npm run bundle:server --workspace @codenomad/tauri-app && cargo build --release --manifest-path "packages/tauri-app/src-tauri/Cargo.toml"`
- Verified `target/release/resources/server/package.json` and `server/public/ui-version.json` report `0.15.0`.
- Verified `target/release/resources/node/win32-x64/node.exe` is present.
- Performed incremental add/update/delete checks under `src-tauri/resources` and confirmed `target/release/resources` resyncs without manual clean.