### PR TITLE
fix(ui): ignore stale permission events after reply

### DIFF
--- a/packages/ui/src/stores/instances.ts
+++ b/packages/ui/src/stores/instances.ts
@@ -32,6 +32,12 @@ import { setSessionPendingPermission, setSessionPendingQuestion } from "./sessio
 import { setHasInstances } from "./ui"
 import { messageStoreBus } from "./message-v2/bus"
 import { upsertPermissionV2, removePermissionV2, upsertQuestionV2, removeQuestionV2 } from "./message-v2/bridge"
+import {
+  clearRepliedPermissions,
+  hasRepliedPermission,
+  markPermissionReplied,
+  pruneRepliedPermissions,
+} from "./permission-replies"
 import { clearCacheForInstance } from "../lib/global-cache"
 import { getLogger } from "../lib/logger"
 import { mergeInstanceMetadata, clearInstanceMetadata } from "./instance-metadata"
@@ -52,8 +58,6 @@ const [activePermissionId, setActivePermissionId] = createSignal<Map<string, str
 const permissionSessionCounts = new Map<string, Map<string, number>>()
 // Track which worktree a permission was enqueued under (by permission request id).
 const permissionWorktreeSlugByInstance = new Map<string, Map<string, string>>()
-const REPLIED_PERMISSION_TOMBSTONE_MS = 30_000
-const repliedPermissionIdsByInstance = new Map<string, Map<string, number>>()
 
 const [questionQueues, setQuestionQueues] = createSignal<Map<string, QuestionRequest[]>>(new Map())
 // Track which worktree a question was enqueued under (by question request id).
@@ -81,42 +85,6 @@ function syncHasInstancesFlag() {
   setHasInstances(readyExists)
 }
 
