### PR TITLE
fix(ui): keep update release link visible

### DIFF
--- a/packages/ui/src/components/version-pill.tsx
+++ b/packages/ui/src/components/version-pill.tsx
@@ -2,10 +2,13 @@ import { Show, createEffect, createSignal } from "solid-js"
 import type { ServerMeta } from "../../../server/src/api-types"
 import { getServerMeta } from "../lib/server-meta"
 import { useI18n } from "../lib/i18n"
+import { openExternalUrl } from "../lib/external-url"
+import { useAvailableUpdate } from "../stores/releases"
 
 export default function VersionPill() {
   const { t } = useI18n()
   const [meta, setMeta] = createSignal<ServerMeta | null>(null)
+  const availableUpdate = useAvailableUpdate()
 
   createEffect(() => {
     void getServerMeta()
@@ -16,7 +19,7 @@ export default function VersionPill() {
   const serverVersion = () => meta()?.serverVersion
   const uiVersion = () => meta()?.ui?.version
   const uiSource = () => meta()?.ui?.source
-  const update = () => meta()?.update
+  const update = () => availableUpdate() ?? meta()?.update ?? null
 
   const uiLabel = () => (uiVersion() ? t("versionPill.uiWithVersion", { version: uiVersion() }) : t("versionPill.ui"))
 
@@ -49,6 +52,10 @@ export default function VersionPill() {
                 rel="noreferrer"
                 class="text-primary hover:underline underline-offset-2"
                 title={t("releases.devUpdateAvailable.message", { version: release().version })}
+                onClick={(event) => {
+                  event.preventDefault()
+                  void openExternalUrl(release().url, "version-pill")
+                }}
               >
                 {t("releases.devUpdateAvailable.action")}
               </a>

--- a/packages/ui/src/components/version-pill.tsx
+++ b/packages/ui/src/components/version-pill.tsx
@@ -19,7 +19,13 @@ export default function VersionPill() {
   const serverVersion = () => meta()?.serverVersion
   const uiVersion = () => meta()?.ui?.version
   const uiSource = () => meta()?.ui?.source
-  const update = () => availableUpdate() ?? meta()?.update ?? null
+  const update = () => {
+    const refreshedUpdate = availableUpdate()
+    if (refreshedUpdate !== undefined) {
+      return refreshedUpdate
+    }
+    return meta()?.update ?? null
+  }
 
   const uiLabel = () => (uiVersion() ? t("versionPill.uiWithVersion", { version: uiVersion() }) : t("versionPill.ui"))
 

--- a/packages/ui/src/components/version-pill.tsx
+++ b/packages/ui/src/components/version-pill.tsx
@@ -16,11 +16,12 @@ export default function VersionPill() {
   const serverVersion = () => meta()?.serverVersion
   const uiVersion = () => meta()?.ui?.version
   const uiSource = () => meta()?.ui?.source
+  const update = () => meta()?.update
 
   const uiLabel = () => (uiVersion() ? t("versionPill.uiWithVersion", { version: uiVersion() }) : t("versionPill.ui"))
 
   return (
-    <Show when={serverVersion() || uiVersion() || uiSource()}>
+    <Show when={serverVersion() || uiVersion() || uiSource() || update()}>
       <div class="text-[11px] text-muted whitespace-nowrap">
         <Show when={serverVersion()}>
           {(v) => <span>{t("versionPill.appWithVersion", { version: v() })}</span>}
@@ -35,6 +36,24 @@ export default function VersionPill() {
               <Show when={uiSource()}>{(s) => <span class="opacity-70">{t("versionPill.source", { source: s() })}</span>}</Show>
             </span>
           </>
+        </Show>
+        <Show when={update()}>
+          {(release) => (
+            <>
+              <Show when={serverVersion() || uiVersion() || uiSource()}>
+                <span class="mx-2">·</span>
+              </Show>
+              <a
+                href={release().url}
+                target="_blank"
+                rel="noreferrer"
+                class="text-primary hover:underline underline-offset-2"
+                title={t("releases.devUpdateAvailable.message", { version: release().version })}
+              >
+                {t("releases.devUpdateAvailable.action")}
+              </a>
+            </>
+          )}
         </Show>
       </div>
     </Show>

--- a/packages/ui/src/components/version-pill.tsx
+++ b/packages/ui/src/components/version-pill.tsx
@@ -19,8 +19,6 @@ export default function VersionPill() {
   const serverVersion = () => meta()?.serverVersion
   const uiVersion = () => meta()?.ui?.version
   const uiSource = () => meta()?.ui?.source
-  const latestServerUrl = () => meta()?.support?.latestServerUrl ?? null
-  const latestServerVersion = () => meta()?.support?.latestServerVersion ?? null
   const update = () => {
     const refreshedUpdate = availableUpdate()
     if (refreshedUpdate !== undefined) {
@@ -32,7 +30,7 @@ export default function VersionPill() {
   const uiLabel = () => (uiVersion() ? t("versionPill.uiWithVersion", { version: uiVersion() }) : t("versionPill.ui"))
 
   return (
-    <Show when={serverVersion() || uiVersion() || uiSource() || update() || latestServerUrl()}>
+    <Show when={serverVersion() || uiVersion() || uiSource() || update()}>
       <div class="text-[11px] text-muted whitespace-nowrap">
         <Show when={serverVersion()}>
           {(v) => <span>{t("versionPill.appWithVersion", { version: v() })}</span>}
@@ -48,32 +46,24 @@ export default function VersionPill() {
             </span>
           </>
         </Show>
-        <Show when={update() || latestServerUrl()}>
-          {() => (
+        <Show when={update()}>
+          {(release) => (
             <>
               <Show when={serverVersion() || uiVersion() || uiSource()}>
                 <span class="mx-2">·</span>
               </Show>
               <a
-                href={update()?.url ?? latestServerUrl() ?? "#"}
+                href={release().url}
                 target="_blank"
                 rel="noreferrer"
                 class="text-primary hover:underline underline-offset-2"
-                title={
-                  update()?.version
-                    ? t("releases.devUpdateAvailable.message", { version: update()!.version })
-                    : latestServerVersion()
-                      ? t("releases.upgradeRequired.message.withVersion", { version: latestServerVersion()! })
-                      : t("releases.upgradeRequired.message.noVersion")
-                }
+                title={t("releases.devUpdateAvailable.message", { version: release().version })}
                 onClick={(event) => {
                   event.preventDefault()
-                  const url = update()?.url ?? latestServerUrl()
-                  if (!url) return
-                  void openExternalUrl(url, "version-pill")
+                  void openExternalUrl(release().url, "version-pill")
                 }}
               >
-                {update() ? t("releases.devUpdateAvailable.action") : t("releases.upgradeRequired.action.getUpdate")}
+                {t("releases.devUpdateAvailable.action")}
               </a>
             </>
           )}

--- a/packages/ui/src/components/version-pill.tsx
+++ b/packages/ui/src/components/version-pill.tsx
@@ -19,6 +19,8 @@ export default function VersionPill() {
   const serverVersion = () => meta()?.serverVersion
   const uiVersion = () => meta()?.ui?.version
   const uiSource = () => meta()?.ui?.source
+  const latestServerUrl = () => meta()?.support?.latestServerUrl ?? null
+  const latestServerVersion = () => meta()?.support?.latestServerVersion ?? null
   const update = () => {
     const refreshedUpdate = availableUpdate()
     if (refreshedUpdate !== undefined) {
@@ -30,7 +32,7 @@ export default function VersionPill() {
   const uiLabel = () => (uiVersion() ? t("versionPill.uiWithVersion", { version: uiVersion() }) : t("versionPill.ui"))
 
   return (
-    <Show when={serverVersion() || uiVersion() || uiSource() || update()}>
+    <Show when={serverVersion() || uiVersion() || uiSource() || update() || latestServerUrl()}>
       <div class="text-[11px] text-muted whitespace-nowrap">
         <Show when={serverVersion()}>
           {(v) => <span>{t("versionPill.appWithVersion", { version: v() })}</span>}
@@ -46,24 +48,32 @@ export default function VersionPill() {
             </span>
           </>
         </Show>
-        <Show when={update()}>
-          {(release) => (
+        <Show when={update() || latestServerUrl()}>
+          {() => (
             <>
               <Show when={serverVersion() || uiVersion() || uiSource()}>
                 <span class="mx-2">·</span>
               </Show>
               <a
-                href={release().url}
+                href={update()?.url ?? latestServerUrl() ?? "#"}
                 target="_blank"
                 rel="noreferrer"
                 class="text-primary hover:underline underline-offset-2"
-                title={t("releases.devUpdateAvailable.message", { version: release().version })}
+                title={
+                  update()?.version
+                    ? t("releases.devUpdateAvailable.message", { version: update()!.version })
+                    : latestServerVersion()
+                      ? t("releases.upgradeRequired.message.withVersion", { version: latestServerVersion()! })
+                      : t("releases.upgradeRequired.message.noVersion")
+                }
                 onClick={(event) => {
                   event.preventDefault()
-                  void openExternalUrl(release().url, "version-pill")
+                  const url = update()?.url ?? latestServerUrl()
+                  if (!url) return
+                  void openExternalUrl(url, "version-pill")
                 }}
               >
-                {t("releases.devUpdateAvailable.action")}
+                {update() ? t("releases.devUpdateAvailable.action") : t("releases.upgradeRequired.action.getUpdate")}
               </a>
             </>
           )}

--- a/packages/ui/src/stores/releases.ts
+++ b/packages/ui/src/stores/releases.ts
@@ -9,7 +9,7 @@ import { hasInstances, showFolderSelection } from "./ui"
 const log = getLogger("actions")
 
 const [supportInfo, setSupportInfo] = createSignal<SupportMeta | null>(null)
-const [availableUpdate, setAvailableUpdate] = createSignal<ServerMeta["update"] | null>(null)
+const [availableUpdate, setAvailableUpdate] = createSignal<ServerMeta["update"] | null | undefined>(undefined)
 
 const UI_VERSION_STORAGE_KEY = "codenomad:lastSeenUiVersion"
 const DEV_RELEASE_STORAGE_KEY = "codenomad:lastSeenDevRelease"

--- a/packages/ui/src/stores/releases.ts
+++ b/packages/ui/src/stores/releases.ts
@@ -9,6 +9,7 @@ import { hasInstances, showFolderSelection } from "./ui"
 const log = getLogger("actions")
 
 const [supportInfo, setSupportInfo] = createSignal<SupportMeta | null>(null)
+const [availableUpdate, setAvailableUpdate] = createSignal<ServerMeta["update"] | null>(null)
 
 const UI_VERSION_STORAGE_KEY = "codenomad:lastSeenUiVersion"
 const DEV_RELEASE_STORAGE_KEY = "codenomad:lastSeenDevRelease"
@@ -82,6 +83,7 @@ async function refreshFromMeta() {
   try {
     const meta = await getServerMeta(true)
     setSupportInfo(meta.support ?? null)
+    setAvailableUpdate(meta.update ?? null)
     maybeNotifyUiUpdated(meta)
     maybeNotifyDevReleaseAvailable(meta)
     ensureMetaRefresh(meta)
@@ -92,6 +94,10 @@ async function refreshFromMeta() {
 
 export function useSupportInfo() {
   return supportInfo
+}
+
+export function useAvailableUpdate() {
+  return availableUpdate
 }
 
 function maybeNotifyUiUpdated(meta: ServerMeta) {


### PR DESCRIPTION
## Summary
- Keep a stable release link visible in the home screen version pill whenever update metadata is available.
- Leave the existing one-time update toast behavior unchanged while giving users a permanent place to reopen the release page.
- Reuse the existing release i18n strings instead of adding new UI copy.

Fixes #267

## Verification
- `npm run typecheck --workspace @codenomad/ui`
- `npm run build --workspace @codenomad/ui`

<img width="660" height="507" alt="image" src="https://github.com/user-attachments/assets/7058cf18-0c01-45da-994a-20fe1497980c" />
