### PR TITLE
fix(ui): follow up idle badge behavior

### DIFF
--- a/packages/ui/src/components/instance-tab.tsx
+++ b/packages/ui/src/components/instance-tab.tsx
@@ -1,8 +1,9 @@
-import { Component, Show, createMemo } from "solid-js"
+import { Component, Show, createMemo, createSignal, onCleanup } from "solid-js"
 import type { Instance } from "../types/instance"
-import { getInstanceSessionIndicatorStatus } from "../stores/session-status"
+import { getInstanceIdleFadeClass, getInstanceSessionIndicatorStatus } from "../stores/session-status"
 import { FolderOpen, ShieldAlert, X } from "lucide-solid"
 import { useI18n } from "../lib/i18n"
+import { useConfig } from "../stores/preferences"
 
 interface InstanceTabProps {
   instance: Instance
@@ -20,12 +21,25 @@ function getPathBasename(path: string): string {
 
 const InstanceTab: Component<InstanceTabProps> = (props) => {
   const { t } = useI18n()
+  const { preferences } = useConfig()
+  const [now, setNow] = createSignal(Date.now())
 
-  const aggregatedStatus = createMemo(() => getInstanceSessionIndicatorStatus(props.instance.id))
+  if (typeof window !== "undefined") {
+    const timer = window.setInterval(() => setNow(Date.now()), 1000)
+    onCleanup(() => window.clearInterval(timer))
+  }
+
+  const aggregatedStatus = createMemo(() =>
+    getInstanceSessionIndicatorStatus(props.instance.id, now(), preferences().keepUnseenSubagentIdleStatus),
+  )
   const statusClassName = createMemo(() => {
     const status = aggregatedStatus()
     if (!status) return null
-    return status === "permission" ? "session-permission" : `session-${status}`
+    if (status === "permission") return "session-permission"
+    const base = `session-${status}`
+    const fadeClass =
+      status === "idle" ? getInstanceIdleFadeClass(props.instance.id, now(), preferences().keepUnseenSubagentIdleStatus) : ""
+    return fadeClass ? `${base} ${fadeClass}` : base
   })
   const statusTitle = createMemo(() => {
     switch (aggregatedStatus()) {

--- a/packages/ui/src/components/instance/instance-shell2.tsx
+++ b/packages/ui/src/components/instance/instance-shell2.tsx
@@ -41,9 +41,10 @@ import SessionSidebar from "./shell/SessionSidebar"
 import { useSessionSidebarRequests } from "./shell/useSessionSidebarRequests"
 import RightPanel from "./shell/right-panel/RightPanel"
 import { useDrawerChrome } from "./shell/useDrawerChrome"
-import { getRetrySeconds, getSessionRetry, getSessionStatus, shouldShowSessionStatus } from "../../stores/session-status"
+import { getRetrySeconds, getSessionIdleFadeClass, getSessionRetry, getSessionStatus, shouldShowSessionStatus } from "../../stores/session-status"
 import { Maximize2, Search, ShieldAlert } from "lucide-solid"
 import type { PromptInputApi } from "../prompt-input/types"
+import { useConfig } from "../../stores/preferences"
 
 import type { LayoutMode } from "./shell/types"
 import {
@@ -91,6 +92,7 @@ interface InstanceShellProps {
 
 const InstanceShell2: Component<InstanceShellProps> = (props) => {
   const { t, locale } = useI18n()
+  const { preferences } = useConfig()
   const isRTL = () => locale() === "he"
 
   const [sessionSidebarWidth, setSessionSidebarWidth] = createSignal(DEFAULT_SESSION_SIDEBAR_WIDTH)
@@ -330,7 +332,12 @@ const InstanceShell2: Component<InstanceShellProps> = (props) => {
 
     const status = getSessionStatus(props.instance.id, activeSessionId)
     const retry = getSessionRetry(props.instance.id, activeSessionId)
-    const showStatus = shouldShowSessionStatus(props.instance.id, activeSessionId)
+    const showStatus = shouldShowSessionStatus(
+      props.instance.id,
+      activeSessionId,
+      now(),
+      preferences().keepUnseenSubagentIdleStatus,
+    )
     if (!showStatus) {
       return null
     }
@@ -345,8 +352,11 @@ const InstanceShell2: Component<InstanceShellProps> = (props) => {
           ? t("sessionList.status.compacting")
           : t("sessionList.status.idle")
 
+    const baseClassName = `session-${retry ? "retrying" : status}`
+    const fadeClassName = getSessionIdleFadeClass(props.instance.id, activeSessionId)
+
     return {
-      className: `session-${retry ? "retrying" : status}`,
+      className: fadeClassName ? `${baseClassName} ${fadeClassName}` : baseClassName,
       text,
       showAlertIcon: false,
       title: retry

--- a/packages/ui/src/components/session-list.tsx
+++ b/packages/ui/src/components/session-list.tsx
@@ -1,7 +1,7 @@
 import { Component, For, Show, createSignal, createMemo, createEffect, JSX, onCleanup } from "solid-js"
 import type { SessionStatus } from "../types/session"
 import type { SessionThread } from "../stores/session-state"
-import { getRetrySeconds, getSessionRetry, getSessionStatus, shouldShowSessionStatus } from "../stores/session-status"
+import { getRetrySeconds, getSessionIdleFadeClass, getSessionRetry, getSessionStatus, shouldShowSessionStatus } from "../stores/session-status"
 import { Bot, User, Copy, Trash2, Pencil, ShieldAlert, ChevronDown, Search, Square, CheckSquare, MinusSquare, Split, RotateCw } from "lucide-solid"
 import KeyboardHint from "./keyboard-hint"
 import SessionRenameDialog from "./session-rename-dialog"
@@ -24,6 +24,7 @@ import {
 import { getGitRepoStatus, getWorktreeSlugForParentSession } from "../stores/worktrees"
 import { getLogger } from "../lib/logger"
 import { copyToClipboard } from "../lib/clipboard"
+import { useConfig } from "../stores/preferences"
 const log = getLogger("session")
 
 
@@ -47,6 +48,7 @@ function formatSessionStatus(status: SessionStatus): string {
 
 const SessionList: Component<SessionListProps> = (props) => {
   const { t } = useI18n()
+  const { preferences } = useConfig()
   const [renameTarget, setRenameTarget] = createSignal<{ id: string; title: string; label: string } | null>(null)
   const [isRenaming, setIsRenaming] = createSignal(false)
 
@@ -426,8 +428,20 @@ const SessionList: Component<SessionListProps> = (props) => {
     const needsPermission = () => Boolean(session()?.pendingPermission)
     const needsQuestion = () => Boolean((session() as any)?.pendingQuestion)
     const needsInput = () => needsPermission() || needsQuestion()
-    const statusClassName = () => (needsInput() ? "session-permission" : `session-${retry() ? "retrying" : status()}`)
-    const showStatus = () => needsInput() || shouldShowSessionStatus(props.instanceId, rowProps.sessionId)
+    const statusClassName = () => {
+      if (needsInput()) return "session-permission"
+      const base = `session-${retry() ? "retrying" : status()}`
+      const fadeClass = getSessionIdleFadeClass(props.instanceId, rowProps.sessionId)
+      return fadeClass ? `${base} ${fadeClass}` : base
+    }
+    const showStatus = () =>
+      needsInput() ||
+      shouldShowSessionStatus(
+        props.instanceId,
+        rowProps.sessionId,
+        now(),
+        preferences().keepUnseenSubagentIdleStatus,
+      )
     const statusText = () =>
       needsPermission()
         ? t("sessionList.status.needsPermission")

--- a/packages/ui/src/components/session/session-view.tsx
+++ b/packages/ui/src/components/session/session-view.tsx
@@ -8,8 +8,8 @@ import PromptInput from "../prompt-input"
 import PromptAttachmentsBar from "../prompt-input/PromptAttachmentsBar"
 import { getAttachments, removeAttachment } from "../../stores/attachments"
 import { instances } from "../../stores/instances"
-import { loadMessages, sendMessage, forkSession, renameSession, isSessionMessagesLoading, markViewedSessionIdleSeen, setActiveParentSession, setActiveSession, runShellCommand, abortSession } from "../../stores/sessions"
-import { IDLE_STATUS_VISIBILITY_MS, isSessionBusy as getSessionBusyStatus, markSessionIdleFadeStarted } from "../../stores/session-status"
+import { loadMessages, sendMessage, forkSession, renameSession, isSessionMessagesLoading, markSessionIdleSeen, setActiveParentSession, setActiveSession, runShellCommand, abortSession } from "../../stores/sessions"
+import { clearSessionIdleFade, IDLE_STATUS_VISIBILITY_MS, isSessionBusy as getSessionBusyStatus, markSessionIdleFadeStarted } from "../../stores/session-status"
 import { deleteMessage } from "../../stores/session-actions"
 import { showAlertDialog } from "../../stores/alerts"
 import { getLogger } from "../../lib/logger"
@@ -17,6 +17,7 @@ import { requestData } from "../../lib/opencode-api"
 import { useI18n } from "../../lib/i18n"
 import type { PromptInputApi, PromptInsertMode } from "../prompt-input/types"
 import { clearConversationPlaybackForSession } from "../../stores/conversation-speech"
+import { useConfig } from "../../stores/preferences"
 
 const log = getLogger("session")
 
@@ -41,6 +42,7 @@ interface SessionViewProps {
 
 export const SessionView: Component<SessionViewProps> = (props) => {
   const { t } = useI18n()
+  const { preferences } = useConfig()
   const session = () => props.activeSessions.get(props.sessionId)
   const messagesLoading = createMemo(() => isSessionMessagesLoading(props.instanceId, props.sessionId))
   const messageStore = createMemo(() => messageStoreBus.getOrCreate(props.instanceId))
@@ -82,14 +84,14 @@ export const SessionView: Component<SessionViewProps> = (props) => {
     })
   }
 
-  function getSeenIdleEntries(currentSession: Session): Array<{ id: string; idleSince: number }> {
+  function getSeenIdleEntries(currentSession: Session, keepUnseenSubagentIdleStatus: boolean): Array<{ id: string; idleSince: number }> {
     const entries: Array<{ id: string; idleSince: number }> = []
 
     if (currentSession.status === "idle" && typeof currentSession.idleSince === "number") {
       entries.push({ id: currentSession.id, idleSince: currentSession.idleSince })
     }
 
-    if (currentSession.parentId === null) {
+    if (currentSession.parentId === null && !keepUnseenSubagentIdleStatus) {
       for (const child of props.activeSessions.values()) {
         if (child.parentId !== currentSession.id) continue
         if (child.status !== "idle") continue
@@ -99,10 +101,6 @@ export const SessionView: Component<SessionViewProps> = (props) => {
     }
 
     return entries
-  }
-
-  function getSeenIdleSignature(entries: Array<{ id: string; idleSince: number }>): string {
-    return entries.map((entry) => `${entry.id}:${entry.idleSince}`).sort().join("|")
   }
 
   createEffect(
@@ -121,23 +119,22 @@ export const SessionView: Component<SessionViewProps> = (props) => {
     const currentSession = session()
     if (!props.isActive || !currentSession) return
 
-    const seenIdleEntries = getSeenIdleEntries(currentSession)
-    const seenIdleSignature = getSeenIdleSignature(seenIdleEntries)
-    if (!seenIdleSignature) return
-    const timerKey = `${props.instanceId}:${currentSession.id}:${seenIdleSignature}`
-    if (pendingIdleSeenTimers.has(timerKey)) return
-    pendingIdleSeenTimers.add(timerKey)
+    const seenIdleEntries = getSeenIdleEntries(currentSession, preferences().keepUnseenSubagentIdleStatus)
     for (const entry of seenIdleEntries) {
+      const timerKey = `${props.instanceId}:${entry.id}:${entry.idleSince}`
+      if (pendingIdleSeenTimers.has(timerKey)) continue
+      pendingIdleSeenTimers.add(timerKey)
       markSessionIdleFadeStarted(props.instanceId, entry.id)
-    }
 
-    window.setTimeout(() => {
-      pendingIdleSeenTimers.delete(timerKey)
-      const latestSession = session()
-      if (!latestSession) return
-      if (getSeenIdleSignature(getSeenIdleEntries(latestSession)) !== seenIdleSignature) return
-      markViewedSessionIdleSeen(props.instanceId, latestSession.id, false)
-    }, IDLE_STATUS_VISIBILITY_MS)
+      window.setTimeout(() => {
+        pendingIdleSeenTimers.delete(timerKey)
+        const latestEntry = props.activeSessions.get(entry.id)
+        if (latestEntry?.status === "idle" && latestEntry.idleSince === entry.idleSince) {
+          markSessionIdleSeen(props.instanceId, entry.id)
+        }
+        clearSessionIdleFade(props.instanceId, entry.id, entry.idleSince)
+      }, IDLE_STATUS_VISIBILITY_MS)
+    }
   })
 
   createEffect(

--- a/packages/ui/src/components/session/session-view.tsx
+++ b/packages/ui/src/components/session/session-view.tsx
@@ -1,4 +1,4 @@
-import { Show, createMemo, createEffect, on, onCleanup, type Component } from "solid-js"
+import { Show, createMemo, createEffect, on, type Component } from "solid-js"
 import type { Session } from "../../types/session"
 import type { Attachment } from "../../types/attachment"
 import type { ClientPart } from "../../types/message"
@@ -9,7 +9,7 @@ import PromptAttachmentsBar from "../prompt-input/PromptAttachmentsBar"
 import { getAttachments, removeAttachment } from "../../stores/attachments"
 import { instances } from "../../stores/instances"
 import { loadMessages, sendMessage, forkSession, renameSession, isSessionMessagesLoading, markViewedSessionIdleSeen, setActiveParentSession, setActiveSession, runShellCommand, abortSession } from "../../stores/sessions"
-import { IDLE_STATUS_VISIBILITY_MS, isSessionBusy as getSessionBusyStatus } from "../../stores/session-status"
+import { IDLE_STATUS_VISIBILITY_MS, isSessionBusy as getSessionBusyStatus, markSessionIdleFadeStarted } from "../../stores/session-status"
 import { deleteMessage } from "../../stores/session-actions"
 import { showAlertDialog } from "../../stores/alerts"
 import { getLogger } from "../../lib/logger"
@@ -17,7 +17,6 @@ import { requestData } from "../../lib/opencode-api"
 import { useI18n } from "../../lib/i18n"
 import type { PromptInputApi, PromptInsertMode } from "../prompt-input/types"
 import { clearConversationPlaybackForSession } from "../../stores/conversation-speech"
-import { useConfig } from "../../stores/preferences"
 
 const log = getLogger("session")
 
@@ -42,7 +41,6 @@ interface SessionViewProps {
 
 export const SessionView: Component<SessionViewProps> = (props) => {
   const { t } = useI18n()
-  const { preferences } = useConfig()
   const session = () => props.activeSessions.get(props.sessionId)
   const messagesLoading = createMemo(() => isSessionMessagesLoading(props.instanceId, props.sessionId))
   const messageStore = createMemo(() => messageStoreBus.getOrCreate(props.instanceId))
@@ -68,6 +66,7 @@ export const SessionView: Component<SessionViewProps> = (props) => {
 
   let scrollToBottomHandle: (() => void) | undefined
   let rootRef: HTMLDivElement | undefined
+  const pendingIdleSeenTimers = new Set<string>()
 
   function shouldScrollToBottomOnActivate() {
     const current = session()
@@ -83,23 +82,27 @@ export const SessionView: Component<SessionViewProps> = (props) => {
     })
   }
 
-  function getSeenIdleSignature(currentSession: Session, keepUnseenSubagentIdleStatus: boolean): string {
-    const ids: string[] = []
+  function getSeenIdleEntries(currentSession: Session): Array<{ id: string; idleSince: number }> {
+    const entries: Array<{ id: string; idleSince: number }> = []
 
     if (currentSession.status === "idle" && typeof currentSession.idleSince === "number") {
-      ids.push(`${currentSession.id}:${currentSession.idleSince}`)
+      entries.push({ id: currentSession.id, idleSince: currentSession.idleSince })
     }
 
-    if (currentSession.parentId === null && !keepUnseenSubagentIdleStatus) {
+    if (currentSession.parentId === null) {
       for (const child of props.activeSessions.values()) {
         if (child.parentId !== currentSession.id) continue
         if (child.status !== "idle") continue
         if (typeof child.idleSince !== "number") continue
-        ids.push(`${child.id}:${child.idleSince}`)
+        entries.push({ id: child.id, idleSince: child.idleSince })
       }
     }
 
-    return ids.sort().join("|")
+    return entries
+  }
+
+  function getSeenIdleSignature(entries: Array<{ id: string; idleSince: number }>): string {
+    return entries.map((entry) => `${entry.id}:${entry.idleSince}`).sort().join("|")
   }
 
   createEffect(
@@ -118,19 +121,23 @@ export const SessionView: Component<SessionViewProps> = (props) => {
     const currentSession = session()
     if (!props.isActive || !currentSession) return
 
-    const keepUnseenSubagentIdleStatus = preferences().keepUnseenSubagentIdleStatus
-    const seenIdleSignature = getSeenIdleSignature(currentSession, keepUnseenSubagentIdleStatus)
+    const seenIdleEntries = getSeenIdleEntries(currentSession)
+    const seenIdleSignature = getSeenIdleSignature(seenIdleEntries)
     if (!seenIdleSignature) return
+    const timerKey = `${props.instanceId}:${currentSession.id}:${seenIdleSignature}`
+    if (pendingIdleSeenTimers.has(timerKey)) return
+    pendingIdleSeenTimers.add(timerKey)
+    for (const entry of seenIdleEntries) {
+      markSessionIdleFadeStarted(props.instanceId, entry.id)
+    }
 
-    const timeout = window.setTimeout(() => {
+    window.setTimeout(() => {
+      pendingIdleSeenTimers.delete(timerKey)
       const latestSession = session()
-      if (!props.isActive || !latestSession) return
-      const latestKeepUnseenSubagentIdleStatus = preferences().keepUnseenSubagentIdleStatus
-      if (getSeenIdleSignature(latestSession, latestKeepUnseenSubagentIdleStatus) !== seenIdleSignature) return
-      markViewedSessionIdleSeen(props.instanceId, latestSession.id, latestKeepUnseenSubagentIdleStatus)
+      if (!latestSession) return
+      if (getSeenIdleSignature(getSeenIdleEntries(latestSession)) !== seenIdleSignature) return
+      markViewedSessionIdleSeen(props.instanceId, latestSession.id, false)
     }, IDLE_STATUS_VISIBILITY_MS)
-
-    onCleanup(() => window.clearTimeout(timeout))
   })
 
   createEffect(

--- a/packages/ui/src/stores/session-status.test.ts
+++ b/packages/ui/src/stores/session-status.test.ts
@@ -2,7 +2,8 @@ import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 
 import { getIdleSinceForStatusTransition } from "../types/session.ts"
-import { IDLE_STATUS_VISIBILITY_MS, shouldShowIdleStatus } from "./session-status.ts"
+import { clearSessionIdleFade, getSessionIdleFadeClass, IDLE_STATUS_VISIBILITY_MS, markSessionIdleFadeStarted, shouldShowIdleStatus } from "./session-status.ts"
+import { setSessions } from "./session-state.ts"
 import { shouldSessionHoldWakeLock } from "./wake-lock-eligibility.ts"
 
 describe("shouldSessionHoldWakeLock", () => {
@@ -60,5 +61,38 @@ describe("idle status visibility", () => {
 
     assert.equal(idleSince, null)
     assert.equal(shouldShowIdleStatus({ status: "working", idleSince, parentId: null }), false)
+  })
+
+  it("clears idle fade state for a specific idle transition", () => {
+    const instanceId = "instance"
+    const sessionId = "session"
+    const idleSince = 1_000
+
+    setSessions(
+      new Map([
+        [
+          instanceId,
+          new Map([
+            [
+              sessionId,
+              {
+                id: sessionId,
+                status: "idle",
+                idleSince,
+                parentId: null,
+              } as any,
+            ],
+          ]),
+        ],
+      ]),
+    )
+
+    markSessionIdleFadeStarted(instanceId, sessionId)
+    assert.equal(getSessionIdleFadeClass(instanceId, sessionId), "session-status-fading")
+
+    clearSessionIdleFade(instanceId, sessionId, idleSince)
+    assert.equal(getSessionIdleFadeClass(instanceId, sessionId), "")
+
+    setSessions(new Map())
   })
 })

--- a/packages/ui/src/stores/session-status.test.ts
+++ b/packages/ui/src/stores/session-status.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 
 import { getIdleSinceForStatusTransition } from "../types/session.ts"
-import { clearSessionIdleFade, getSessionIdleFadeClass, IDLE_STATUS_VISIBILITY_MS, markSessionIdleFadeStarted, shouldShowIdleStatus } from "./session-status.ts"
+import { clearSessionIdleFade, getSessionIdleFadeClass, IDLE_STATUS_VISIBILITY_MS, markSessionIdleFadeStarted, shouldShowIdleStatus, shouldShowSessionStatus } from "./session-status.ts"
 import { setSessions } from "./session-state.ts"
 import { shouldSessionHoldWakeLock } from "./wake-lock-eligibility.ts"
 
@@ -93,6 +93,39 @@ describe("idle status visibility", () => {
     clearSessionIdleFade(instanceId, sessionId, idleSince)
     assert.equal(getSessionIdleFadeClass(instanceId, sessionId), "")
 
+    setSessions(new Map())
+  })
+
+  it("keeps a default-mode subagent visible while its parent-triggered fade runs", () => {
+    const instanceId = "instance"
+    const sessionId = "subsession"
+    const idleSince = 1_000
+
+    setSessions(
+      new Map([
+        [
+          instanceId,
+          new Map([
+            [
+              sessionId,
+              {
+                id: sessionId,
+                status: "idle",
+                idleSince,
+                parentId: "parent",
+              } as any,
+            ],
+          ]),
+        ],
+      ]),
+    )
+
+    assert.equal(shouldShowSessionStatus(instanceId, sessionId, 7_000, false), false)
+
+    markSessionIdleFadeStarted(instanceId, sessionId)
+    assert.equal(shouldShowSessionStatus(instanceId, sessionId, 7_000, false), true)
+
+    clearSessionIdleFade(instanceId, sessionId, idleSince)
     setSessions(new Map())
   })
 })

--- a/packages/ui/src/stores/session-status.test.ts
+++ b/packages/ui/src/stores/session-status.test.ts
@@ -37,14 +37,15 @@ describe("idle status visibility", () => {
   it("keeps subagent idle visible until the parent or child session is seen", () => {
     const idleSince = getIdleSinceForStatusTransition("working", "idle", null, 1_000)
 
-    assert.equal(shouldShowIdleStatus({ status: "idle", idleSince, parentId: "parent" }), true)
-    assert.equal(shouldShowIdleStatus({ status: "idle", idleSince, parentId: "parent" }), true)
+    assert.equal(shouldShowIdleStatus({ status: "idle", idleSince, parentId: "parent" }, 2_000, true), true)
+    assert.equal(shouldShowIdleStatus({ status: "idle", idleSince, parentId: "parent" }, 10_000, true), true)
   })
 
-  it("does not use the keep-unseen setting to age out visible idle markers", () => {
+  it("ages out subagent idle markers unless keep-unseen is enabled", () => {
     const idleSince = getIdleSinceForStatusTransition("working", "idle", null, 1_000)
 
-    assert.equal(shouldShowIdleStatus({ status: "idle", idleSince, parentId: "parent" }), true)
+    assert.equal(shouldShowIdleStatus({ status: "idle", idleSince, parentId: "parent" }, 2_000, false), true)
+    assert.equal(shouldShowIdleStatus({ status: "idle", idleSince, parentId: "parent" }, 7_000, false), false)
   })
 
   it("does not show idle for sessions that started idle", () => {

--- a/packages/ui/src/stores/session-status.ts
+++ b/packages/ui/src/stores/session-status.ts
@@ -54,16 +54,16 @@ export function markSessionIdleFadeStarted(instanceId: string, sessionId: string
     next.set(key, Date.now())
     return next
   })
-  if (typeof window !== "undefined") {
-    window.setTimeout(() => {
-      setIdleFadeStarts((prev) => {
-        if (!prev.has(key)) return prev
-        const next = new Map(prev)
-        next.delete(key)
-        return next
-      })
-    }, IDLE_STATUS_VISIBILITY_MS + 1000)
-  }
+}
+
+export function clearSessionIdleFade(instanceId: string, sessionId: string, idleSince: number): void {
+  const key = idleFadeKey(instanceId, sessionId, idleSince)
+  setIdleFadeStarts((prev) => {
+    if (!prev.has(key)) return prev
+    const next = new Map(prev)
+    next.delete(key)
+    return next
+  })
 }
 
 export function getSessionIdleFadeClass(instanceId: string, sessionId: string): string {

--- a/packages/ui/src/stores/session-status.ts
+++ b/packages/ui/src/stores/session-status.ts
@@ -80,9 +80,10 @@ export function getInstanceIdleFadeClass(instanceId: string, now = Date.now(), k
   let hasVisibleIdle = false
   for (const session of instanceSessions.values()) {
     if (!session.id) continue
-    if (!shouldShowIdleStatus(session, now, keepUnseenSubagentIdleStatus)) continue
+    const isFading = Boolean(getSessionIdleFadeClass(instanceId, session.id))
+    if (!isFading && !shouldShowIdleStatus(session, now, keepUnseenSubagentIdleStatus)) continue
     hasVisibleIdle = true
-    if (!getSessionIdleFadeClass(instanceId, session.id)) return ""
+    if (!isFading) return ""
   }
 
   return hasVisibleIdle ? "session-status-fading" : ""
@@ -123,6 +124,10 @@ export function shouldShowSessionStatus(
     return true
   }
 
+  if (session.status === "idle" && getSessionIdleFadeClass(instanceId, sessionId)) {
+    return true
+  }
+
   return session.status !== "idle" || shouldShowIdleStatus(session, now, keepUnseenSubagentIdleStatus)
 }
 
@@ -148,6 +153,9 @@ export function getInstanceSessionIndicatorStatus(
   }
 
   for (const session of instanceSessions.values()) {
+    if (session.id && getSessionIdleFadeClass(instanceId, session.id)) {
+      return "idle"
+    }
     if (shouldShowIdleStatus(session, now, keepUnseenSubagentIdleStatus)) {
       return "idle"
     }

--- a/packages/ui/src/stores/session-status.ts
+++ b/packages/ui/src/stores/session-status.ts
@@ -1,8 +1,15 @@
 import type { Session, SessionRetryState, SessionStatus } from "../types/session"
 import { getInstanceSessionIndicatorStatusCached, sessions } from "./session-state"
 import { shouldSessionHoldWakeLock } from "./wake-lock-eligibility"
+import { createSignal } from "solid-js"
 
 export const IDLE_STATUS_VISIBILITY_MS = 5000
+
+const [idleFadeStarts, setIdleFadeStarts] = createSignal<Map<string, number>>(new Map())
+
+function idleFadeKey(instanceId: string, sessionId: string, idleSince: number): string {
+  return `${instanceId}:${sessionId}:${idleSince}`
+}
 
 function getSession(instanceId: string, sessionId: string): Session | null {
   const instanceSessions = sessions().get(instanceId)
@@ -37,8 +44,54 @@ export function getSessionRetry(instanceId: string, sessionId: string): SessionR
   return session?.retry ?? null
 }
 
+export function markSessionIdleFadeStarted(instanceId: string, sessionId: string): void {
+  const session = getSession(instanceId, sessionId)
+  if (!session || session.status !== "idle" || typeof session.idleSince !== "number") return
+  const key = idleFadeKey(instanceId, sessionId, session.idleSince)
+  setIdleFadeStarts((prev) => {
+    if (prev.has(key)) return prev
+    const next = new Map(prev)
+    next.set(key, Date.now())
+    return next
+  })
+  if (typeof window !== "undefined") {
+    window.setTimeout(() => {
+      setIdleFadeStarts((prev) => {
+        if (!prev.has(key)) return prev
+        const next = new Map(prev)
+        next.delete(key)
+        return next
+      })
+    }, IDLE_STATUS_VISIBILITY_MS + 1000)
+  }
+}
+
+export function getSessionIdleFadeClass(instanceId: string, sessionId: string): string {
+  const session = getSession(instanceId, sessionId)
+  if (!session || session.status !== "idle" || typeof session.idleSince !== "number") return ""
+  const startedAt = idleFadeStarts().get(idleFadeKey(instanceId, sessionId, session.idleSince))
+  return typeof startedAt === "number" ? "session-status-fading" : ""
+}
+
+export function getInstanceIdleFadeClass(instanceId: string, now = Date.now(), keepUnseenSubagentIdleStatus = false): string {
+  const instanceSessions = sessions().get(instanceId)
+  if (!instanceSessions) return ""
+
+  let hasVisibleIdle = false
+  for (const session of instanceSessions.values()) {
+    if (!session.id) continue
+    if (!shouldShowIdleStatus(session, now, keepUnseenSubagentIdleStatus)) continue
+    hasVisibleIdle = true
+    if (!getSessionIdleFadeClass(instanceId, session.id)) return ""
+  }
+
+  return hasVisibleIdle ? "session-status-fading" : ""
+}
+
 export function shouldShowIdleStatus(
   session: Pick<Session, "status" | "idleSince" | "parentId"> | null | undefined,
+  now = Date.now(),
+  keepUnseenSubagentIdleStatus = false,
 ): boolean {
   if (!session || session.status !== "idle") {
     return false
@@ -48,12 +101,18 @@ export function shouldShowIdleStatus(
     return false
   }
 
+  if (session.parentId && !keepUnseenSubagentIdleStatus) {
+    return now - session.idleSince < IDLE_STATUS_VISIBILITY_MS
+  }
+
   return true
 }
 
 export function shouldShowSessionStatus(
   instanceId: string,
   sessionId: string,
+  now = Date.now(),
+  keepUnseenSubagentIdleStatus = false,
 ): boolean {
   const session = getSession(instanceId, sessionId)
   if (!session) {
@@ -64,7 +123,7 @@ export function shouldShowSessionStatus(
     return true
   }
 
-  return session.status !== "idle" || shouldShowIdleStatus(session)
+  return session.status !== "idle" || shouldShowIdleStatus(session, now, keepUnseenSubagentIdleStatus)
 }
 
 export function getRetrySeconds(next: number, now = Date.now()): number {
@@ -75,6 +134,8 @@ export type InstanceSessionIndicatorStatus = "permission" | SessionStatus
 
 export function getInstanceSessionIndicatorStatus(
   instanceId: string,
+  now = Date.now(),
+  keepUnseenSubagentIdleStatus = false,
 ): InstanceSessionIndicatorStatus | null {
   const aggregated = getInstanceSessionIndicatorStatusCached(instanceId)
   if (aggregated !== "idle") {
@@ -87,7 +148,7 @@ export function getInstanceSessionIndicatorStatus(
   }
 
   for (const session of instanceSessions.values()) {
-    if (shouldShowIdleStatus(session)) {
+    if (shouldShowIdleStatus(session, now, keepUnseenSubagentIdleStatus)) {
       return "idle"
     }
   }

--- a/packages/ui/src/styles/panels/session-layout.css
+++ b/packages/ui/src/styles/panels/session-layout.css
@@ -442,6 +442,10 @@ session-sidebar-controls .selector-trigger-primary {
   --session-status-dot: var(--session-status-idle-fg);
 }
 
+.status-indicator.session-status.session-idle.session-status-fading {
+  animation: session-status-fade-out 5s ease-out forwards;
+}
+
 .status-indicator.session-status.session-permission {
   color: var(--session-status-permission-fg);
   --session-status-dot: var(--session-status-permission-fg);
@@ -488,6 +492,16 @@ session-sidebar-controls .selector-trigger-primary {
   padding: 0.125rem 0.5rem;
   border-radius: 9999px;
   border: 1px solid transparent;
+}
+
+@keyframes session-status-fade-out {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
 }
 
 .status-indicator.session-yolo-mode {


### PR DESCRIPTION
## Summary
- Follow-up to #395 after the idle badge persistence behavior regressed around `keepUnseenSubagentIdleStatus`.
- Restores `keepUnseenSubagentIdleStatus` handling across session, active-session, and instance-tab badge helpers.
- Starts a 5s fade when a viewed idle session/thread is seen, then clears each exact idle transition after the animation even if focus moves away.
- Keeps unseen subagent idle badges visible when the preference is enabled, and keeps aggregate instance badges solid when any other visible idle contributor is still unseen.

## Validation
- `git diff --check`
- `npm run typecheck --workspace @codenomad/ui`
- `npm run build --workspace @codenomad/ui`
- Gatekeeper re-review: no blocking findings remain for the prior preference/race findings.

## Notes
- `node --test packages/ui/src/stores/session-status.test.ts` was attempted, but the repo's extensionless TypeScript imports are not directly resolvable by Node's test runner.