-function pruneRepliedPermissions(instanceId: string, replied = repliedPermissionIdsByInstance.get(instanceId)): void {
-  if (!replied) return
-  const now = Date.now()
-  for (const [permissionId, repliedAt] of replied) {
-    if (now - repliedAt > REPLIED_PERMISSION_TOMBSTONE_MS) {
-      replied.delete(permissionId)
-    }
-  }
-  if (replied.size === 0) {
-    repliedPermissionIdsByInstance.delete(instanceId)
-  }
-}
-
-function markPermissionReplied(instanceId: string, permissionId: string): void {
-  if (!permissionId) return
-  let replied = repliedPermissionIdsByInstance.get(instanceId)
-  if (!replied) {
-    replied = new Map()
-    repliedPermissionIdsByInstance.set(instanceId, replied)
-  }
-  pruneRepliedPermissions(instanceId, replied)
-  replied.set(permissionId, Date.now())
-}
-
-function hasRecentlyRepliedPermission(instanceId: string, permissionId: string): boolean {
-  const replied = repliedPermissionIdsByInstance.get(instanceId)
-  if (!replied) return false
-  pruneRepliedPermissions(instanceId, replied)
-  const repliedAt = replied.get(permissionId)
-  if (!repliedAt) return false
-  return Date.now() - repliedAt <= REPLIED_PERMISSION_TOMBSTONE_MS
-}
-
-function clearRepliedPermissions(instanceId: string): void {
-  repliedPermissionIdsByInstance.delete(instanceId)
-}
 interface DisconnectedInstanceInfo {
   id: string
   folder: string
@@ -225,12 +193,16 @@ async function syncPendingPermissions(instanceId: string): Promise<void> {
   if (!instance?.client) return
 
   try {
+    const syncStartedAt = Date.now()
     const remote = await requestData<PermissionRequestLike[]>(
       instance.client.permission.list(),
       "permission.list",
     )
 
-    const pendingRemote = remote.filter((item) => !hasRecentlyRepliedPermission(instanceId, item.id))
+    const remotePendingIds = new Set(remote.map((item) => item.id))
+    pruneRepliedPermissions(instanceId, remotePendingIds, syncStartedAt)
+
+    const pendingRemote = remote.filter((item) => !hasRepliedPermission(instanceId, item.id))
     const remoteIds = new Set(pendingRemote.map((item) => item.id))
     const local = getPermissionQueue(instanceId)
 
@@ -1175,7 +1147,7 @@ export {
   addPermissionToQueue,
   removePermissionFromQueue,
   markPermissionReplied,
-  hasRecentlyRepliedPermission,
+  hasRepliedPermission,
   clearPermissionQueue,
   sendPermissionResponse,
   setActivePermissionIdForInstance,

--- a/packages/ui/src/stores/instances.ts
+++ b/packages/ui/src/stores/instances.ts
@@ -52,6 +52,8 @@ const [activePermissionId, setActivePermissionId] = createSignal<Map<string, str
 const permissionSessionCounts = new Map<string, Map<string, number>>()
 // Track which worktree a permission was enqueued under (by permission request id).
 const permissionWorktreeSlugByInstance = new Map<string, Map<string, string>>()
+const REPLIED_PERMISSION_TOMBSTONE_MS = 30_000
+const repliedPermissionIdsByInstance = new Map<string, Map<string, number>>()
 
 const [questionQueues, setQuestionQueues] = createSignal<Map<string, QuestionRequest[]>>(new Map())
 // Track which worktree a question was enqueued under (by question request id).
@@ -77,6 +79,43 @@ const [activeInterruption, setActiveInterruption] = createSignal<Map<string, Act
 function syncHasInstancesFlag() {
   const readyExists = Array.from(instances().values()).some((instance) => instance.status === "ready")
   setHasInstances(readyExists)
+}
+
+function pruneRepliedPermissions(instanceId: string, replied = repliedPermissionIdsByInstance.get(instanceId)): void {
+  if (!replied) return
+  const now = Date.now()
+  for (const [permissionId, repliedAt] of replied) {
+    if (now - repliedAt > REPLIED_PERMISSION_TOMBSTONE_MS) {
+      replied.delete(permissionId)
+    }
+  }
+  if (replied.size === 0) {
+    repliedPermissionIdsByInstance.delete(instanceId)
+  }
+}
+
+function markPermissionReplied(instanceId: string, permissionId: string): void {
+  if (!permissionId) return
+  let replied = repliedPermissionIdsByInstance.get(instanceId)
+  if (!replied) {
+    replied = new Map()
+    repliedPermissionIdsByInstance.set(instanceId, replied)
+  }
+  pruneRepliedPermissions(instanceId, replied)
+  replied.set(permissionId, Date.now())
+}
+
+function hasRecentlyRepliedPermission(instanceId: string, permissionId: string): boolean {
+  const replied = repliedPermissionIdsByInstance.get(instanceId)
+  if (!replied) return false
+  pruneRepliedPermissions(instanceId, replied)
+  const repliedAt = replied.get(permissionId)
+  if (!repliedAt) return false
+  return Date.now() - repliedAt <= REPLIED_PERMISSION_TOMBSTONE_MS
+}
+
+function clearRepliedPermissions(instanceId: string): void {
+  repliedPermissionIdsByInstance.delete(instanceId)
 }
 interface DisconnectedInstanceInfo {
   id: string
@@ -191,7 +230,8 @@ async function syncPendingPermissions(instanceId: string): Promise<void> {
       "permission.list",
     )
 
-    const remoteIds = new Set(remote.map((item) => item.id))
+    const pendingRemote = remote.filter((item) => !hasRecentlyRepliedPermission(instanceId, item.id))
+    const remoteIds = new Set(pendingRemote.map((item) => item.id))
     const local = getPermissionQueue(instanceId)
 
     // Remove any stale local permissions missing from server.
@@ -203,7 +243,7 @@ async function syncPendingPermissions(instanceId: string): Promise<void> {
     }
 
     // Upsert all server-side pending permissions.
-    for (const permission of remote) {
+    for (const permission of pendingRemote) {
       addPermissionToQueue(instanceId, permission)
       upsertPermissionV2(instanceId, permission)
     }
@@ -512,6 +552,7 @@ function removeInstance(id: string) {
   removeLogContainer(id)
   clearCommands(id)
   clearPermissionQueue(id)
+  clearRepliedPermissions(id)
   clearQuestionQueue(id)
   clearInstanceMetadata(id)
 
@@ -1034,8 +1075,11 @@ async function sendPermissionResponse(
       "permission.reply",
     )
 
-    // Remove from queue after successful response
+    markPermissionReplied(instanceId, requestId)
+    // Remove from both local queues after successful response; the SSE replied event
+    // is still accepted, but the UI no longer depends on receiving it.
     removePermissionFromQueue(instanceId, requestId)
+    removePermissionV2(instanceId, requestId)
   } catch (error) {
     log.error("Failed to send permission response", error)
     throw error
@@ -1130,6 +1174,8 @@ export {
   getPermissionQueueLength,
   addPermissionToQueue,
   removePermissionFromQueue,
+  markPermissionReplied,
+  hasRecentlyRepliedPermission,
   clearPermissionQueue,
   sendPermissionResponse,
   setActivePermissionIdForInstance,

--- a/packages/ui/src/stores/permission-replies.test.ts
+++ b/packages/ui/src/stores/permission-replies.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import {
+  clearRepliedPermissions,
+  hasRepliedPermission,
+  markPermissionReplied,
+  pruneRepliedPermissions,
+} from "./permission-replies.ts"
+
+describe("replied permission tracking", () => {
+  it("keeps replied ids when an older sync does not include them", () => {
+    const instanceId = "instance-old-sync"
+    const permissionId = "permission-1"
+
+    markPermissionReplied(instanceId, permissionId, 1_000)
+    pruneRepliedPermissions(instanceId, new Set(), 900)
+
+    assert.equal(hasRepliedPermission(instanceId, permissionId), true)
+    clearRepliedPermissions(instanceId)
+  })
+
+  it("keeps replied ids while the server still reports them pending", () => {
+    const instanceId = "instance-still-pending"
+    const permissionId = "permission-1"
+
+    markPermissionReplied(instanceId, permissionId, 1_000)
+    pruneRepliedPermissions(instanceId, new Set([permissionId]), 1_100)
+
+    assert.equal(hasRepliedPermission(instanceId, permissionId), true)
+    clearRepliedPermissions(instanceId)
+  })
+
+  it("clears replied ids once a newer sync observes them missing", () => {
+    const instanceId = "instance-new-sync"
+    const permissionId = "permission-1"
+
+    markPermissionReplied(instanceId, permissionId, 1_000)
+    pruneRepliedPermissions(instanceId, new Set(), 1_100)
+
+    assert.equal(hasRepliedPermission(instanceId, permissionId), false)
+    clearRepliedPermissions(instanceId)
+  })
+})

--- a/packages/ui/src/stores/permission-replies.ts
+++ b/packages/ui/src/stores/permission-replies.ts
@@ -1,0 +1,38 @@
+const repliedPermissionIdsByInstance = new Map<string, Map<string, number>>()
+
+function pruneRepliedPermissions(instanceId: string, remotePendingIds: Set<string>, syncStartedAt: number): void {
+  const replied = repliedPermissionIdsByInstance.get(instanceId)
+  if (!replied) return
+  for (const [permissionId, repliedAt] of replied) {
+    // Only a sync started after the local reply can prove the server no longer
+    // considers this permission pending.
+    if (!remotePendingIds.has(permissionId) && syncStartedAt >= repliedAt) {
+      replied.delete(permissionId)
+    }
+  }
+  if (replied.size === 0) {
+    repliedPermissionIdsByInstance.delete(instanceId)
+  }
+}
+
+function markPermissionReplied(instanceId: string, permissionId: string, repliedAt = Date.now()): void {
+  if (!permissionId) return
+  let replied = repliedPermissionIdsByInstance.get(instanceId)
+  if (!replied) {
+    replied = new Map()
+    repliedPermissionIdsByInstance.set(instanceId, replied)
+  }
+  replied.set(permissionId, repliedAt)
+}
+
+function hasRepliedPermission(instanceId: string, permissionId: string): boolean {
+  const replied = repliedPermissionIdsByInstance.get(instanceId)
+  if (!replied) return false
+  return replied.has(permissionId)
+}
+
+function clearRepliedPermissions(instanceId: string): void {
+  repliedPermissionIdsByInstance.delete(instanceId)
+}
+
+export { clearRepliedPermissions, hasRepliedPermission, markPermissionReplied, pruneRepliedPermissions }

--- a/packages/ui/src/stores/session-events.ts
+++ b/packages/ui/src/stores/session-events.ts
@@ -35,6 +35,8 @@ import {
   instances,
   addPermissionToQueue,
   removePermissionFromQueue,
+  markPermissionReplied,
+  hasRecentlyRepliedPermission,
   addQuestionToQueue,
   removeQuestionFromQueue,
 } from "./instances"
@@ -689,8 +691,13 @@ function handleTuiToast(_instanceId: string, event: TuiToastEvent): void {
 function handlePermissionUpdated(instanceId: string, event: { type: string; properties?: PermissionRequestLike } | any): void {
   const permission = event?.properties as PermissionRequestLike | undefined
   if (!permission) return
+  const permissionId = getPermissionId(permission)
+  if (permissionId && hasRecentlyRepliedPermission(instanceId, permissionId)) {
+    log.info(`[SSE] Ignoring stale permission request after local reply: ${permissionId}`)
+    return
+  }
 
-  log.info(`[SSE] Permission request: ${getPermissionId(permission)} (${getPermissionKind(permission)})`)
+  log.info(`[SSE] Permission request: ${permissionId} (${getPermissionKind(permission)})`)
   addPermissionToQueue(instanceId, permission)
   upsertPermissionV2(instanceId, permission)
 
@@ -710,6 +717,7 @@ function handlePermissionReplied(instanceId: string, event: { type: string; prop
   if (!requestId) return
 
   log.info(`[SSE] Permission replied: ${requestId}`)
+  markPermissionReplied(instanceId, requestId)
   removePermissionFromQueue(instanceId, requestId)
   removePermissionV2(instanceId, requestId)
 }

--- a/packages/ui/src/stores/session-events.ts
+++ b/packages/ui/src/stores/session-events.ts
@@ -36,7 +36,7 @@ import {
   addPermissionToQueue,
   removePermissionFromQueue,
   markPermissionReplied,
-  hasRecentlyRepliedPermission,
+  hasRepliedPermission,
   addQuestionToQueue,
   removeQuestionFromQueue,
 } from "./instances"
@@ -692,7 +692,7 @@ function handlePermissionUpdated(instanceId: string, event: { type: string; prop
   const permission = event?.properties as PermissionRequestLike | undefined
   if (!permission) return
   const permissionId = getPermissionId(permission)
-  if (permissionId && hasRecentlyRepliedPermission(instanceId, permissionId)) {
+  if (permissionId && hasRepliedPermission(instanceId, permissionId)) {
     log.info(`[SSE] Ignoring stale permission request after local reply: ${permissionId}`)
     return
   }


### PR DESCRIPTION
## Summary
- Split out from #422 as the stale-permission-events fix.
- Clears permission UI state immediately after a successful local permission reply instead of waiting for `permission.replied` SSE.
- Tracks replied permission IDs until a newer pending-permission sync observes that the server no longer reports them pending.
- Marks SSE `permission.replied` events into the same replied-ID path so delayed pending events/sync results cannot resurrect prompts that were just answered.

## Why
A permission prompt could remain on screen after clicking Allow/Deny, or clicking Allow could look like it did not take effect and require another click. Reloading could fix the UI, which pointed to stale local permission state rather than the server still waiting.

The UI receives permission state from local replies, SSE events, and pending-permission sync. If an older pending event or sync result is processed after a confirmed reply, the UI can re-add a permission that was already answered. Replied IDs stay suppressed until a sync started after the local reply proves the server has dropped that permission from the pending list.

## Validation
- `git diff --check`
- `node --test packages/ui/src/stores/permission-replies.test.ts`
- `npm run typecheck --workspace @codenomad/ui`