### PR TITLE
Improve prompt layout for narrow session panes

### DIFF
--- a/packages/ui/src/components/branded-empty-state.tsx
+++ b/packages/ui/src/components/branded-empty-state.tsx
@@ -17,8 +17,8 @@ const BrandedEmptyState: Component<BrandedEmptyStateProps> = (props) => {
     <div class={`empty-state ${props.class ?? ""}`.trim()}>
       <div class="empty-state-content">
         <div class="flex flex-col items-center gap-3 mb-6">
-          <img src={codeNomadLogo} alt={t("messageSection.empty.logoAlt")} class="h-48 w-auto" loading="lazy" />
-          <h1 class="text-3xl font-semibold text-primary">{t("messageSection.empty.brandTitle")}</h1>
+          <img src={codeNomadLogo} alt={t("messageSection.empty.logoAlt")} class="empty-state-logo h-48 w-auto" loading="lazy" />
+          <h1 class="empty-state-brand-title text-3xl font-semibold text-primary">{t("messageSection.empty.brandTitle")}</h1>
         </div>
         {props.title ? <h3>{props.title}</h3> : null}
         <p>{props.description}</p>

--- a/packages/ui/src/components/instance/instance-shell2.tsx
+++ b/packages/ui/src/components/instance/instance-shell2.tsx
@@ -70,6 +70,13 @@ import { isPermissionAutoAcceptEnabled } from "../../stores/permission-auto-acce
 const log = getLogger("session")
 const OPEN_SESSION_SEARCH_EVENT = "codenomad:open-session-search"
 const NO_SESSION_DRAFT_SESSION_ID = "__no_session_draft__"
+type SessionCenterWidthStep = "narrow" | "medium" | "wide"
+
+function getSessionCenterWidthStep(width: number): SessionCenterWidthStep {
+  if (width < 768) return "narrow"
+  if (width < 1280) return "medium"
+  return "wide"
+}
 
 interface InstanceShellProps {
   instance: Instance
@@ -105,6 +112,8 @@ const InstanceShell2: Component<InstanceShellProps> = (props) => {
   const [rightDrawerContentEl, setRightDrawerContentEl] = createSignal<HTMLElement | null>(null)
   const [leftToggleButtonEl, setLeftToggleButtonEl] = createSignal<HTMLElement | null>(null)
   const [rightToggleButtonEl, setRightToggleButtonEl] = createSignal<HTMLElement | null>(null)
+  const [sessionCenterEl, setSessionCenterEl] = createSignal<HTMLElement | null>(null)
+  const [sessionCenterWidthStep, setSessionCenterWidthStep] = createSignal<SessionCenterWidthStep>("wide")
 
   const [selectedBackgroundProcess, setSelectedBackgroundProcess] = createSignal<BackgroundProcess | null>(null)
   const [showBackgroundOutput, setShowBackgroundOutput] = createSignal(false)
@@ -251,6 +260,25 @@ const InstanceShell2: Component<InstanceShellProps> = (props) => {
     if (typeof window === "undefined") return
     const timer = window.setInterval(() => setNow(Date.now()), 1000)
     onCleanup(() => window.clearInterval(timer))
+  })
+
+  createEffect(() => {
+    const element = sessionCenterEl()
+    if (!element || typeof ResizeObserver === "undefined") return
+
+    const updateWidthStep = (width: number) => {
+      setSessionCenterWidthStep(getSessionCenterWidthStep(width))
+    }
+
+    updateWidthStep(element.getBoundingClientRect().width)
+
+    const observer = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width ?? element.getBoundingClientRect().width
+      updateWidthStep(width)
+    })
+    observer.observe(element)
+
+    onCleanup(() => observer.disconnect())
   })
 
   const connectionStatus = () => sseManager.getStatus(props.instance.id)
