### PR TITLE
fix(electron): avoid shell for resource prep

### DIFF
--- a/packages/electron-app/scripts/build.js
+++ b/packages/electron-app/scripts/build.js
@@ -137,6 +137,7 @@ async function build(platform) {
       console.log(`\n📦 Preparing resources for ${job.nodeTarget}...\n`)
       await run(process.execPath, [join(appDir, "scripts", "prepare-resources.js")], {
         cwd: workspaceRoot,
+        shell: false,
         env: { NODE_PATH: workspaceNodeModulesPath, CODENOMAD_NODE_TARGET: job.nodeTarget },
       })
 


### PR DESCRIPTION
## Summary
- Avoid routing the Electron resource-prep Node invocation through the Windows shell.
- Fix local `build:win` when Node is installed under `C:\Program Files\nodejs\node.exe`.

## Validation
- `npm run build:win --workspace @neuralnomads/codenomad-electron-app`

## Notes
- This targets `opencode-config-merge` so it can be merged into #433.