### PR TITLE
fix(tauri): prefer bundled server entry in release

### DIFF
--- a/packages/tauri-app/src-tauri/src/cli_manager.rs
+++ b/packages/tauri-app/src-tauri/src/cli_manager.rs
@@ -1215,10 +1215,7 @@ fn resolve_dev_entry(_app: &AppHandle) -> Option<String> {
 }
 
 fn resolve_prod_entry(_app: &AppHandle) -> Option<String> {
-    let base = workspace_root();
-    let mut candidates = vec![base
-        .as_ref()
-        .map(|p| p.join("packages/server/dist/bin.js"))];
+    let mut candidates = Vec::new();
 
     if let Ok(exe) = std::env::current_exe() {
         if let Some(dir) = exe.parent() {
@@ -1235,6 +1232,12 @@ fn resolve_prod_entry(_app: &AppHandle) -> Option<String> {
             }
         }
     }
+
+    let base = workspace_root();
+    candidates.push(
+        base.as_ref()
+            .map(|p| p.join("packages/server/dist/bin.js")),
+    );
 
     first_existing(candidates)
 }


### PR DESCRIPTION
## Why
When running the Tauri release executable from `target/release`, the app should start the server bundle that was packaged next to the executable:

`target/release/resources/server/dist/bin.js`

Before this change, `resolve_prod_entry()` checked the workspace build first:

`packages/server/dist/bin.js`

That can make a release run depend on the local checkout instead of the packaged resources. It also makes rebuild/runtime checks misleading, because the exe may appear to work while using files outside the release bundle.

## What Changed
- Check bundled release resource paths first when resolving the production server entry.
- Keep the workspace `packages/server/dist/bin.js` path as a fallback.

## Validation
- Verified the change is limited to production entry resolution in `cli_manager.rs`.
- This was discovered while launching the rebuilt Tauri release executable and checking that the spawned Node process used `target/release/resources/server/dist`.