@@ -801,7 +829,12 @@ const InstanceShell2: Component<InstanceShellProps> = (props) => {
     >
       {renderLeftPanel()}
 
-      <Box sx={{ display: "flex", flexDirection: "column", flex: 1, minWidth: 0, minHeight: 0, overflowX: "hidden" }}>
+      <Box
+        class="session-center-column"
+        ref={setSessionCenterEl}
+        data-session-center-width={sessionCenterWidthStep()}
+        sx={{ display: "flex", flexDirection: "column", flex: 1, minWidth: 0, minHeight: 0, overflowX: "hidden" }}
+      >
         <Show when={!mobileFullscreen()}>
           <AppBar position="sticky" color="default" elevation={0} class="border-b border-base">
             <Toolbar variant="dense" class="session-toolbar flex flex-wrap items-center gap-2 py-0 min-h-[40px]">

--- a/packages/ui/src/components/prompt-input.tsx
+++ b/packages/ui/src/components/prompt-input.tsx
@@ -652,6 +652,16 @@ export default function PromptInput(props: PromptInputProps) {
                 autoCapitalize="off"
                 autocomplete="off"
               />
+              <button
+                type="button"
+                class="prompt-clear-button prompt-clear-button-inline"
+                onClick={handleClearPrompt}
+                disabled={!canClearPrompt()}
+                aria-label={t("promptInput.clear.ariaLabel")}
+                title={t("promptInput.clear.title")}
+              >
+                <X class="h-4 w-4" aria-hidden="true" />
+              </button>
               <Show when={shouldShowOverlay()}>
                 <div class={`prompt-input-overlay keyboard-hints ${mode() === "shell" ? "shell-mode" : ""}`}>
                   <Show
@@ -781,16 +791,6 @@ export default function PromptInput(props: PromptInputProps) {
                 title={t("promptInput.attachFiles.title")}
               >
                 <Paperclip class="h-4 w-4" aria-hidden="true" />
-              </button>
-              <button
-                type="button"
-                class="prompt-clear-button"
-                onClick={handleClearPrompt}
-                disabled={!canClearPrompt()}
-                aria-label={t("promptInput.clear.ariaLabel")}
-                title={t("promptInput.clear.title")}
-              >
-                <X class="h-4 w-4" aria-hidden="true" />
               </button>
             </div>
             <div class="prompt-nav-column prompt-nav-column-right">

--- a/packages/ui/src/components/prompt-input.tsx
+++ b/packages/ui/src/components/prompt-input.tsx
@@ -687,7 +687,7 @@ export default function PromptInput(props: PromptInputProps) {
                               <Kbd>Enter</Kbd> {t("promptInput.overlay.send")} • <Kbd shortcut="cmd+enter" /> {t("promptInput.overlay.newLine")}
                             </>
                           </Show>
-                          {" "}• <Kbd>@</Kbd> {t("promptInput.overlay.filesAgents")} • <Kbd>↑↓</Kbd> {t("promptInput.overlay.history")}
+                          {" "}• <Kbd>↑↓</Kbd> {t("promptInput.overlay.history")}
                         </span>
                         <Show when={attachments().length > 0}>
                           <span class="prompt-overlay-text prompt-overlay-muted">{t("promptInput.overlay.attachments", { count: attachments().length })}</span>

--- a/packages/ui/src/components/prompt-input.tsx
+++ b/packages/ui/src/components/prompt-input.tsx
@@ -630,7 +630,7 @@ export default function PromptInput(props: PromptInputProps) {
           </Suspense>
         </Show>
 
-        <div class="flex flex-1 flex-col">
+        <div class="prompt-input-main flex flex-1 flex-col">
           <div class={`prompt-input-field-container ${expandState() === "expanded" ? "is-expanded" : ""}`}>
 
             <div class={`prompt-input-field ${expandState() === "expanded" ? "is-expanded" : ""}`}>
@@ -662,6 +662,12 @@ export default function PromptInput(props: PromptInputProps) {
               >
                 <X class="h-4 w-4" aria-hidden="true" />
               </button>
+              <div class="prompt-expand-button-inline">
+                <ExpandButton
+                  expandState={expandState}
+                  onToggleExpand={handleExpandToggle}
+                />
+              </div>
               <Show when={shouldShowOverlay()}>
                 <div class={`prompt-input-overlay keyboard-hints ${mode() === "shell" ? "shell-mode" : ""}`}>
                   <Show
@@ -794,10 +800,6 @@ export default function PromptInput(props: PromptInputProps) {
               </button>
             </div>
             <div class="prompt-nav-column prompt-nav-column-right">
-              <ExpandButton
-                expandState={expandState}
-                onToggleExpand={handleExpandToggle}
-              />
               <Show when={hasHistory()}>
                 <button
                   type="button"

--- a/packages/ui/src/styles/messaging/prompt-input.css
+++ b/packages/ui/src/styles/messaging/prompt-input.css
@@ -47,7 +47,7 @@
 .prompt-input {
   @apply w-full pt-2.5 border text-sm resize-none outline-none transition-colors;
   padding-inline-start: 0.75rem;
-  padding-inline-end: 0.75rem;
+  padding-inline-end: 2.5rem;
   font-family: inherit;
   background-color: var(--surface-base);
   color: var(--text-primary);
@@ -151,6 +151,13 @@
 .prompt-clear-button:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
+
+.prompt-clear-button-inline {
+  position: absolute;
+  top: 0.5rem;
+  inset-inline-end: 0.5rem;
+  z-index: 2;
 }
 
 .prompt-overlay-text {
@@ -437,6 +444,7 @@
   .prompt-input {
     min-height: 0;
     padding: 0.5rem 0.75rem;
+    padding-inline-end: 2.5rem;
     padding-bottom: 0.75rem;
   }
 

--- a/packages/ui/src/styles/messaging/prompt-input.css
+++ b/packages/ui/src/styles/messaging/prompt-input.css
@@ -5,10 +5,15 @@
 }
 
 .prompt-input-wrapper {
+  --prompt-input-compact-height: 104px;
   @apply grid items-stretch;
   grid-template-columns: minmax(0, 1fr) 72px 64px;
   gap: 0;
   padding: 0;
+}
+
+.prompt-input-main {
+  min-width: 0;
 }
 
 .prompt-input-actions {
@@ -47,7 +52,7 @@
 .prompt-input {
   @apply w-full pt-2.5 border text-sm resize-none outline-none transition-colors;
   padding-inline-start: 0.75rem;
-  padding-inline-end: 2.5rem;
+  padding-inline-end: 4.5rem;
   font-family: inherit;
   background-color: var(--surface-base);
   color: var(--text-primary);
@@ -154,6 +159,13 @@
 }
 
 .prompt-clear-button-inline {
+  position: absolute;
+  top: 2.5rem;
+  inset-inline-end: 0.5rem;
+  z-index: 2;
+}
+
+.prompt-expand-button-inline {
   position: absolute;
   top: 0.5rem;
   inset-inline-end: 0.5rem;
@@ -410,41 +422,77 @@
   }
 }
 
-@media (max-width: 1279px) {
-  :root {
-    --prompt-input-compact-height: 104px;
-  }
-
-  .prompt-input-wrapper {
-    min-height: var(--prompt-input-compact-height);
-  }
-
-  .prompt-input-field-container {
-    min-height: var(--prompt-input-compact-height);
-    height: var(--prompt-input-compact-height);
-  }
-
-  .prompt-input-field {
-    height: var(--prompt-input-compact-height);
-  }
-
-  .prompt-input-field-container.is-expanded,
-  .prompt-input-field.is-expanded {
-    height: auto;
-  }
+.session-center-column[data-session-center-width="medium"] .prompt-input-wrapper,
+.session-center-column[data-session-center-width="narrow"] .prompt-input-wrapper {
+  min-height: var(--prompt-input-compact-height);
 }
 
-@media (max-width: 720px) {
-  .prompt-input-wrapper {
-    grid-template-columns: minmax(0, 1fr) 64px 40px;
-  }
+.session-center-column[data-session-center-width="medium"] .prompt-input-field-container,
+.session-center-column[data-session-center-width="narrow"] .prompt-input-field-container {
+  min-height: var(--prompt-input-compact-height);
+  height: var(--prompt-input-compact-height);
+}
+
+.session-center-column[data-session-center-width="medium"] .prompt-input-field,
+.session-center-column[data-session-center-width="narrow"] .prompt-input-field {
+  height: var(--prompt-input-compact-height);
+}
+
+.session-center-column[data-session-center-width="medium"] .prompt-input-field-container.is-expanded,
+.session-center-column[data-session-center-width="medium"] .prompt-input-field.is-expanded,
+.session-center-column[data-session-center-width="narrow"] .prompt-input-field-container.is-expanded,
+.session-center-column[data-session-center-width="narrow"] .prompt-input-field.is-expanded {
+  height: auto;
+}
+
+.session-center-column[data-session-center-width="narrow"] .prompt-input-wrapper {
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas:
+    "field field"
+    "actions primary";
+}
+
+.session-center-column[data-session-center-width="narrow"] .prompt-input-main {
+  grid-area: field;
+}
+
+.session-center-column[data-session-center-width="narrow"] .prompt-input-actions {
+  grid-area: actions;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  height: auto;
+  padding: 0.25rem 0.5rem 0.5rem;
+}
+
+.session-center-column[data-session-center-width="narrow"] .prompt-input-primary-actions {
+  grid-area: primary;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+  width: auto;
+  height: auto;
+  padding: 0.25rem 0.5rem 0.5rem 0;
+  border-inline-start: none;
+}
+
+.session-center-column[data-session-center-width="narrow"] .prompt-nav-buttons {
+  justify-content: flex-start;
+  gap: 0.25rem;
+}
+
+.session-center-column[data-session-center-width="narrow"] .prompt-nav-column {
+  flex-direction: row;
+  align-items: center;
+  min-width: 0;
+  gap: 0.25rem;
 }
 
 @media (max-width: 640px) {
   .prompt-input {
     min-height: 0;
     padding: 0.5rem 0.75rem;
-    padding-inline-end: 2.5rem;
+    padding-inline-end: 4.5rem;
     padding-bottom: 0.75rem;
   }
 

--- a/packages/ui/src/styles/panels/empty-loading.css
+++ b/packages/ui/src/styles/panels/empty-loading.css
@@ -15,6 +15,15 @@
   @apply text-center max-w-sm;
 }
 
+.session-center-column[data-session-center-width="narrow"] .empty-state-logo {
+  height: 9rem;
+}
+
+.session-center-column[data-session-center-width="narrow"] .empty-state-brand-title {
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+
 .empty-state-content h3 {
   font-size: var(--font-size-xl);
   margin-bottom: 12px;

--- a/packages/ui/src/styles/panels/session-layout.css
+++ b/packages/ui/src/styles/panels/session-layout.css
@@ -6,6 +6,21 @@
   overflow: hidden;
 }
 
+.session-center-column {
+  container-name: session-center;
+  container-type: inline-size;
+  --session-center-width-step: wide;
+}
+
+/* Canonical session-center width steps: narrow < 768px, medium < 1280px, wide >= 1280px. */
+.session-center-column[data-session-center-width="narrow"] {
+  --session-center-width-step: narrow;
+}
+
+.session-center-column[data-session-center-width="medium"] {
+  --session-center-width-step: medium;
+}
+
 .session-list-container {
   @apply flex flex-col flex-1 min-h-0 relative;
   background-color: var(--surface-secondary);


### PR DESCRIPTION
## Summary
- Add measured `narrow` / `medium` / `wide` width steps to the session center column so chat UI can respond to pane width rather than viewport width.
- Rework prompt composer controls: clear/expand move into the text field, narrow panes place auxiliary controls below the textarea, and stop/send align bottom-right.
- Reduce branded empty-state logo/title size in narrow session panes and remove the prompt `@ files/agents` overlay hint.

## Validation
- `npm run typecheck --workspace @codenomad/ui`