### PR TITLE
fix(desktop): keep remote window server titles

### DIFF
--- a/packages/electron-app/electron/main/main.ts
+++ b/packages/electron-app/electron/main/main.ts
@@ -474,12 +474,7 @@ function finalizeCliSwap(url: string) {
 }
 
 function buildRemoteWindowTitle(name: string, baseUrl: string) {
-  try {
-    const parsed = new URL(baseUrl)
-    return `${name} - ${parsed.host}`
-  } catch {
-    return `${name} - ${baseUrl}`
-  }
+  return `${name} - ${baseUrl}`
 }
 
 function lockWindowTitle(window: BrowserWindow, title: string) {

--- a/packages/electron-app/electron/main/main.ts
+++ b/packages/electron-app/electron/main/main.ts
@@ -482,6 +482,14 @@ function buildRemoteWindowTitle(name: string, baseUrl: string) {
   }
 }
 
+function lockWindowTitle(window: BrowserWindow, title: string) {
+  window.setTitle(title)
+  window.webContents.on("page-title-updated", (event) => {
+    event.preventDefault()
+    window.setTitle(title)
+  })
+}
+
 function buildRemoteErrorHtml(name: string, baseUrl: string, message: string) {
   const escapedName = name.replace(/[&<>"]/g, (char) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[char] ?? char))
   const escapedUrl = baseUrl.replace(/[&<>"]/g, (char) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[char] ?? char))
@@ -508,6 +516,7 @@ async function openRemoteWindow(payload: { id: string; name: string; baseUrl: st
       additionalArguments: ["--codenomad-window-context=remote"],
     },
   })
+  lockWindowTitle(window, title)
 
   setWindowAllowedOrigin(window, targetUrl.toString())
   if (payload.skipTlsVerify) {

--- a/packages/tauri-app/src-tauri/src/main.rs
+++ b/packages/tauri-app/src-tauri/src/main.rs
@@ -42,7 +42,49 @@ const ZOOM_STEP: f64 = 0.1;
 const MIN_ZOOM_LEVEL: f64 = 0.2;
 const MAX_ZOOM_LEVEL: f64 = 5.0;
 const LOCAL_WINDOW_CONTEXT_SCRIPT: &str = "window.__CODENOMAD_WINDOW_CONTEXT__ = 'local';";
-const REMOTE_WINDOW_CONTEXT_SCRIPT: &str = "window.__CODENOMAD_WINDOW_CONTEXT__ = 'remote';";
+fn build_remote_window_context_script(title: &str) -> String {
+    let title_json = serde_json::to_string(title).unwrap_or_else(|_| "\"CodeNomad\"".to_string());
+    format!(
+        r#"
+window.__CODENOMAD_WINDOW_CONTEXT__ = 'remote';
+window.__CODENOMAD_WINDOW_TITLE__ = {title_json};
+(function () {{
+  var descriptor = Object.getOwnPropertyDescriptor(Document.prototype, 'title');
+  function applyTitle() {{
+    var title = window.__CODENOMAD_WINDOW_TITLE__;
+    if (descriptor && typeof descriptor.set === 'function') {{
+      descriptor.set.call(document, title);
+    }} else {{
+      var titleElement = document.querySelector('title');
+      if (!titleElement && document.head) {{
+        titleElement = document.createElement('title');
+        document.head.appendChild(titleElement);
+      }}
+      if (titleElement) {{
+        titleElement.textContent = title;
+      }}
+    }}
+  }}
+  Object.defineProperty(document, 'title', {{
+    configurable: true,
+    get: function () {{ return window.__CODENOMAD_WINDOW_TITLE__; }},
+    set: applyTitle,
+  }});
+  applyTitle();
+}})();
+"#
+    )
+}
+
+fn build_remote_window_title_update_script(title: &str) -> String {
+    let title_json = serde_json::to_string(title).unwrap_or_else(|_| "\"CodeNomad\"".to_string());
+    format!(
+        r#"
+window.__CODENOMAD_WINDOW_TITLE__ = {title_json};
+document.title = window.__CODENOMAD_WINDOW_TITLE__;
+"#
+    )
+}
 
 #[cfg(windows)]
 const WINDOWS_APP_USER_MODEL_ID: &str = "ai.neuralnomads.codenomad.client";
@@ -300,6 +342,7 @@ async fn open_remote_window_impl(
         linux_tls::ensure_remote_window_tls_handler(&existing, &app, &label)?;
 
         let _ = existing.set_title(&title);
+        let _ = existing.eval(build_remote_window_title_update_script(&title));
         let _ = existing.navigate(window_url.clone());
         apply_remote_window_title(&app, &label);
         let _ = existing.show();
@@ -324,7 +367,7 @@ async fn open_remote_window_impl(
         label.clone(),
         WebviewUrl::External(initial_url.clone()),
     )
-    .initialization_script(REMOTE_WINDOW_CONTEXT_SCRIPT)
+    .initialization_script(build_remote_window_context_script(&title))
     .title(title)
     .inner_size(1400.0, 900.0)
     .min_inner_size(800.0, 600.0)

--- a/packages/tauri-app/src-tauri/src/main.rs
+++ b/packages/tauri-app/src-tauri/src/main.rs
@@ -47,8 +47,16 @@ fn build_remote_window_context_script(title: &str) -> String {
     format!(
         r#"
 window.__CODENOMAD_WINDOW_CONTEXT__ = 'remote';
-window.__CODENOMAD_WINDOW_TITLE__ = {title_json};
 (function () {{
+  var titlePrefix = '__CODENOMAD_WINDOW_TITLE__:';
+  var fallbackTitle = {title_json};
+  function readTitle() {{
+    return typeof window.name === 'string' && window.name.startsWith(titlePrefix)
+      ? window.name.slice(titlePrefix.length)
+      : fallbackTitle;
+  }}
+  window.__CODENOMAD_WINDOW_TITLE__ = readTitle();
+  window.name = titlePrefix + window.__CODENOMAD_WINDOW_TITLE__;
   var descriptor = Object.getOwnPropertyDescriptor(Document.prototype, 'title');
   function applyTitle() {{
     var title = window.__CODENOMAD_WINDOW_TITLE__;
@@ -81,6 +89,7 @@ fn build_remote_window_title_update_script(title: &str) -> String {
     format!(
         r#"
 window.__CODENOMAD_WINDOW_TITLE__ = {title_json};
+window.name = '__CODENOMAD_WINDOW_TITLE__:' + window.__CODENOMAD_WINDOW_TITLE__;
 document.title = window.__CODENOMAD_WINDOW_TITLE__;
 "#
     )

--- a/packages/tauri-app/src-tauri/src/main.rs
+++ b/packages/tauri-app/src-tauri/src/main.rs
@@ -17,7 +17,7 @@ use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::menu::{MenuBuilder, MenuItem, SubmenuBuilder};
 use tauri::plugin::{Builder as PluginBuilder, TauriPlugin};
-use tauri::webview::Webview;
+use tauri::webview::{PageLoadEvent, Webview};
 use tauri::{
     AppHandle, Emitter, Manager, Runtime, WebviewUrl, WebviewWindowBuilder, WindowEvent, Wry,
 };
@@ -42,46 +42,7 @@ const ZOOM_STEP: f64 = 0.1;
 const MIN_ZOOM_LEVEL: f64 = 0.2;
 const MAX_ZOOM_LEVEL: f64 = 5.0;
 const LOCAL_WINDOW_CONTEXT_SCRIPT: &str = "window.__CODENOMAD_WINDOW_CONTEXT__ = 'local';";
-fn build_remote_window_context_script(title: &str) -> String {
-    let title_json = serde_json::to_string(title).unwrap_or_else(|_| "\"CodeNomad\"".to_string());
-    format!(
-        r#"
-window.__CODENOMAD_WINDOW_CONTEXT__ = 'remote';
-window.__CODENOMAD_WINDOW_TITLE__ = {title_json};
-(function () {{
-  var lockedTitle = {title_json};
-  var descriptor = Object.getOwnPropertyDescriptor(Document.prototype, 'title');
-  function applyTitle() {{
-    if (descriptor && typeof descriptor.set === 'function') {{
-      descriptor.set.call(document, lockedTitle);
-    }} else {{
-      var titleElement = document.querySelector('title');
-      if (!titleElement && document.head) {{
-        titleElement = document.createElement('title');
-        document.head.appendChild(titleElement);
-      }}
-      if (titleElement) {{
-        titleElement.textContent = lockedTitle;
-      }}
-    }}
-  }}
-  Object.defineProperty(document, 'title', {{
-    configurable: true,
-    get: function () {{ return lockedTitle; }},
-    set: applyTitle,
-  }});
-  applyTitle();
-  if (document.documentElement) {{
-    new MutationObserver(applyTitle).observe(document.documentElement, {{
-      childList: true,
-      subtree: true,
-      characterData: true,
-    }});
-  }}
-}})();
-"#
-    )
-}
+const REMOTE_WINDOW_CONTEXT_SCRIPT: &str = "window.__CODENOMAD_WINDOW_CONTEXT__ = 'remote';";
 
 #[cfg(windows)]
 const WINDOWS_APP_USER_MODEL_ID: &str = "ai.neuralnomads.codenomad.client";
@@ -94,6 +55,7 @@ pub struct AppState {
     pub remote_proxy_sessions: Mutex<HashMap<String, String>>,
     pub remote_skip_tls_verify: Mutex<HashMap<String, bool>>,
     pub remote_tls_handlers: Mutex<HashSet<String>>,
+    pub remote_titles: Mutex<HashMap<String, String>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -266,6 +228,22 @@ fn intercept_navigation<R: Runtime>(webview: &Webview<R>, url: &Url) -> bool {
     false
 }
 
+fn apply_remote_window_title(app_handle: &AppHandle, window_label: &str) {
+    let Some(title) = app_handle
+        .state::<AppState>()
+        .remote_titles
+        .lock()
+        .ok()
+        .and_then(|titles| titles.get(window_label).cloned())
+    else {
+        return;
+    };
+
+    if let Some(window) = app_handle.get_webview_window(window_label) {
+        let _ = window.set_title(&title);
+    }
+}
+
 async fn open_remote_window_impl(
     app: AppHandle,
     payload: RemoteWindowPayload,
@@ -276,14 +254,7 @@ async fn open_remote_window_impl(
         .unwrap_or(payload.base_url.as_str());
     let parsed = Url::parse(entry_url).map_err(|err| err.to_string())?;
     let label = format!("remote-{}", payload.id);
-    let title = format!(
-        "{} - {}",
-        payload.name,
-        Url::parse(&payload.base_url)
-            .ok()
-            .and_then(|url| url.host_str().map(str::to_string))
-            .unwrap_or_else(|| payload.base_url.clone())
-    );
+    let title = format!("{} - {}", payload.name, payload.base_url);
 
     let window_url = parsed.clone();
 
@@ -300,6 +271,11 @@ async fn open_remote_window_impl(
         .lock()
         .map_err(|err| err.to_string())?
         .insert(label.clone(), allow_linux_tls_certificate);
+    app.state::<AppState>()
+        .remote_titles
+        .lock()
+        .map_err(|err| err.to_string())?
+        .insert(label.clone(), title.clone());
 
     let replaced_session = {
         let state = app.state::<AppState>();
@@ -323,8 +299,9 @@ async fn open_remote_window_impl(
         #[cfg(target_os = "linux")]
         linux_tls::ensure_remote_window_tls_handler(&existing, &app, &label)?;
 
-        let _ = existing.navigate(window_url.clone());
         let _ = existing.set_title(&title);
+        let _ = existing.navigate(window_url.clone());
+        apply_remote_window_title(&app, &label);
         let _ = existing.show();
         let _ = existing.unminimize();
         let _ = existing.set_focus();
@@ -342,13 +319,12 @@ async fn open_remote_window_impl(
     #[cfg(not(target_os = "linux"))]
     let initial_url = window_url.clone();
 
-    let remote_context_script = build_remote_window_context_script(&title);
     let window = WebviewWindowBuilder::new(
         &app,
         label.clone(),
         WebviewUrl::External(initial_url.clone()),
     )
-    .initialization_script(remote_context_script)
+    .initialization_script(REMOTE_WINDOW_CONTEXT_SCRIPT)
     .title(title)
     .inner_size(1400.0, 900.0)
     .min_inner_size(800.0, 600.0)
@@ -380,6 +356,9 @@ async fn open_remote_window_impl(
             }
             if let Ok(mut handlers) = app_handle.state::<AppState>().remote_tls_handlers.lock() {
                 handlers.remove(&label_for_cleanup);
+            }
+            if let Ok(mut titles) = app_handle.state::<AppState>().remote_titles.lock() {
+                titles.remove(&label_for_cleanup);
             }
         }
     });
@@ -590,6 +569,12 @@ fn main() {
             remote_proxy_sessions: Mutex::new(HashMap::new()),
             remote_skip_tls_verify: Mutex::new(HashMap::new()),
             remote_tls_handlers: Mutex::new(HashSet::new()),
+            remote_titles: Mutex::new(HashMap::new()),
+        })
+        .on_page_load(|webview, payload| {
+            if matches!(payload.event(), PageLoadEvent::Started | PageLoadEvent::Finished) {
+                apply_remote_window_title(&webview.app_handle(), webview.label());
+            }
         })
         .setup(|app| {
             set_windows_app_user_model_id();

--- a/packages/tauri-app/src-tauri/src/main.rs
+++ b/packages/tauri-app/src-tauri/src/main.rs
@@ -3,9 +3,9 @@
 #[allow(dead_code)]
 mod cert_manager;
 mod cli_manager;
-mod managed_node;
 #[cfg(target_os = "linux")]
 mod linux_tls;
+mod managed_node;
 
 use cli_manager::{CliProcessManager, CliStatus};
 use keepawake::KeepAwake;
@@ -42,7 +42,46 @@ const ZOOM_STEP: f64 = 0.1;
 const MIN_ZOOM_LEVEL: f64 = 0.2;
 const MAX_ZOOM_LEVEL: f64 = 5.0;
 const LOCAL_WINDOW_CONTEXT_SCRIPT: &str = "window.__CODENOMAD_WINDOW_CONTEXT__ = 'local';";
-const REMOTE_WINDOW_CONTEXT_SCRIPT: &str = "window.__CODENOMAD_WINDOW_CONTEXT__ = 'remote';";
+fn build_remote_window_context_script(title: &str) -> String {
+    let title_json = serde_json::to_string(title).unwrap_or_else(|_| "\"CodeNomad\"".to_string());
+    format!(
+        r#"
+window.__CODENOMAD_WINDOW_CONTEXT__ = 'remote';
+window.__CODENOMAD_WINDOW_TITLE__ = {title_json};
+(function () {{
+  var lockedTitle = {title_json};
+  var descriptor = Object.getOwnPropertyDescriptor(Document.prototype, 'title');
+  function applyTitle() {{
+    if (descriptor && typeof descriptor.set === 'function') {{
+      descriptor.set.call(document, lockedTitle);
+    }} else {{
+      var titleElement = document.querySelector('title');
+      if (!titleElement && document.head) {{
+        titleElement = document.createElement('title');
+        document.head.appendChild(titleElement);
+      }}
+      if (titleElement) {{
+        titleElement.textContent = lockedTitle;
+      }}
+    }}
+  }}
+  Object.defineProperty(document, 'title', {{
+    configurable: true,
+    get: function () {{ return lockedTitle; }},
+    set: applyTitle,
+  }});
+  applyTitle();
+  if (document.documentElement) {{
+    new MutationObserver(applyTitle).observe(document.documentElement, {{
+      childList: true,
+      subtree: true,
+      characterData: true,
+    }});
+  }}
+}})();
+"#
+    )
+}
 
 #[cfg(windows)]
 const WINDOWS_APP_USER_MODEL_ID: &str = "ai.neuralnomads.codenomad.client";
@@ -231,7 +270,10 @@ async fn open_remote_window_impl(
     app: AppHandle,
     payload: RemoteWindowPayload,
 ) -> Result<(), String> {
-    let entry_url = payload.entry_url.as_deref().unwrap_or(payload.base_url.as_str());
+    let entry_url = payload
+        .entry_url
+        .as_deref()
+        .unwrap_or(payload.base_url.as_str());
     let parsed = Url::parse(entry_url).map_err(|err| err.to_string())?;
     let label = format!("remote-{}", payload.id);
     let title = format!(
@@ -245,8 +287,8 @@ async fn open_remote_window_impl(
 
     let window_url = parsed.clone();
 
-    let allow_linux_tls_certificate =
-        parsed.scheme() == "https" && (payload.proxy_session_id.is_some() || payload.skip_tls_verify);
+    let allow_linux_tls_certificate = parsed.scheme() == "https"
+        && (payload.proxy_session_id.is_some() || payload.skip_tls_verify);
 
     app.state::<AppState>()
         .remote_origins
@@ -290,25 +332,28 @@ async fn open_remote_window_impl(
     }
 
     #[cfg(target_os = "linux")]
-    let initial_url = if linux_tls::should_bootstrap_tls_navigation(
-        &window_url,
-        allow_linux_tls_certificate,
-    ) {
-        Url::parse("about:blank").map_err(|err| err.to_string())?
-    } else {
-        window_url.clone()
-    };
+    let initial_url =
+        if linux_tls::should_bootstrap_tls_navigation(&window_url, allow_linux_tls_certificate) {
+            Url::parse("about:blank").map_err(|err| err.to_string())?
+        } else {
+            window_url.clone()
+        };
 
     #[cfg(not(target_os = "linux"))]
     let initial_url = window_url.clone();
 
-    let window = WebviewWindowBuilder::new(&app, label.clone(), WebviewUrl::External(initial_url.clone()))
-        .initialization_script(REMOTE_WINDOW_CONTEXT_SCRIPT)
-        .title(title)
-        .inner_size(1400.0, 900.0)
-        .min_inner_size(800.0, 600.0)
-        .build()
-        .map_err(|err| err.to_string())?;
+    let remote_context_script = build_remote_window_context_script(&title);
+    let window = WebviewWindowBuilder::new(
+        &app,
+        label.clone(),
+        WebviewUrl::External(initial_url.clone()),
+    )
+    .initialization_script(remote_context_script)
+    .title(title)
+    .inner_size(1400.0, 900.0)
+    .min_inner_size(800.0, 600.0)
+    .build()
+    .map_err(|err| err.to_string())?;
 
     #[cfg(target_os = "linux")]
     {
@@ -364,7 +409,10 @@ fn needs_local_certificate_install() -> Result<bool, String> {
 async fn open_remote_window(app: AppHandle, payload: RemoteWindowPayload) -> Result<(), String> {
     #[cfg(not(target_os = "linux"))]
     {
-        let entry_url = payload.entry_url.as_deref().unwrap_or(payload.base_url.as_str());
+        let entry_url = payload
+            .entry_url
+            .as_deref()
+            .unwrap_or(payload.base_url.as_str());
         let parsed = Url::parse(entry_url).map_err(|err| err.to_string())?;
         if payload.proxy_session_id.is_some() && parsed.scheme() == "https" {
             let local_cert = cert_manager::ensure_local_cert().map_err(|err| {

--- a/packages/tauri-app/src-tauri/src/main.rs
+++ b/packages/tauri-app/src-tauri/src/main.rs
@@ -42,58 +42,7 @@ const ZOOM_STEP: f64 = 0.1;
 const MIN_ZOOM_LEVEL: f64 = 0.2;
 const MAX_ZOOM_LEVEL: f64 = 5.0;
 const LOCAL_WINDOW_CONTEXT_SCRIPT: &str = "window.__CODENOMAD_WINDOW_CONTEXT__ = 'local';";
-fn build_remote_window_context_script(title: &str) -> String {
-    let title_json = serde_json::to_string(title).unwrap_or_else(|_| "\"CodeNomad\"".to_string());
-    format!(
-        r#"
-window.__CODENOMAD_WINDOW_CONTEXT__ = 'remote';
-(function () {{
-  var titlePrefix = '__CODENOMAD_WINDOW_TITLE__:';
-  var fallbackTitle = {title_json};
-  function readTitle() {{
-    return typeof window.name === 'string' && window.name.startsWith(titlePrefix)
-      ? window.name.slice(titlePrefix.length)
-      : fallbackTitle;
-  }}
-  window.__CODENOMAD_WINDOW_TITLE__ = readTitle();
-  window.name = titlePrefix + window.__CODENOMAD_WINDOW_TITLE__;
-  var descriptor = Object.getOwnPropertyDescriptor(Document.prototype, 'title');
-  function applyTitle() {{
-    var title = window.__CODENOMAD_WINDOW_TITLE__;
-    if (descriptor && typeof descriptor.set === 'function') {{
-      descriptor.set.call(document, title);
-    }} else {{
-      var titleElement = document.querySelector('title');
-      if (!titleElement && document.head) {{
-        titleElement = document.createElement('title');
-        document.head.appendChild(titleElement);
-      }}
-      if (titleElement) {{
-        titleElement.textContent = title;
-      }}
-    }}
-  }}
-  Object.defineProperty(document, 'title', {{
-    configurable: true,
-    get: function () {{ return window.__CODENOMAD_WINDOW_TITLE__; }},
-    set: applyTitle,
-  }});
-  applyTitle();
-}})();
-"#
-    )
-}
-
-fn build_remote_window_title_update_script(title: &str) -> String {
-    let title_json = serde_json::to_string(title).unwrap_or_else(|_| "\"CodeNomad\"".to_string());
-    format!(
-        r#"
-window.__CODENOMAD_WINDOW_TITLE__ = {title_json};
-window.name = '__CODENOMAD_WINDOW_TITLE__:' + window.__CODENOMAD_WINDOW_TITLE__;
-document.title = window.__CODENOMAD_WINDOW_TITLE__;
-"#
-    )
-}
+const REMOTE_WINDOW_CONTEXT_SCRIPT: &str = "window.__CODENOMAD_WINDOW_CONTEXT__ = 'remote';";
 
 #[cfg(windows)]
 const WINDOWS_APP_USER_MODEL_ID: &str = "ai.neuralnomads.codenomad.client";
@@ -351,7 +300,6 @@ async fn open_remote_window_impl(
         linux_tls::ensure_remote_window_tls_handler(&existing, &app, &label)?;
 
         let _ = existing.set_title(&title);
-        let _ = existing.eval(build_remote_window_title_update_script(&title));
         let _ = existing.navigate(window_url.clone());
         apply_remote_window_title(&app, &label);
         let _ = existing.show();
@@ -376,7 +324,7 @@ async fn open_remote_window_impl(
         label.clone(),
         WebviewUrl::External(initial_url.clone()),
     )
-    .initialization_script(build_remote_window_context_script(&title))
+    .initialization_script(REMOTE_WINDOW_CONTEXT_SCRIPT)
     .title(title)
     .inner_size(1400.0, 900.0)
     .min_inner_size(800.0, 600.0)
@@ -624,7 +572,10 @@ fn main() {
             remote_titles: Mutex::new(HashMap::new()),
         })
         .on_page_load(|webview, payload| {
-            if matches!(payload.event(), PageLoadEvent::Started | PageLoadEvent::Finished) {
+            if matches!(
+                payload.event(),
+                PageLoadEvent::Started | PageLoadEvent::Finished
+            ) {
                 apply_remote_window_title(&webview.app_handle(), webview.label());
             }
         })


### PR DESCRIPTION
## Summary
- Lock Electron remote BrowserWindow titles to the generated saved-server title.
- Lock Tauri remote webview document titles through the remote initialization script so native window titles remain distinguishable.
- Preserve the existing title format that includes the saved server name and host.

Closes #427

## Validation
- npm run typecheck --workspace @neuralnomads/codenomad-electron-app
- cargo check (packages/tauri-app/src-tauri)