### PR TITLE
fix(ui): harden permission event reconciliation

### DIFF
--- a/packages/ui/src/components/instance/instance-shell2.tsx
+++ b/packages/ui/src/components/instance/instance-shell2.tsx
@@ -36,7 +36,7 @@ import { serverApi } from "../../lib/api-client"
 import { loadBackgroundProcesses } from "../../stores/background-processes"
 import { BackgroundProcessOutputDialog } from "../background-process-output-dialog"
 import { useI18n } from "../../lib/i18n"
-import { getPermissionQueue, getPermissionQueueLength, getQuestionQueueLength, sendPermissionResponse } from "../../stores/instances"
+import { getPermissionQueueLength, getQuestionQueueLength } from "../../stores/instances"
 import SessionSidebar from "./shell/SessionSidebar"
 import { useSessionSidebarRequests } from "./shell/useSessionSidebarRequests"
 import RightPanel from "./shell/right-panel/RightPanel"
@@ -58,13 +58,7 @@ import { useDrawerHostMeasure } from "./shell/useDrawerHostMeasure"
 import { useDrawerResize } from "./shell/useDrawerResize"
 import { useSessionCache } from "./shell/useSessionCache"
 import { useInstanceSessionContext } from "./shell/useInstanceSessionContext"
-import { getPermissionSessionId } from "../../types/permission"
-import {
-  canAutoRespondPermission,
-  finishAutoRespondPermission,
-  getPermissionAutoAcceptInFlightVersion,
-  isPermissionAutoAcceptEnabled,
-} from "../../stores/permission-auto-accept"
+import { isPermissionAutoAcceptEnabled } from "../../stores/permission-auto-accept"
 
 const log = getLogger("session")
 const OPEN_SESSION_SEARCH_EVENT = "codenomad:open-session-search"
@@ -269,8 +263,6 @@ const InstanceShell2: Component<InstanceShellProps> = (props) => {
     return permissions + questions > 0
   })
 
-  const permissionQueue = createMemo(() => getPermissionQueue(props.instance.id))
-
   const activePromptInputApi = createMemo(() => {
     const sessionId = activeSessionIdForInstance()
     if (!sessionId || sessionId === "info") return null
@@ -283,25 +275,6 @@ const InstanceShell2: Component<InstanceShellProps> = (props) => {
       [sessionId]: api,
     }))
   }
-
-  createEffect(() => {
-    getPermissionAutoAcceptInFlightVersion()
-
-    for (const permission of permissionQueue()) {
-      const sessionId = getPermissionSessionId(permission)
-      if (!sessionId) continue
-      if (!permission?.id) continue
-      if (!canAutoRespondPermission(props.instance.id, sessionId, permission.id)) continue
-
-      void sendPermissionResponse(props.instance.id, sessionId, permission.id, "once")
-        .catch((error) => {
-          log.error("Failed to auto-accept permission", error)
-        })
-        .finally(() => {
-          finishAutoRespondPermission(props.instance.id, sessionId, permission.id)
-        })
-    }
-  })
 
   const yoloModeEnabled = createMemo(() => {
     const session = activeSessionForInstance()

--- a/packages/ui/src/components/instance/shell/right-panel/tabs/StatusTab.tsx
+++ b/packages/ui/src/components/instance/shell/right-panel/tabs/StatusTab.tsx
@@ -13,7 +13,8 @@ import type { Session } from "../../../../../types/session"
 import ContextUsagePanel from "../../../../session/context-usage-panel"
 import { TodoListView } from "../../../../tool-call/renderers/todo"
 import InstanceServiceStatus from "../../../../instance-service-status"
-import { isPermissionAutoAcceptEnabled, togglePermissionAutoAccept } from "../../../../../stores/permission-auto-accept"
+import { getPermissionQueue, sendPermissionResponse } from "../../../../../stores/instances"
+import { drainAutoAcceptPermissions, isPermissionAutoAcceptEnabled, togglePermissionAutoAccept } from "../../../../../stores/permission-auto-accept"
 
 interface StatusTabProps {
   t: (key: string, vars?: Record<string, any>) => string
@@ -51,6 +52,18 @@ const StatusTab: Component<StatusTabProps> = (props) => {
       )
     }
 
+    const toggleYoloMode = () => {
+      const willEnable = !isPermissionAutoAcceptEnabled(props.instanceId, session.id)
+      togglePermissionAutoAccept(props.instanceId, session.id)
+      if (!willEnable) return
+      drainAutoAcceptPermissions(
+        props.instanceId,
+        getPermissionQueue(props.instanceId),
+        sendPermissionResponse,
+        (instanceId, permissionId) => getPermissionQueue(instanceId).some((permission) => permission.id === permissionId),
+      )
+    }
+
     return (
       <div class="rounded-md border border-base bg-surface-secondary px-3 py-2">
         <div class="flex items-start justify-between gap-3">
@@ -63,7 +76,7 @@ const StatusTab: Component<StatusTabProps> = (props) => {
             color="warning"
             size="small"
             inputProps={{ "aria-label": props.t("instanceShell.yoloMode.title") }}
-            onChange={() => togglePermissionAutoAccept(props.instanceId, session.id)}
+            onChange={toggleYoloMode}
           />
         </div>
       </div>

--- a/packages/ui/src/components/instance/shell/right-panel/tabs/StatusTab.tsx
+++ b/packages/ui/src/components/instance/shell/right-panel/tabs/StatusTab.tsx
@@ -13,8 +13,8 @@ import type { Session } from "../../../../../types/session"
 import ContextUsagePanel from "../../../../session/context-usage-panel"
 import { TodoListView } from "../../../../tool-call/renderers/todo"
 import InstanceServiceStatus from "../../../../instance-service-status"
-import { getPermissionQueue, sendPermissionResponse } from "../../../../../stores/instances"
-import { drainAutoAcceptPermissions, isPermissionAutoAcceptEnabled, togglePermissionAutoAccept } from "../../../../../stores/permission-auto-accept"
+import { togglePermissionAutoAcceptForSession } from "../../../../../stores/instances"
+import { isPermissionAutoAcceptEnabled } from "../../../../../stores/permission-auto-accept"
 
 interface StatusTabProps {
   t: (key: string, vars?: Record<string, any>) => string
@@ -52,18 +52,6 @@ const StatusTab: Component<StatusTabProps> = (props) => {
       )
     }
 
-    const toggleYoloMode = () => {
-      const willEnable = !isPermissionAutoAcceptEnabled(props.instanceId, session.id)
-      togglePermissionAutoAccept(props.instanceId, session.id)
-      if (!willEnable) return
-      drainAutoAcceptPermissions(
-        props.instanceId,
-        getPermissionQueue(props.instanceId),
-        sendPermissionResponse,
-        (instanceId, permissionId) => getPermissionQueue(instanceId).some((permission) => permission.id === permissionId),
-      )
-    }
-
     return (
       <div class="rounded-md border border-base bg-surface-secondary px-3 py-2">
         <div class="flex items-start justify-between gap-3">
@@ -76,7 +64,7 @@ const StatusTab: Component<StatusTabProps> = (props) => {
             color="warning"
             size="small"
             inputProps={{ "aria-label": props.t("instanceShell.yoloMode.title") }}
-            onChange={toggleYoloMode}
+            onChange={() => togglePermissionAutoAcceptForSession(props.instanceId, session.id)}
           />
         </div>
       </div>

--- a/packages/ui/src/stores/instances.ts
+++ b/packages/ui/src/stores/instances.ts
@@ -32,7 +32,7 @@ import { setSessionPendingPermission, setSessionPendingQuestion } from "./sessio
 import { setHasInstances } from "./ui"
 import { messageStoreBus } from "./message-v2/bus"
 import { upsertPermissionV2, removePermissionV2, upsertQuestionV2, removeQuestionV2 } from "./message-v2/bridge"
-import { drainAutoAcceptPermissions } from "./permission-auto-accept"
+import { clearAutoAcceptPermission, drainAutoAcceptPermissions, isPermissionAutoAcceptEnabled, togglePermissionAutoAccept } from "./permission-auto-accept"
 import { clearCacheForInstance } from "../lib/global-cache"
 import { getLogger } from "../lib/logger"
 import { mergeInstanceMetadata, clearInstanceMetadata } from "./instance-metadata"
@@ -105,6 +105,32 @@ function hasRecentlyRepliedPermission(instanceId: string, permissionId: string):
     return false
   }
   return true
+}
+
+function mergePermissionRequest(previous: PermissionRequestLike | undefined, next: PermissionRequestLike): PermissionRequestLike {
+  if (!previous) return next
+  const merged = {
+    ...previous,
+    ...next,
+    metadata: {
+      ...(previous.metadata ?? {}),
+      ...(next.metadata ?? {}),
+    },
+    time: {
+      ...(previous.time ?? {}),
+      ...(next.time ?? {}),
+    },
+    tool: previous.tool || next.tool ? {
+      ...(previous.tool ?? {}),
+      ...(next.tool ?? {}),
+    } : undefined,
+  }
+  for (const key of ["sessionID", "sessionId", "messageID", "messageId", "callID", "callId", "partID", "partId", "toolCallID", "toolCallId"] as const) {
+    if ((next as any)[key] === undefined && (previous as any)[key] !== undefined) {
+      ;(merged as any)[key] = (previous as any)[key]
+    }
+  }
+  return merged
 }
 interface DisconnectedInstanceInfo {
   id: string
@@ -233,8 +259,8 @@ async function syncPendingPermissions(instanceId: string): Promise<void> {
 
     // Upsert all server-side pending permissions.
     for (const permission of pendingRemote) {
-      addPermissionToQueue(instanceId, permission)
-      upsertPermissionV2(instanceId, permission)
+      const queuedPermission = addPermissionToQueue(instanceId, permission) ?? permission
+      upsertPermissionV2(instanceId, queuedPermission)
     }
     drainAutoAcceptPermissions(instanceId, getPermissionQueue(instanceId), sendPermissionResponse, hasPendingPermission)
   } catch (error) {
@@ -792,10 +818,11 @@ function clearQuestionSessionPendingCounts(instanceId: string): void {
   questionSessionCounts.delete(instanceId)
 }
 
-function addPermissionToQueue(instanceId: string, permission: PermissionRequestLike): void {
+function addPermissionToQueue(instanceId: string, permission: PermissionRequestLike): PermissionRequestLike | undefined {
   let inserted = false
   let updated = false
   let previousPermission: PermissionRequestLike | undefined
+  let queuedPermission = permission
 
   setPermissionQueues((prev) => {
     const next = new Map(prev)
@@ -804,27 +831,28 @@ function addPermissionToQueue(instanceId: string, permission: PermissionRequestL
 
     if (existingIndex !== -1) {
       previousPermission = queue[existingIndex]
+      queuedPermission = mergePermissionRequest(previousPermission, permission)
       const updatedQueue = queue.slice()
-      updatedQueue[existingIndex] = permission
+      updatedQueue[existingIndex] = queuedPermission
       next.set(instanceId, updatedQueue.sort((a, b) => getPermissionCreatedAt(a) - getPermissionCreatedAt(b)))
       updated = true
       return next
     }
 
-    const updatedQueue = [...queue, permission].sort((a, b) => getPermissionCreatedAt(a) - getPermissionCreatedAt(b))
+    const updatedQueue = [...queue, queuedPermission].sort((a, b) => getPermissionCreatedAt(a) - getPermissionCreatedAt(b))
     next.set(instanceId, updatedQueue)
     inserted = true
     return next
   })
 
   if (!inserted && !updated) {
-    return
+    return undefined
   }
 
   recomputeActiveInterruption(instanceId)
 
   const previousSessionId = previousPermission ? getPermissionSessionId(previousPermission) : undefined
-  const sessionId = getPermissionSessionId(permission)
+  const sessionId = getPermissionSessionId(queuedPermission)
   if (previousSessionId && previousSessionId !== sessionId) {
     const remaining = decrementSessionPendingCount(instanceId, previousSessionId)
     setSessionPendingPermission(instanceId, previousSessionId, remaining > 0)
@@ -843,10 +871,11 @@ function addPermissionToQueue(instanceId: string, permission: PermissionRequestL
       byPermissionId = new Map()
       permissionWorktreeSlugByInstance.set(instanceId, byPermissionId)
     }
-    byPermissionId.set(permission.id, slug)
+    byPermissionId.set(queuedPermission.id, slug)
   }
 
-  drainAutoAcceptPermissions(instanceId, [permission], sendPermissionResponse, hasPendingPermission)
+  drainAutoAcceptPermissions(instanceId, [queuedPermission], sendPermissionResponse, hasPendingPermission)
+  return queuedPermission
 }
 
 function removePermissionFromQueue(instanceId: string, permissionId: string): void {
@@ -883,13 +912,27 @@ function removePermissionFromQueue(instanceId: string, permissionId: string): vo
     permissionWorktreeSlugByInstance.get(instanceId)?.delete(permissionId)
     const removedSessionId = getPermissionSessionId(removed)
     if (removedSessionId) {
+      clearAutoAcceptPermission(instanceId, removedSessionId, permissionId)
       const remaining = decrementSessionPendingCount(instanceId, removedSessionId)
       setSessionPendingPermission(instanceId, removedSessionId, remaining > 0)
     }
   }
 }
 
+function togglePermissionAutoAcceptForSession(instanceId: string, sessionId: string): void {
+  const willEnable = !isPermissionAutoAcceptEnabled(instanceId, sessionId)
+  togglePermissionAutoAccept(instanceId, sessionId)
+  if (!willEnable) return
+  drainAutoAcceptPermissions(instanceId, getPermissionQueue(instanceId), sendPermissionResponse, hasPendingPermission)
+}
+
 function clearPermissionQueue(instanceId: string): void {
+  for (const permission of getPermissionQueue(instanceId)) {
+    const sessionId = getPermissionSessionId(permission)
+    if (sessionId) {
+      clearAutoAcceptPermission(instanceId, sessionId, permission.id)
+    }
+  }
   setPermissionQueues((prev) => {
     const next = new Map(prev)
     next.delete(instanceId)
@@ -1186,6 +1229,7 @@ export {
   removePermissionFromQueue,
   markPermissionReplied,
   hasRecentlyRepliedPermission,
+  togglePermissionAutoAcceptForSession,
   clearPermissionQueue,
   sendPermissionResponse,
   setActivePermissionIdForInstance,

--- a/packages/ui/src/stores/instances.ts
+++ b/packages/ui/src/stores/instances.ts
@@ -32,6 +32,7 @@ import { setSessionPendingPermission, setSessionPendingQuestion } from "./sessio
 import { setHasInstances } from "./ui"
 import { messageStoreBus } from "./message-v2/bus"
 import { upsertPermissionV2, removePermissionV2, upsertQuestionV2, removeQuestionV2 } from "./message-v2/bridge"
+import { drainAutoAcceptPermissions } from "./permission-auto-accept"
 import { clearCacheForInstance } from "../lib/global-cache"
 import { getLogger } from "../lib/logger"
 import { mergeInstanceMetadata, clearInstanceMetadata } from "./instance-metadata"
@@ -218,7 +219,8 @@ async function syncPendingPermissions(instanceId: string): Promise<void> {
       "permission.list",
     )
 
-    const remoteIds = new Set(remote.map((item) => item.id))
+    const pendingRemote = remote.filter((item) => !hasRecentlyRepliedPermission(instanceId, item.id))
+    const remoteIds = new Set(pendingRemote.map((item) => item.id))
     const local = getPermissionQueue(instanceId)
 
     // Remove any stale local permissions missing from server.
@@ -230,10 +232,11 @@ async function syncPendingPermissions(instanceId: string): Promise<void> {
     }
 
     // Upsert all server-side pending permissions.
-    for (const permission of remote) {
+    for (const permission of pendingRemote) {
       addPermissionToQueue(instanceId, permission)
       upsertPermissionV2(instanceId, permission)
     }
+    drainAutoAcceptPermissions(instanceId, getPermissionQueue(instanceId), sendPermissionResponse, hasPendingPermission)
   } catch (error) {
     log.warn("Failed to sync pending permissions", { instanceId, error })
   }
@@ -642,6 +645,10 @@ function getPermissionQueueLength(instanceId: string): number {
   return getPermissionQueue(instanceId).length
 }
 
+function hasPendingPermission(instanceId: string, permissionId: string): boolean {
+  return getPermissionQueue(instanceId).some((permission) => permission.id === permissionId)
+}
+
 function getQuestionQueue(instanceId: string): QuestionRequest[] {
   const queue = questionQueues().get(instanceId)
   if (!queue) {
@@ -838,6 +845,8 @@ function addPermissionToQueue(instanceId: string, permission: PermissionRequestL
     }
     byPermissionId.set(permission.id, slug)
   }
+
+  drainAutoAcceptPermissions(instanceId, [permission], sendPermissionResponse, hasPendingPermission)
 }
 
 function removePermissionFromQueue(instanceId: string, permissionId: string): void {

--- a/packages/ui/src/stores/instances.ts
+++ b/packages/ui/src/stores/instances.ts
@@ -89,22 +89,34 @@ function markPermissionReplied(instanceId: string, permissionId: string): void {
     replied = new Map()
     repliedPermissionIdsByInstance.set(instanceId, replied)
   }
+  pruneRepliedPermissions(instanceId, replied)
   replied.set(permissionId, Date.now())
 }
 
 function hasRecentlyRepliedPermission(instanceId: string, permissionId: string): boolean {
   const replied = repliedPermissionIdsByInstance.get(instanceId)
   if (!replied) return false
+  pruneRepliedPermissions(instanceId, replied)
   const repliedAt = replied.get(permissionId)
   if (!repliedAt) return false
-  if (Date.now() - repliedAt > REPLIED_PERMISSION_TOMBSTONE_MS) {
-    replied.delete(permissionId)
-    if (replied.size === 0) {
-      repliedPermissionIdsByInstance.delete(instanceId)
+  return Date.now() - repliedAt <= REPLIED_PERMISSION_TOMBSTONE_MS
+}
+
+function pruneRepliedPermissions(instanceId: string, replied = repliedPermissionIdsByInstance.get(instanceId)): void {
+  if (!replied) return
+  const now = Date.now()
+  for (const [permissionId, repliedAt] of replied) {
+    if (now - repliedAt > REPLIED_PERMISSION_TOMBSTONE_MS) {
+      replied.delete(permissionId)
     }
-    return false
   }
-  return true
+  if (replied.size === 0) {
+    repliedPermissionIdsByInstance.delete(instanceId)
+  }
+}
+
+function clearRepliedPermissions(instanceId: string): void {
+  repliedPermissionIdsByInstance.delete(instanceId)
 }
 
 function mergePermissionRequest(previous: PermissionRequestLike | undefined, next: PermissionRequestLike): PermissionRequestLike {
@@ -132,10 +144,12 @@ function mergePermissionRequest(previous: PermissionRequestLike | undefined, nex
   }
   return merged
 }
+
 interface DisconnectedInstanceInfo {
   id: string
   folder: string
   reason: string
+  details?: string
 }
 const [disconnectedInstance, setDisconnectedInstance] = createSignal<DisconnectedInstanceInfo | null>(null)
 
@@ -568,6 +582,7 @@ function removeInstance(id: string) {
   removeLogContainer(id)
   clearCommands(id)
   clearPermissionQueue(id)
+  clearRepliedPermissions(id)
   clearQuestionQueue(id)
   clearInstanceMetadata(id)
 
@@ -901,8 +916,6 @@ function removePermissionFromQueue(instanceId: string, permissionId: string): vo
     }
     return next
   })
-
-  const updatedQueue = getPermissionQueue(instanceId)
 
   recomputeActiveInterruption(instanceId)
 

--- a/packages/ui/src/stores/instances.ts
+++ b/packages/ui/src/stores/instances.ts
@@ -52,6 +52,8 @@ const [activePermissionId, setActivePermissionId] = createSignal<Map<string, str
 const permissionSessionCounts = new Map<string, Map<string, number>>()
 // Track which worktree a permission was enqueued under (by permission request id).
 const permissionWorktreeSlugByInstance = new Map<string, Map<string, string>>()
+const REPLIED_PERMISSION_TOMBSTONE_MS = 30_000
+const repliedPermissionIdsByInstance = new Map<string, Map<string, number>>()
 
 const [questionQueues, setQuestionQueues] = createSignal<Map<string, QuestionRequest[]>>(new Map())
 // Track which worktree a question was enqueued under (by question request id).
@@ -77,6 +79,31 @@ const [activeInterruption, setActiveInterruption] = createSignal<Map<string, Act
 function syncHasInstancesFlag() {
   const readyExists = Array.from(instances().values()).some((instance) => instance.status === "ready")
   setHasInstances(readyExists)
+}
+
+function markPermissionReplied(instanceId: string, permissionId: string): void {
+  if (!permissionId) return
+  let replied = repliedPermissionIdsByInstance.get(instanceId)
+  if (!replied) {
+    replied = new Map()
+    repliedPermissionIdsByInstance.set(instanceId, replied)
+  }
+  replied.set(permissionId, Date.now())
+}
+
+function hasRecentlyRepliedPermission(instanceId: string, permissionId: string): boolean {
+  const replied = repliedPermissionIdsByInstance.get(instanceId)
+  if (!replied) return false
+  const repliedAt = replied.get(permissionId)
+  if (!repliedAt) return false
+  if (Date.now() - repliedAt > REPLIED_PERMISSION_TOMBSTONE_MS) {
+    replied.delete(permissionId)
+    if (replied.size === 0) {
+      repliedPermissionIdsByInstance.delete(instanceId)
+    }
+    return false
+  }
+  return true
 }
 interface DisconnectedInstanceInfo {
   id: string
@@ -760,12 +787,20 @@ function clearQuestionSessionPendingCounts(instanceId: string): void {
 
 function addPermissionToQueue(instanceId: string, permission: PermissionRequestLike): void {
   let inserted = false
+  let updated = false
+  let previousPermission: PermissionRequestLike | undefined
 
   setPermissionQueues((prev) => {
     const next = new Map(prev)
     const queue = next.get(instanceId) ?? []
+    const existingIndex = queue.findIndex((p) => p.id === permission.id)
 
-    if (queue.some((p) => p.id === permission.id)) {
+    if (existingIndex !== -1) {
+      previousPermission = queue[existingIndex]
+      const updatedQueue = queue.slice()
+      updatedQueue[existingIndex] = permission
+      next.set(instanceId, updatedQueue.sort((a, b) => getPermissionCreatedAt(a) - getPermissionCreatedAt(b)))
+      updated = true
       return next
     }
 
@@ -775,19 +810,26 @@ function addPermissionToQueue(instanceId: string, permission: PermissionRequestL
     return next
   })
 
-  if (!inserted) {
+  if (!inserted && !updated) {
     return
   }
 
   recomputeActiveInterruption(instanceId)
 
+  const previousSessionId = previousPermission ? getPermissionSessionId(previousPermission) : undefined
   const sessionId = getPermissionSessionId(permission)
+  if (previousSessionId && previousSessionId !== sessionId) {
+    const remaining = decrementSessionPendingCount(instanceId, previousSessionId)
+    setSessionPendingPermission(instanceId, previousSessionId, remaining > 0)
+  }
+
   if (sessionId) {
-    incrementSessionPendingCount(instanceId, sessionId)
+    if (inserted || previousSessionId !== sessionId) {
+      incrementSessionPendingCount(instanceId, sessionId)
+    }
     setSessionPendingPermission(instanceId, sessionId, true)
 
-    // Record the worktree slug at the time the permission is enqueued.
-    // This is used to respond in the same worktree context even from the global permission center.
+    // Refresh this when duplicate permission events carry better session/worktree hydration.
     const slug = getWorktreeSlugForSession(instanceId, sessionId)
     let byPermissionId = permissionWorktreeSlugByInstance.get(instanceId)
     if (!byPermissionId) {
@@ -1034,8 +1076,11 @@ async function sendPermissionResponse(
       "permission.reply",
     )
 
-    // Remove from queue after successful response
+    markPermissionReplied(instanceId, requestId)
+    // Remove from both local queues after successful response; the SSE replied event
+    // is still accepted, but the UI no longer depends on receiving it.
     removePermissionFromQueue(instanceId, requestId)
+    removePermissionV2(instanceId, requestId)
   } catch (error) {
     log.error("Failed to send permission response", error)
     throw error
@@ -1130,6 +1175,8 @@ export {
   getPermissionQueueLength,
   addPermissionToQueue,
   removePermissionFromQueue,
+  markPermissionReplied,
+  hasRecentlyRepliedPermission,
   clearPermissionQueue,
   sendPermissionResponse,
   setActivePermissionIdForInstance,

--- a/packages/ui/src/stores/message-v2/bridge.ts
+++ b/packages/ui/src/stores/message-v2/bridge.ts
@@ -189,7 +189,7 @@ export function reconcilePendingPermissionsV2(instanceId: string, sessionId?: st
   if (!pending || pending.length === 0) return
 
   for (const entry of pending) {
-    if (!entry || entry.partId) continue
+    if (!entry) continue
     const permission = entry.permission
     if (!permission) continue
 
@@ -199,6 +199,9 @@ export function reconcilePendingPermissionsV2(instanceId: string, sessionId?: st
     }
 
     const messageId = entry.messageId ?? extractPermissionMessageId(permission)
+    if (entry.partId && messageId && store.getPermissionState(messageId, entry.partId)) {
+      continue
+    }
     const callId = extractPermissionCallId(permission)
     const resolvedPartId = resolvePartIdFromCallId(store, messageId, callId)
     if (!resolvedPartId) continue

--- a/packages/ui/src/stores/message-v2/instance-store.ts
+++ b/packages/ui/src/stores/message-v2/instance-store.ts
@@ -3,6 +3,7 @@ import { createStore, produce, reconcile } from "solid-js/store"
 import type { SetStoreFunction } from "solid-js/store"
 import { getLogger } from "../../lib/logger"
 import type { ClientPart, MessageInfo } from "../../types/message"
+import type { PermissionRequestLike } from "../../types/permission"
 import { clearRecordDisplayCacheForMessages } from "./record-display-cache"
 import type {
   InstanceMessageState,
@@ -604,6 +605,31 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     )
   }
 
+  function partsRepresentSameUserInput(a: ClientPart, b: ClientPart): boolean {
+    if (a.type !== b.type) return false
+    if (a.type === "text" && b.type === "text") {
+      return typeof (a as any).text === "string" && (a as any).text === (b as any).text
+    }
+    if (a.type === "file" && b.type === "file") {
+      const left = a as any
+      const right = b as any
+      return (
+        typeof left.url === "string" &&
+        left.url === right.url &&
+        (left.filename ?? "") === (right.filename ?? "") &&
+        (left.mime ?? "") === (right.mime ?? "")
+      )
+    }
+    return false
+  }
+
+  function shouldReplaceSyntheticUserPart(message: MessageRecord, incoming: ClientPart, existing: ClientPart): boolean {
+    if (message.role !== "user") return false
+    if ((incoming as any).synthetic) return false
+    if (!(existing as any).synthetic) return false
+    return partsRepresentSameUserInput(incoming, existing)
+  }
+
   function applyPartUpdate(input: PartUpdateInput) {
     const message = state.messages[input.messageId]
     if (!message) {
@@ -621,6 +647,13 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
         if (!draft.partIds.includes(partId)) {
           draft.partIds = [...draft.partIds, partId]
         }
+        draft.partIds = draft.partIds.filter((id) => {
+          if (id === partId) return true
+          const existingPart = draft.parts[id]?.data
+          if (!existingPart || !shouldReplaceSyntheticUserPart(message, cloned, existingPart)) return true
+          delete draft.parts[id]
+          return false
+        })
         const existing = draft.parts[partId]
         const nextRevision = existing ? existing.revision + 1 : (cloned as any).version ?? 0
         draft.parts[partId] = {
@@ -817,8 +850,8 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
       id: options.newId,
       isEphemeral: false,
       updatedAt: Date.now(),
-      partIds: options.clearParts ? [] : existing.partIds,
-      parts: options.clearParts ? {} : existing.parts,
+      partIds: existing.partIds,
+      parts: existing.parts,
     }
 
     setState("messages", options.newId, cloned)
@@ -904,7 +937,45 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     return messageInfoCache.get(messageId)
   }
 
-  function upsertPermission(entry: PermissionEntry) {
+  function mergePermissionPayload(previous: PermissionRequestLike, next: PermissionRequestLike): PermissionRequestLike {
+    const merged = {
+      ...previous,
+      ...next,
+      metadata: {
+        ...(previous.metadata ?? {}),
+        ...(next.metadata ?? {}),
+      },
+      time: {
+        ...(previous.time ?? {}),
+        ...(next.time ?? {}),
+      },
+      tool: previous.tool || next.tool ? {
+        ...(previous.tool ?? {}),
+        ...(next.tool ?? {}),
+      } : undefined,
+    }
+    for (const key of ["sessionID", "sessionId", "messageID", "messageId", "callID", "callId", "partID", "partId", "toolCallID", "toolCallId"] as const) {
+      if ((next as any)[key] === undefined && (previous as any)[key] !== undefined) {
+        ;(merged as any)[key] = (previous as any)[key]
+      }
+    }
+    return merged
+  }
+
+  function mergePermissionEntry(entry: PermissionEntry): PermissionEntry {
+    const existing = state.permissions.queue.find((item) => item.permission.id === entry.permission.id)
+    if (!existing) return entry
+    return {
+      ...entry,
+      permission: mergePermissionPayload(existing.permission, entry.permission),
+      messageId: entry.messageId ?? existing.messageId,
+      partId: entry.partId ?? existing.partId,
+      enqueuedAt: Math.min(existing.enqueuedAt, entry.enqueuedAt),
+    }
+  }
+
+  function upsertPermission(input: PermissionEntry) {
+    const entry = mergePermissionEntry(input)
     const messageKey = entry.messageId ?? "__global__"
     const partKey = entry.partId ?? entry.permission?.id ?? "__global__"
 

--- a/packages/ui/src/stores/message-v2/instance-store.ts
+++ b/packages/ui/src/stores/message-v2/instance-store.ts
@@ -911,6 +911,17 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     setState(
       "permissions",
       produce((draft) => {
+        Object.keys(draft.byMessage).forEach((existingMessageKey) => {
+          const partEntries = draft.byMessage[existingMessageKey]
+          Object.keys(partEntries).forEach((existingPartKey) => {
+            if (partEntries[existingPartKey].permission.id === entry.permission.id) {
+              delete partEntries[existingPartKey]
+            }
+          })
+          if (Object.keys(partEntries).length === 0) {
+            delete draft.byMessage[existingMessageKey]
+          }
+        })
         draft.byMessage[messageKey] = draft.byMessage[messageKey] ?? {}
         draft.byMessage[messageKey][partKey] = entry
         const existingIndex = draft.queue.findIndex((item) => item.permission.id === entry.permission.id)
@@ -919,9 +930,8 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
         } else {
           draft.queue[existingIndex] = entry
         }
-        if (!draft.active || draft.active.permission.id === entry.permission.id) {
-          draft.active = entry
-        }
+        draft.queue.sort((left, right) => left.enqueuedAt - right.enqueuedAt)
+        draft.active = draft.queue[0] ?? null
       }),
     )
   }

--- a/packages/ui/src/stores/message-v2/types.ts
+++ b/packages/ui/src/stores/message-v2/types.ts
@@ -153,7 +153,6 @@ export interface PartUpdateInput {
 export interface ReplaceMessageIdOptions {
   oldId: string
   newId: string
-  clearParts?: boolean
 }
 
 export interface ScrollCacheKey {

--- a/packages/ui/src/stores/permission-auto-accept.ts
+++ b/packages/ui/src/stores/permission-auto-accept.ts
@@ -65,6 +65,9 @@ export function setPermissionAutoAcceptEnabled(instanceId: string, sessionId: st
     persist(next)
     return next
   })
+  if (!enabled) {
+    clearAutoAcceptSession(instanceId, sessionId)
+  }
 }
 
 export function togglePermissionAutoAccept(instanceId: string, sessionId: string) {
@@ -82,6 +85,31 @@ function clearRetry(requestKey: string) {
     retryTimers.delete(requestKey)
   }
   retryAttempts.delete(requestKey)
+}
+
+export function clearAutoAcceptPermission(instanceId: string, sessionId: string, requestId: string) {
+  const requestKey = makeRequestKey(instanceId, sessionId, requestId)
+  inFlight.delete(requestKey)
+  clearRetry(requestKey)
+}
+
+export function clearAutoAcceptSession(instanceId: string, sessionId: string) {
+  const prefix = `${makeKey(instanceId, sessionId)}:`
+  for (const requestKey of Array.from(inFlight)) {
+    if (requestKey.startsWith(prefix)) {
+      inFlight.delete(requestKey)
+    }
+  }
+  for (const requestKey of Array.from(retryTimers.keys())) {
+    if (requestKey.startsWith(prefix)) {
+      clearRetry(requestKey)
+    }
+  }
+  for (const requestKey of Array.from(retryAttempts.keys())) {
+    if (requestKey.startsWith(prefix)) {
+      retryAttempts.delete(requestKey)
+    }
+  }
 }
 
 function scheduleRetry(

--- a/packages/ui/src/stores/permission-auto-accept.ts
+++ b/packages/ui/src/stores/permission-auto-accept.ts
@@ -1,6 +1,16 @@
 import { createSignal } from "solid-js"
+import type { PermissionRequestLike, PermissionReply } from "../types/permission"
+import { getPermissionSessionId } from "../types/permission"
+import { getLogger } from "../lib/logger"
 
 const STORAGE_KEY = "codenomad:permission-auto-accept:v1"
+const RETRY_BASE_DELAY_MS = 1_000
+const RETRY_MAX_DELAY_MS = 10_000
+
+const log = getLogger("api")
+
+type AutoAcceptResponder = (instanceId: string, sessionId: string, requestId: string, reply: PermissionReply) => Promise<void>
+type PendingPermissionChecker = (instanceId: string, requestId: string) => boolean
 
 function makeKey(instanceId: string, sessionId: string) {
   return `${instanceId}:${sessionId}`
@@ -34,9 +44,10 @@ function persist(next: Map<string, boolean>) {
 }
 
 const [autoAcceptState, setAutoAcceptState] = createSignal(readInitialState())
-const [inFlightVersion, setInFlightVersion] = createSignal(0)
 
 const inFlight = new Set<string>()
+const retryAttempts = new Map<string, number>()
+const retryTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
 export function isPermissionAutoAcceptEnabled(instanceId: string, sessionId: string) {
   return autoAcceptState().get(makeKey(instanceId, sessionId)) ?? false
@@ -60,22 +71,75 @@ export function togglePermissionAutoAccept(instanceId: string, sessionId: string
   setPermissionAutoAcceptEnabled(instanceId, sessionId, !isPermissionAutoAcceptEnabled(instanceId, sessionId))
 }
 
-export function canAutoRespondPermission(instanceId: string, sessionId: string, requestId: string) {
-  const key = makeKey(instanceId, sessionId)
-  if (!autoAcceptState().get(key)) return false
-  const requestKey = `${key}:${requestId}`
-  if (inFlight.has(requestKey)) return false
-  inFlight.add(requestKey)
-  return true
+function makeRequestKey(instanceId: string, sessionId: string, requestId: string) {
+  return `${makeKey(instanceId, sessionId)}:${requestId}`
 }
 
-export function getPermissionAutoAcceptInFlightVersion() {
-  return inFlightVersion()
-}
-
-export function finishAutoRespondPermission(instanceId: string, sessionId: string, requestId: string) {
-  if (!inFlight.delete(`${makeKey(instanceId, sessionId)}:${requestId}`)) {
-    return
+function clearRetry(requestKey: string) {
+  const timer = retryTimers.get(requestKey)
+  if (timer) {
+    clearTimeout(timer)
+    retryTimers.delete(requestKey)
   }
-  setInFlightVersion((value) => value + 1)
+  retryAttempts.delete(requestKey)
+}
+
+function scheduleRetry(
+  instanceId: string,
+  permission: PermissionRequestLike,
+  responder: AutoAcceptResponder,
+  isPending: PendingPermissionChecker,
+  requestKey: string,
+) {
+  if (retryTimers.has(requestKey)) return
+  const attempt = (retryAttempts.get(requestKey) ?? 0) + 1
+  retryAttempts.set(requestKey, attempt)
+  const delay = Math.min(RETRY_BASE_DELAY_MS * 2 ** (attempt - 1), RETRY_MAX_DELAY_MS)
+  const timer = setTimeout(() => {
+    retryTimers.delete(requestKey)
+    drainAutoAcceptPermission(instanceId, permission, responder, isPending)
+  }, delay)
+  retryTimers.set(requestKey, timer)
+}
+
+export function drainAutoAcceptPermission(
+  instanceId: string,
+  permission: PermissionRequestLike,
+  responder: AutoAcceptResponder,
+  isPending: PendingPermissionChecker,
+) {
+  const sessionId = getPermissionSessionId(permission)
+  if (!sessionId || !permission?.id) return
+  if (!isPermissionAutoAcceptEnabled(instanceId, sessionId)) return
+  if (!isPending(instanceId, permission.id)) return
+
+  const requestKey = makeRequestKey(instanceId, sessionId, permission.id)
+  if (inFlight.has(requestKey) || retryTimers.has(requestKey)) return
+
+  inFlight.add(requestKey)
+
+  void responder(instanceId, sessionId, permission.id, "once")
+    .then(() => {
+      clearRetry(requestKey)
+    })
+    .catch((error) => {
+      log.error("Failed to auto-accept permission", error)
+      if (isPending(instanceId, permission.id) && isPermissionAutoAcceptEnabled(instanceId, sessionId)) {
+        scheduleRetry(instanceId, permission, responder, isPending, requestKey)
+      }
+    })
+    .finally(() => {
+      inFlight.delete(requestKey)
+    })
+}
+
+export function drainAutoAcceptPermissions(
+  instanceId: string,
+  permissions: PermissionRequestLike[],
+  responder: AutoAcceptResponder,
+  isPending: PendingPermissionChecker,
+) {
+  for (const permission of permissions) {
+    drainAutoAcceptPermission(instanceId, permission, responder, isPending)
+  }
 }

--- a/packages/ui/src/stores/session-events.ts
+++ b/packages/ui/src/stores/session-events.ts
@@ -349,7 +349,7 @@ function handleMessageUpdate(instanceId: string, event: MessageUpdateEvent | Mes
     if (!record) {
       const pendingId = findPendingSyntheticMessageId(store, sessionId, role)
       if (pendingId && pendingId !== messageId) {
-        replaceMessageIdV2(instanceId, pendingId, messageId, { clearParts: role === "user" })
+        replaceMessageIdV2(instanceId, pendingId, messageId)
         record = store.getMessage(messageId)
       }
     }
@@ -415,7 +415,7 @@ function handleMessageUpdate(instanceId: string, event: MessageUpdateEvent | Mes
     if (!record) {
       const pendingId = findPendingSyntheticMessageId(store, sessionId, role)
       if (pendingId && pendingId !== messageId) {
-        replaceMessageIdV2(instanceId, pendingId, messageId, { clearParts: role === "user" })
+        replaceMessageIdV2(instanceId, pendingId, messageId)
         record = store.getMessage(messageId)
       }
     }
@@ -700,8 +700,8 @@ function handlePermissionUpdated(instanceId: string, event: { type: string; prop
   }
 
   log.info(`[SSE] Permission request: ${permissionId} (${getPermissionKind(permission)})`)
-  addPermissionToQueue(instanceId, permission)
-  upsertPermissionV2(instanceId, permission)
+  const queuedPermission = addPermissionToQueue(instanceId, permission) ?? permission
+  upsertPermissionV2(instanceId, queuedPermission)
 
   const sessionId = getPermissionSessionId(permission)
 

--- a/packages/ui/src/stores/session-events.ts
+++ b/packages/ui/src/stores/session-events.ts
@@ -35,6 +35,8 @@ import {
   instances,
   addPermissionToQueue,
   removePermissionFromQueue,
+  markPermissionReplied,
+  hasRecentlyRepliedPermission,
   addQuestionToQueue,
   removeQuestionFromQueue,
 } from "./instances"
@@ -59,6 +61,7 @@ import {
   applyPartUpdateV2,
   applyPartDeltaV2,
   replaceMessageIdV2,
+  reconcilePendingPermissionsV2,
   reconcilePendingQuestionsV2,
   upsertMessageInfoV2,
   upsertPermissionV2,
@@ -370,8 +373,9 @@ function handleMessageUpdate(instanceId: string, event: MessageUpdateEvent | Mes
     applyPartUpdateV2(instanceId, { ...part, sessionID: sessionId, messageID: messageId })
     handleConversationAssistantPartUpdated(instanceId, { ...part, sessionID: sessionId, messageID: messageId }, messageInfo)
 
-    if (part.type === "tool" && part.tool === "question") {
-      // Questions can arrive before their tool part exists; re-link now.
+    if (part.type === "tool") {
+      // Interruptions can arrive before their tool part exists; re-link now.
+      reconcilePendingPermissionsV2(instanceId, sessionId)
       reconcilePendingQuestionsV2(instanceId, sessionId)
     }
 
@@ -689,8 +693,13 @@ function handleTuiToast(_instanceId: string, event: TuiToastEvent): void {
 function handlePermissionUpdated(instanceId: string, event: { type: string; properties?: PermissionRequestLike } | any): void {
   const permission = event?.properties as PermissionRequestLike | undefined
   if (!permission) return
+  const permissionId = getPermissionId(permission)
+  if (permissionId && hasRecentlyRepliedPermission(instanceId, permissionId)) {
+    log.info(`[SSE] Ignoring stale permission request after local reply: ${permissionId}`)
+    return
+  }
 
-  log.info(`[SSE] Permission request: ${getPermissionId(permission)} (${getPermissionKind(permission)})`)
+  log.info(`[SSE] Permission request: ${permissionId} (${getPermissionKind(permission)})`)
   addPermissionToQueue(instanceId, permission)
   upsertPermissionV2(instanceId, permission)
 
@@ -710,6 +719,7 @@ function handlePermissionReplied(instanceId: string, event: { type: string; prop
   if (!requestId) return
 
   log.info(`[SSE] Permission replied: ${requestId}`)
+  markPermissionReplied(instanceId, requestId)
   removePermissionFromQueue(instanceId, requestId)
   removePermissionV2(instanceId, requestId)
 }


### PR DESCRIPTION
Fixes #290
Supersedes #367

## Summary
- keep permission replies idempotent by clearing both the global queue and message-v2 state after a successful reply
- reconcile pending permissions when tool parts arrive, matching the existing question flow
- prevent stale or duplicate permission events from leaving mismatched active/attached permission state
- drain YOLO auto-accept from the permission flow itself instead of the rendered instance shell
- preserve optimistic user attachments across SSE event reordering until official server parts arrive

## Bugs and Fragile Flows Fixed
- **Reply cleanup depended on `permission.replied` SSE**: `sendPermissionResponse()` removed only the global permission queue entry, so if the replied event was delayed or missed, inline tool-call UI could keep showing a stale permission.
- **Delayed permission events could resurrect handled prompts**: a late `permission.updated` for an already accepted permission could re-add it locally until reload corrected state from `permission.list()`.
- **Duplicate permission payloads were discarded or downgraded**: repeated events for the same permission ID could drop richer session/worktree/tool-call metadata when a later payload was partial.
- **Pending session badges could drift**: replacing a permission payload with a different session ID did not rebalance pending permission counters.
- **Permission/tool-call attachment was asymmetric with questions**: live `message.part.updated` re-linked questions, but permissions depended on narrower incidental rebind paths or full message reload.
- **message-v2 could keep multiple attachment keys for one permission**: a permission could remain under an old global/ID key and later also be inserted under the resolved tool part.
- **message-v2 active permission could stay stale**: active state was only refreshed in limited cases instead of being derived from the ordered pending queue.
- **Optimistic user attachments could disappear during ID replacement**: `message.updated` could replace a synthetic message ID before user part events arrived and clear the optimistic parts, including resolved pasted/file attachment content.
- **YOLO auto-accept depended on shell rendering**: the auto-accept drain lived in `instance-shell2`, so heavy message rendering or permission UI churn could delay replies even though the request was already queued.
- **YOLO retry could amplify UI churn or outlive permissions**: transient reply failures were retried through a reactive render effect, and retry state was not fully cleaned up when permissions were removed, queues were cleared, or YOLO was disabled.

## Implementation
- Add short-lived local tombstones for replied permission IDs to ignore stale permission updates after a successful local or SSE reply.
- Merge duplicate permission entries conservatively in both the global queue and message-v2, preserving existing IDs and nested metadata/time/tool data when incoming events are partial.
- Update duplicate permission entries in the global queue, including pending session counters and worktree slug mapping.
- Remove permissions from both `instances.ts` and `message-v2` after successful replies so the UI does not depend on receiving `permission.replied`.
- Run `reconcilePendingPermissionsV2()` for every live tool part update.
- Make `message-v2` enforce one `byMessage` attachment per permission ID and recalculate active permission from the sorted queue.
- Allow permission reconciliation to repair entries whose `partId` exists but whose `byMessage` attachment was lost.
- Preserve optimistic user message parts when temporary message IDs are replaced, then remove matching synthetic text/file parts only when the official server part arrives.
- Move YOLO draining into `permission-auto-accept.ts` and trigger it from permission sync, live permission enqueue, and the Status-tab toggle.
- Add bounded retry backoff for failed YOLO replies while verifying the permission is still pending before retrying.
- Clear YOLO retry/in-flight state when permissions are removed, queues are cleared, or per-session auto-accept is disabled.

## YOLO Mode
- No product behavior change: YOLO remains per-session and continues to reply with `once` only.
- This only decouples auto-accept from rendered UI so queued permissions can be answered without waiting for permission/tool-call UI to render.

## Validation
- `git diff --check`
- `npm run typecheck --workspace @codenomad/ui`
- `npm run build --workspace @codenomad/ui`
- final read-only gatekeeper review: clear

## Notes
- `packages/ui` does not currently define a test script/runner, so this PR is validated with typecheck/build rather than new automated unit tests.
- Build still emits the existing `virtua` JSX import-source warning and large chunk warnings.
