### PR TITLE
fix(ui): recover legacy sessions with export fallback

### DIFF
--- a/packages/server/src/api-types.ts
+++ b/packages/server/src/api-types.ts
@@ -59,6 +59,11 @@ export interface WorkspaceDeleteResponse {
   status: WorkspaceStatus
 }
 
+export interface WorkspaceSessionExportResponse {
+  info: Record<string, unknown>
+  messages: unknown[]
+}
+
 export type WorktreeKind = "root" | "worktree"
 
 export interface WorktreeDescriptor {

--- a/packages/server/src/server/routes/workspaces.ts
+++ b/packages/server/src/server/routes/workspaces.ts
@@ -103,6 +103,16 @@ export function registerWorkspaceRoutes(app: FastifyInstance, deps: RouteDeps) {
   })
 
   app.get<{
+    Params: { id: string; sessionId: string }
+  }>("/api/workspaces/:id/sessions/:sessionId/export", async (request, reply) => {
+    try {
+      return await deps.workspaceManager.exportSessionData(request.params.id, request.params.sessionId)
+    } catch (error) {
+      return handleWorkspaceError(error, reply)
+    }
+  })
+
+  app.get<{
     Params: { id: string }
     Querystring: { path?: string }
   }>("/api/workspaces/:id/files", async (request, reply) => {

--- a/packages/server/src/server/routes/workspaces.ts
+++ b/packages/server/src/server/routes/workspaces.ts
@@ -104,8 +104,8 @@ export function registerWorkspaceRoutes(app: FastifyInstance, deps: RouteDeps) {
   })
 
   app.get<{
-    Params: { id: string; sessionId: string }
-  }>("/api/workspaces/:id/sessions/:sessionId/export", async (request, reply) => {
+    Params: { id: string; slug: string; sessionId: string }
+  }>("/api/workspaces/:id/worktrees/:slug/sessions/:sessionId/export", async (request, reply) => {
     const controller = new AbortController()
     const handleAbort = () => controller.abort()
     request.raw.on("close", handleAbort)
@@ -132,8 +132,28 @@ export function registerWorkspaceRoutes(app: FastifyInstance, deps: RouteDeps) {
     reply.raw.on("finish", handleReplyDone)
 
     try {
+      const workspace = deps.workspaceManager.get(request.params.id)
+      if (!workspace) {
+        await cleanup()
+        reply.code(404)
+        return { error: "Workspace not found" }
+      }
+
+      const directory = await resolveWorktreeDirectory({
+        workspaceId: workspace.id,
+        workspacePath: workspace.path,
+        worktreeSlug: request.params.slug,
+        logger: request.log,
+      })
+      if (!directory) {
+        await cleanup()
+        reply.code(404)
+        return { error: "Worktree not found" }
+      }
+
       exportFile = await deps.workspaceManager.exportSessionDataToFile(request.params.id, request.params.sessionId, {
         signal: controller.signal,
+        directory,
       })
       const stream = createReadStream(exportFile.filePath)
       stream.on("error", () => {

--- a/packages/server/src/server/routes/workspaces.ts
+++ b/packages/server/src/server/routes/workspaces.ts
@@ -1,3 +1,4 @@
+import { createReadStream } from "fs"
 import { FastifyInstance, FastifyReply } from "fastify"
 import { z } from "zod"
 import { WorkspaceManager } from "../../workspaces/manager"
@@ -105,9 +106,50 @@ export function registerWorkspaceRoutes(app: FastifyInstance, deps: RouteDeps) {
   app.get<{
     Params: { id: string; sessionId: string }
   }>("/api/workspaces/:id/sessions/:sessionId/export", async (request, reply) => {
+    const controller = new AbortController()
+    const handleAbort = () => controller.abort()
+    request.raw.on("close", handleAbort)
+    request.raw.on("error", handleAbort)
+
+    let exportFile: Awaited<ReturnType<WorkspaceManager["exportSessionDataToFile"]>> | null = null
+    let cleanedUp = false
+
+    const cleanup = async () => {
+      if (cleanedUp) return
+      cleanedUp = true
+      request.raw.off("close", handleAbort)
+      request.raw.off("error", handleAbort)
+      reply.raw.off("close", handleReplyDone)
+      reply.raw.off("finish", handleReplyDone)
+      await exportFile?.cleanup().catch(() => undefined)
+    }
+
+    const handleReplyDone = () => {
+      void cleanup()
+    }
+
+    reply.raw.on("close", handleReplyDone)
+    reply.raw.on("finish", handleReplyDone)
+
     try {
-      return await deps.workspaceManager.exportSessionData(request.params.id, request.params.sessionId)
+      exportFile = await deps.workspaceManager.exportSessionDataToFile(request.params.id, request.params.sessionId, {
+        signal: controller.signal,
+      })
+      const stream = createReadStream(exportFile.filePath)
+      stream.on("error", () => {
+        void cleanup()
+      })
+      reply.type("application/json; charset=utf-8")
+      return reply.send(stream)
     } catch (error) {
+      await cleanup()
+      if (request.raw.destroyed || controller.signal.aborted) {
+        return
+      }
+      if (error instanceof Error && error.message.includes("Session export timed out")) {
+        reply.code(504)
+        return { error: error.message }
+      }
       return handleWorkspaceError(error, reply)
     }
   })

--- a/packages/server/src/workspaces/manager.ts
+++ b/packages/server/src/workspaces/manager.ts
@@ -1,5 +1,5 @@
 import path from "path"
-import { spawnSync } from "child_process"
+import { spawn, spawnSync } from "child_process"
 import { connect } from "net"
 import { EventBus } from "../events/bus"
 import type { SettingsService } from "../settings/service"
@@ -7,7 +7,7 @@ import type { BinaryResolver } from "../settings/binaries"
 import { FileSystemBrowser } from "../filesystem/browser"
 import { searchWorkspaceFiles, WorkspaceFileSearchOptions } from "../filesystem/search"
 import { clearWorkspaceSearchCache } from "../filesystem/search-cache"
-import { WorkspaceDescriptor, WorkspaceFileResponse, FileSystemEntry } from "../api-types"
+import { WorkspaceDescriptor, WorkspaceFileResponse, FileSystemEntry, WorkspaceSessionExportResponse } from "../api-types"
 import { WorkspaceRuntime, ProcessExitInfo } from "./runtime"
 import { Logger } from "../logger"
 import {
@@ -22,6 +22,7 @@ import {
   OPENCODE_SERVER_USERNAME_ENV,
   resolveOpencodeServerAuth,
 } from "./opencode-auth"
+import { buildSpawnSpec } from "./spawn"
 
 const STARTUP_STABILITY_DELAY_MS = 1500
 
@@ -93,6 +94,73 @@ export class WorkspaceManager {
     const workspace = this.requireWorkspace(workspaceId)
     const browser = new FileSystemBrowser({ rootDir: workspace.path })
     browser.writeFile(relativePath, contents)
+  }
+
+  async exportSessionData(workspaceId: string, sessionId: string): Promise<WorkspaceSessionExportResponse> {
+    const workspace = this.requireWorkspace(workspaceId)
+    const normalizedSessionId = sessionId.trim()
+    if (!normalizedSessionId) {
+      throw new Error("Session ID is required")
+    }
+
+    const serverConfig = this.options.settings.getOwner("config", "server")
+    const envVars = (serverConfig as any)?.environmentVariables
+    const userEnvironment = envVars && typeof envVars === "object" && !Array.isArray(envVars) ? (envVars as any) : {}
+    const opencodeConfigContent = buildOpencodeConfigContent(
+      resolveExistingOpencodeConfigContent(userEnvironment),
+      this.codeNomadPluginUrl,
+    )
+
+    const environment = {
+      ...process.env,
+      ...userEnvironment,
+      OPENCODE_CONFIG_CONTENT: opencodeConfigContent,
+    }
+
+    const spec = buildSpawnSpec(workspace.binaryId, ["export", normalizedSessionId], {
+      cwd: workspace.path,
+      env: environment,
+      propagateEnvKeys: Object.keys(userEnvironment),
+    })
+
+    return await new Promise<WorkspaceSessionExportResponse>((resolve, reject) => {
+      const child = spawn(spec.command, spec.args, {
+        cwd: spec.cwd,
+        env: spec.env,
+        stdio: ["ignore", "pipe", "pipe"],
+        ...spec.options,
+      })
+
+      const stdoutChunks: Buffer[] = []
+      const stderrChunks: Buffer[] = []
+
+      child.stdout?.on("data", (chunk: Buffer) => stdoutChunks.push(chunk))
+      child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk))
+      child.on("error", (error) => reject(error))
+      child.on("exit", (code) => {
+        if (code !== 0) {
+          const stderr = Buffer.concat(stderrChunks).toString("utf8").trim()
+          const stdout = Buffer.concat(stdoutChunks).toString("utf8").trim()
+          reject(new Error(stderr || stdout || `opencode export exited with code ${code}`))
+          return
+        }
+
+        try {
+          const stdout = Buffer.concat(stdoutChunks).toString("utf8").trim()
+          if (!stdout) {
+            throw new Error("opencode export returned empty output")
+          }
+
+          const parsed = JSON.parse(stdout) as { info?: Record<string, unknown>; messages?: unknown[] }
+          resolve({
+            info: parsed.info && typeof parsed.info === "object" ? parsed.info : {},
+            messages: Array.isArray(parsed.messages) ? parsed.messages : [],
+          })
+        } catch (error) {
+          reject(error)
+        }
+      })
+    })
   }
 
   async create(folder: string, name?: string): Promise<WorkspaceDescriptor> {

--- a/packages/server/src/workspaces/manager.ts
+++ b/packages/server/src/workspaces/manager.ts
@@ -108,7 +108,7 @@ export class WorkspaceManager {
   async exportSessionDataToFile(
     workspaceId: string,
     sessionId: string,
-    options?: { signal?: AbortSignal },
+    options?: { signal?: AbortSignal; directory?: string },
   ): Promise<SessionExportFile> {
     const workspace = this.requireWorkspace(workspaceId)
     const normalizedSessionId = sessionId.trim()
@@ -131,7 +131,7 @@ export class WorkspaceManager {
     }
 
     const spec = buildSpawnSpec(workspace.binaryId, ["export", normalizedSessionId], {
-      cwd: workspace.path,
+      cwd: options?.directory ?? workspace.path,
       env: environment,
       propagateEnvKeys: Object.keys(userEnvironment),
     })

--- a/packages/server/src/workspaces/manager.ts
+++ b/packages/server/src/workspaces/manager.ts
@@ -1,13 +1,16 @@
+import { createWriteStream, promises as fsp } from "fs"
+import os from "os"
 import path from "path"
 import { spawn, spawnSync } from "child_process"
 import { connect } from "net"
+import { finished } from "stream/promises"
 import { EventBus } from "../events/bus"
 import type { SettingsService } from "../settings/service"
 import type { BinaryResolver } from "../settings/binaries"
 import { FileSystemBrowser } from "../filesystem/browser"
 import { searchWorkspaceFiles, WorkspaceFileSearchOptions } from "../filesystem/search"
 import { clearWorkspaceSearchCache } from "../filesystem/search-cache"
-import { WorkspaceDescriptor, WorkspaceFileResponse, FileSystemEntry, WorkspaceSessionExportResponse } from "../api-types"
+import { WorkspaceDescriptor, WorkspaceFileResponse, FileSystemEntry } from "../api-types"
 import { WorkspaceRuntime, ProcessExitInfo } from "./runtime"
 import { Logger } from "../logger"
 import {
@@ -25,6 +28,12 @@ import {
 import { buildSpawnSpec } from "./spawn"
 
 const STARTUP_STABILITY_DELAY_MS = 1500
+const SESSION_EXPORT_TIMEOUT_MS = 5 * 60_000
+
+interface SessionExportFile {
+  filePath: string
+  cleanup: () => Promise<void>
+}
 
 interface WorkspaceManagerOptions {
   rootDir: string
@@ -96,7 +105,11 @@ export class WorkspaceManager {
     browser.writeFile(relativePath, contents)
   }
 
-  async exportSessionData(workspaceId: string, sessionId: string): Promise<WorkspaceSessionExportResponse> {
+  async exportSessionDataToFile(
+    workspaceId: string,
+    sessionId: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<SessionExportFile> {
     const workspace = this.requireWorkspace(workspaceId)
     const normalizedSessionId = sessionId.trim()
     if (!normalizedSessionId) {
@@ -123,44 +136,91 @@ export class WorkspaceManager {
       propagateEnvKeys: Object.keys(userEnvironment),
     })
 
-    return await new Promise<WorkspaceSessionExportResponse>((resolve, reject) => {
-      const child = spawn(spec.command, spec.args, {
-        cwd: spec.cwd,
-        env: spec.env,
-        stdio: ["ignore", "pipe", "pipe"],
-        ...spec.options,
-      })
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "codenomad-session-export-"))
+    const filePath = path.join(tempDir, `${normalizedSessionId}.json`)
 
-      const stdoutChunks: Buffer[] = []
-      const stderrChunks: Buffer[] = []
+    const cleanup = async () => {
+      await fsp.rm(tempDir, { recursive: true, force: true }).catch(() => undefined)
+    }
 
-      child.stdout?.on("data", (chunk: Buffer) => stdoutChunks.push(chunk))
-      child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk))
-      child.on("error", (error) => reject(error))
-      child.on("exit", (code) => {
-        if (code !== 0) {
-          const stderr = Buffer.concat(stderrChunks).toString("utf8").trim()
-          const stdout = Buffer.concat(stdoutChunks).toString("utf8").trim()
-          reject(new Error(stderr || stdout || `opencode export exited with code ${code}`))
-          return
-        }
+    try {
+      return await new Promise<SessionExportFile>((resolve, reject) => {
+        let settled = false
+        let timedOut = false
+        const controller = new AbortController()
+        const output = createWriteStream(filePath, { encoding: "utf8" })
+        const timeout = setTimeout(() => {
+          timedOut = true
+          controller.abort()
+        }, SESSION_EXPORT_TIMEOUT_MS)
 
-        try {
-          const stdout = Buffer.concat(stdoutChunks).toString("utf8").trim()
-          if (!stdout) {
-            throw new Error("opencode export returned empty output")
+        const finish = async (result: { file?: SessionExportFile; error?: Error }) => {
+          if (settled) return
+          settled = true
+          clearTimeout(timeout)
+          options?.signal?.removeEventListener("abort", handleAbort)
+
+          if (result.error) {
+            output.destroy()
+            await cleanup()
+            reject(result.error)
+            return
           }
 
-          const parsed = JSON.parse(stdout) as { info?: Record<string, unknown>; messages?: unknown[] }
-          resolve({
-            info: parsed.info && typeof parsed.info === "object" ? parsed.info : {},
-            messages: Array.isArray(parsed.messages) ? parsed.messages : [],
-          })
-        } catch (error) {
-          reject(error)
+          resolve(result.file!)
         }
+
+        const handleAbort = () => {
+          controller.abort()
+        }
+
+        options?.signal?.addEventListener("abort", handleAbort)
+
+        const child = spawn(spec.command, spec.args, {
+          cwd: spec.cwd,
+          env: spec.env,
+          stdio: ["ignore", "pipe", "pipe"],
+          signal: controller.signal,
+          ...spec.options,
+        })
+
+        const stderrChunks: Buffer[] = []
+
+        child.stdout?.pipe(output)
+        output.on("error", (error) => {
+          void finish({ error: error instanceof Error ? error : new Error(String(error)) })
+        })
+        child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk))
+        child.on("error", async (error) => {
+          const abortReason = options?.signal?.aborted
+            ? new Error("Session export aborted")
+            : timedOut
+              ? new Error(`Session export timed out after ${SESSION_EXPORT_TIMEOUT_MS}ms`)
+              : error
+          await finish({ error: abortReason })
+        })
+        child.on("exit", (code) => {
+          void (async () => {
+            if (code !== 0) {
+              const stderr = Buffer.concat(stderrChunks).toString("utf8").trim()
+              const errorMessage = stderr || `opencode export exited with code ${code}`
+              await finish({ error: new Error(errorMessage) })
+              return
+            }
+
+            try {
+              await finished(output)
+              await finish({ file: { filePath, cleanup } })
+            } catch (error) {
+              await finish({ error: error instanceof Error ? error : new Error(String(error)) })
+            }
+          })()
+        })
       })
-    })
+    } catch (error) {
+      await cleanup()
+      throw error
+    }
   }
 
   async create(folder: string, name?: string): Promise<WorkspaceDescriptor> {

--- a/packages/ui/src/lib/api-client.ts
+++ b/packages/ui/src/lib/api-client.ts
@@ -216,8 +216,8 @@ export const serverApi = {
     return request<WorktreeMap>(`/api/workspaces/${encodeURIComponent(id)}/worktrees/map`)
   },
 
-  exportSessionData(id: string, sessionId: string): Promise<WorkspaceSessionExportResponse> {
-    return request<WorkspaceSessionExportResponse>(`/api/workspaces/${encodeURIComponent(id)}/sessions/${encodeURIComponent(sessionId)}/export`)
+  exportSessionData(id: string, slug: string, sessionId: string): Promise<WorkspaceSessionExportResponse> {
+    return request<WorkspaceSessionExportResponse>(`/api/workspaces/${encodeURIComponent(id)}/worktrees/${encodeURIComponent(slug)}/sessions/${encodeURIComponent(sessionId)}/export`)
   },
 
   writeWorktreeMap(id: string, map: WorktreeMap): Promise<void> {

--- a/packages/ui/src/lib/api-client.ts
+++ b/packages/ui/src/lib/api-client.ts
@@ -8,6 +8,7 @@ import type {
   FileSystemFileContentResponse,
   FileSystemListResponse,
   InstanceData,
+  WorkspaceSessionExportResponse,
   SpeechCapabilitiesResponse,
   SpeechSynthesisResponse,
   SpeechTranscriptionResponse,
@@ -213,6 +214,10 @@ export const serverApi = {
 
   readWorktreeMap(id: string): Promise<WorktreeMap> {
     return request<WorktreeMap>(`/api/workspaces/${encodeURIComponent(id)}/worktrees/map`)
+  },
+
+  exportSessionData(id: string, sessionId: string): Promise<WorkspaceSessionExportResponse> {
+    return request<WorkspaceSessionExportResponse>(`/api/workspaces/${encodeURIComponent(id)}/sessions/${encodeURIComponent(sessionId)}/export`)
   },
 
   writeWorktreeMap(id: string, map: WorktreeMap): Promise<void> {

--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -761,7 +761,7 @@ async function loadMessages(
 
   try {
     log.info(`[HTTP] GET /session.${"messages"} for instance ${instanceId}`, { sessionId })
-    const apiMessages = await fetchSessionMessages(instanceId, sessionId, client)
+    const apiMessages = await fetchSessionMessages(instanceId, sessionId, worktreeSlug, client)
 
     if (!Array.isArray(apiMessages)) {
       return

--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -49,6 +49,7 @@ import {
   removeParentSessionMapping,
   setWorktreeSlugForParentSession,
 } from "./worktrees"
+import { fetchSessionMessages } from "./session-message-source"
 
 const log = getLogger("api")
 
@@ -760,10 +761,7 @@ async function loadMessages(
 
   try {
     log.info(`[HTTP] GET /session.${"messages"} for instance ${instanceId}`, { sessionId })
-    const apiMessages = await requestData<any[]>(
-      client.session.messages({ sessionID: sessionId }),
-      "session.messages",
-    )
+    const apiMessages = await fetchSessionMessages(instanceId, sessionId, client)
 
     if (!Array.isArray(apiMessages)) {
       return

--- a/packages/ui/src/stores/session-message-fallback.test.ts
+++ b/packages/ui/src/stores/session-message-fallback.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { OpencodeApiError } from "../lib/opencode-api.js"
+import { isLegacyMissingAgentValidationError } from "./session-message-fallback.js"
+
+describe("isLegacyMissingAgentValidationError", () => {
+  it("matches the legacy missing-agent validation error", () => {
+    const error = new OpencodeApiError("session.messages failed", {
+      cause: {
+        name: "BadRequest",
+        data: {
+          kind: "Body",
+          message: 'Missing key\n  at [1]["info"]["agent"]',
+        },
+      },
+    })
+
+    assert.equal(isLegacyMissingAgentValidationError(error), true)
+  })
+
+  it("ignores unrelated missing-key validation failures", () => {
+    const error = new OpencodeApiError("session.messages failed", {
+      cause: {
+        name: "BadRequest",
+        data: {
+          kind: "Body",
+          message: 'Missing key\n  at [1]["info"]["model"]',
+        },
+      },
+    })
+
+    assert.equal(isLegacyMissingAgentValidationError(error), false)
+  })
+})

--- a/packages/ui/src/stores/session-message-fallback.test.ts
+++ b/packages/ui/src/stores/session-message-fallback.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 
 import { OpencodeApiError } from "../lib/opencode-api.js"
-import { isLegacyMissingAgentValidationError } from "./session-message-fallback.js"
+import { getExportedSessionMessages, isLegacyMissingAgentValidationError } from "./session-message-fallback.js"
 
 describe("isLegacyMissingAgentValidationError", () => {
   it("matches the legacy missing-agent validation error", () => {
@@ -31,5 +31,9 @@ describe("isLegacyMissingAgentValidationError", () => {
     })
 
     assert.equal(isLegacyMissingAgentValidationError(error), false)
+  })
+
+  it("throws when the export response does not contain a messages array", () => {
+    assert.throws(() => getExportedSessionMessages({ info: {}, messages: null as any }), /messages array/)
   })
 })

--- a/packages/ui/src/stores/session-message-fallback.ts
+++ b/packages/ui/src/stores/session-message-fallback.ts
@@ -1,0 +1,13 @@
+import { OpencodeApiError } from "../lib/opencode-api"
+
+export function isLegacyMissingAgentValidationError(error: unknown): boolean {
+  if (!(error instanceof OpencodeApiError)) {
+    return false
+  }
+
+  const cause = (error as any).cause
+  const causeName = cause && typeof cause === "object" ? (cause as any).name : undefined
+  const causeData = cause && typeof cause === "object" ? (cause as any).data : undefined
+  const message = typeof causeData?.message === "string" ? causeData.message : ""
+  return causeName === "BadRequest" && causeData?.kind === "Body" && /\["info"\]\["agent"\]/.test(message)
+}

--- a/packages/ui/src/stores/session-message-fallback.ts
+++ b/packages/ui/src/stores/session-message-fallback.ts
@@ -1,4 +1,5 @@
 import { OpencodeApiError } from "../lib/opencode-api"
+import type { WorkspaceSessionExportResponse } from "../../../server/src/api-types"
 
 export function isLegacyMissingAgentValidationError(error: unknown): boolean {
   if (!(error instanceof OpencodeApiError)) {
@@ -10,4 +11,12 @@ export function isLegacyMissingAgentValidationError(error: unknown): boolean {
   const causeData = cause && typeof cause === "object" ? (cause as any).data : undefined
   const message = typeof causeData?.message === "string" ? causeData.message : ""
   return causeName === "BadRequest" && causeData?.kind === "Body" && /\["info"\]\["agent"\]/.test(message)
+}
+
+export function getExportedSessionMessages(exported: WorkspaceSessionExportResponse): unknown[] {
+  if (!exported || !Array.isArray(exported.messages)) {
+    throw new Error("Legacy session export did not return a messages array")
+  }
+
+  return exported.messages
 }

--- a/packages/ui/src/stores/session-message-source.ts
+++ b/packages/ui/src/stores/session-message-source.ts
@@ -1,0 +1,35 @@
+import type { OpencodeClient } from "@opencode-ai/sdk/v2/client"
+
+import { serverApi } from "../lib/api-client"
+import { OpencodeApiError, requestData } from "../lib/opencode-api"
+import { getLogger } from "../lib/logger"
+
+const log = getLogger("api")
+
+function shouldFallbackToSessionExport(error: unknown): boolean {
+  if (!(error instanceof OpencodeApiError)) {
+    return false
+  }
+
+  const cause = (error as any).cause
+  const causeData = cause && typeof cause === "object" ? (cause as any).data : undefined
+  const message = typeof causeData?.message === "string" ? causeData.message : ""
+  return causeData?.kind === "Body" && message.includes("Missing key")
+}
+
+export async function fetchSessionMessages(instanceId: string, sessionId: string, client: OpencodeClient): Promise<any[]> {
+  try {
+    return await requestData<any[]>(
+      client.session.messages({ sessionID: sessionId }),
+      "session.messages",
+    )
+  } catch (error) {
+    if (!shouldFallbackToSessionExport(error)) {
+      throw error
+    }
+
+    log.warn("Falling back to opencode export for malformed session messages", { instanceId, sessionId, error })
+    const exported = await serverApi.exportSessionData(instanceId, sessionId)
+    return Array.isArray(exported.messages) ? exported.messages : []
+  }
+}

--- a/packages/ui/src/stores/session-message-source.ts
+++ b/packages/ui/src/stores/session-message-source.ts
@@ -1,21 +1,11 @@
 import type { OpencodeClient } from "@opencode-ai/sdk/v2/client"
 
 import { serverApi } from "../lib/api-client"
-import { OpencodeApiError, requestData } from "../lib/opencode-api"
+import { requestData } from "../lib/opencode-api"
 import { getLogger } from "../lib/logger"
+import { isLegacyMissingAgentValidationError } from "./session-message-fallback"
 
 const log = getLogger("api")
-
-function shouldFallbackToSessionExport(error: unknown): boolean {
-  if (!(error instanceof OpencodeApiError)) {
-    return false
-  }
-
-  const cause = (error as any).cause
-  const causeData = cause && typeof cause === "object" ? (cause as any).data : undefined
-  const message = typeof causeData?.message === "string" ? causeData.message : ""
-  return causeData?.kind === "Body" && message.includes("Missing key")
-}
 
 export async function fetchSessionMessages(instanceId: string, sessionId: string, client: OpencodeClient): Promise<any[]> {
   try {
@@ -24,7 +14,7 @@ export async function fetchSessionMessages(instanceId: string, sessionId: string
       "session.messages",
     )
   } catch (error) {
-    if (!shouldFallbackToSessionExport(error)) {
+    if (!isLegacyMissingAgentValidationError(error)) {
       throw error
     }
 

--- a/packages/ui/src/stores/session-message-source.ts
+++ b/packages/ui/src/stores/session-message-source.ts
@@ -3,11 +3,16 @@ import type { OpencodeClient } from "@opencode-ai/sdk/v2/client"
 import { serverApi } from "../lib/api-client"
 import { requestData } from "../lib/opencode-api"
 import { getLogger } from "../lib/logger"
-import { isLegacyMissingAgentValidationError } from "./session-message-fallback"
+import { getExportedSessionMessages, isLegacyMissingAgentValidationError } from "./session-message-fallback"
 
 const log = getLogger("api")
 
-export async function fetchSessionMessages(instanceId: string, sessionId: string, client: OpencodeClient): Promise<any[]> {
+export async function fetchSessionMessages(
+  instanceId: string,
+  sessionId: string,
+  worktreeSlug: string,
+  client: OpencodeClient,
+): Promise<any[]> {
   try {
     return await requestData<any[]>(
       client.session.messages({ sessionID: sessionId }),
@@ -19,7 +24,7 @@ export async function fetchSessionMessages(instanceId: string, sessionId: string
     }
 
     log.warn("Falling back to opencode export for malformed session messages", { instanceId, sessionId, error })
-    const exported = await serverApi.exportSessionData(instanceId, sessionId)
-    return Array.isArray(exported.messages) ? exported.messages : []
+    const exported = await serverApi.exportSessionData(instanceId, worktreeSlug, sessionId)
+    return getExportedSessionMessages(exported) as any[]
   }
 }

--- a/packages/ui/src/stores/session-state.ts
+++ b/packages/ui/src/stores/session-state.ts
@@ -7,10 +7,10 @@ import { messageStoreBus } from "./message-v2/bus"
 import { instances } from "./instances"
 import { showConfirmDialog } from "./alerts"
 import { getLogger } from "../lib/logger"
-import { requestData } from "../lib/opencode-api"
 import { getOrCreateWorktreeClient, getWorktreeSlugForSession } from "./worktrees"
 import { tGlobal } from "../lib/i18n"
 import { computeThreadTotals, type ThreadTotals } from "../lib/thread-totals"
+import { fetchSessionMessages } from "./session-message-source"
 
 const log = getLogger("session")
 
@@ -691,14 +691,11 @@ async function isBlankSession(session: Session, instanceId: string, fetchIfNeede
     return isFreshSession
   }
   let messages: any[] = []
-    try {
-      const worktreeSlug = getWorktreeSlugForSession(instanceId, session.id)
-      const client = getOrCreateWorktreeClient(instanceId, worktreeSlug)
-      messages = await requestData<any[]>(
-        client.session.messages({ sessionID: session.id }),
-        "session.messages",
-      )
-    } catch (error) {
+  try {
+    const worktreeSlug = getWorktreeSlugForSession(instanceId, session.id)
+    const client = getOrCreateWorktreeClient(instanceId, worktreeSlug)
+    messages = await fetchSessionMessages(instanceId, session.id, client)
+  } catch (error) {
     log.error(`Failed to fetch messages for session ${session.id}`, error)
     return isFreshSession
   }

--- a/packages/ui/src/stores/session-state.ts
+++ b/packages/ui/src/stores/session-state.ts
@@ -694,7 +694,7 @@ async function isBlankSession(session: Session, instanceId: string, fetchIfNeede
   try {
     const worktreeSlug = getWorktreeSlugForSession(instanceId, session.id)
     const client = getOrCreateWorktreeClient(instanceId, worktreeSlug)
-    messages = await fetchSessionMessages(instanceId, session.id, client)
+    messages = await fetchSessionMessages(instanceId, session.id, worktreeSlug, client)
   } catch (error) {
     log.error(`Failed to fetch messages for session ${session.id}`, error)
     return isFreshSession


### PR DESCRIPTION
## Summary
- recover legacy OpenCode sessions that still appear in `session.list` but fail to open in CodeNomad because the transcript endpoint rejects their historical message payload
- add a narrow recovery path that falls back to `opencode export` only for that known legacy validation failure
- keep normal sessions on the existing `session.messages` flow and harden the fallback so it does not become a new source of hangs or memory spikes

## Problem
The broken sessions are not missing from OpenCode entirely.

They still show up in `session.list`, so CodeNomad can discover them and render them in the session sidebar. The failure happens later, when CodeNomad tries to hydrate the transcript by calling the OpenCode v2 `session.messages` endpoint.

For some historical sessions, at least one assistant message does not satisfy the current v2 response schema anymore. The concrete legacy shape we reproduced is a missing `info.agent` field inside a transcript message. When that happens, the OpenCode endpoint rejects the entire `session.messages` response during validation and returns a `400` body-validation error instead of returning partial transcript data.

That means CodeNomad never receives a message list to hydrate at all. This is why the session can still be visible in the UI while opening it fails.

The error we reproduced on the affected sessions is:

```text
Missing key
  at [1]["info"]["agent"]
```

## Why This Is Not Just A UI Hydration Fix
A UI-only compatibility layer would only help if CodeNomad received the old transcript payload and merely failed to render or normalize it.

That is not what happens here.

The blocking failure occurs inside the OpenCode `session.messages` API path itself, before CodeNomad can hydrate anything. Since the endpoint returns a validation error instead of message data, CodeNomad cannot repair the payload in memory because it never gets access to the transcript through the normal API route.

That is why this PR uses `opencode export` as a read fallback for a very specific legacy failure mode rather than trying to reinterpret `session.messages` client-side.

## Recovery Strategy
The new behavior is:

1. CodeNomad first uses the normal `session.messages` request path.
2. If that call succeeds, nothing changes.
3. If that call fails with the specific legacy body-validation signature for missing `info.agent`, CodeNomad falls back to `opencode export <sessionId>`.
4. The exported transcript is then used only as a replacement read source for hydration.

Important scope limits:
- this does **not** export and re-import sessions
- this does **not** mutate or migrate session data on disk
- this does **not** bypass normal API loading for healthy sessions
- this does **not** swallow arbitrary schema failures; it is restricted to the known legacy missing-agent validation path

## Hardening In This PR
Because the affected transcripts can be very large, the fallback path is also hardened so the recovery mechanism does not introduce a second failure mode.

Specifically:
- the fallback matcher is restricted to the reproduced legacy validation path (`["info"]["agent"]`), so unrelated schema regressions still surface normally
- the server exports to a temporary file and streams that file back instead of buffering the full export payload in memory
- the export subprocess is abortable and protected by a timeout so a stuck export cannot hang the request forever
- temporary export files are cleaned up when the request finishes or is aborted

## Files Changed
- `packages/ui/src/stores/session-message-source.ts`
  - adds the client-side message-loading fallback entry point
- `packages/ui/src/stores/session-message-fallback.ts`
  - isolates the strict legacy error matcher
- `packages/server/src/workspaces/manager.ts`
  - adds the server-side export-to-temp-file helper with timeout and cleanup
- `packages/server/src/server/routes/workspaces.ts`
  - exposes the export stream endpoint used only by the fallback path
- `packages/ui/src/stores/session-api.ts`
  - routes transcript hydration through the guarded loader
- `packages/ui/src/stores/session-state.ts`
  - reuses the same guarded loader for deep blank-session inspection
- `packages/ui/src/lib/api-client.ts`
  - adds the typed server API call for the export endpoint

## Validation
- `npm run typecheck --workspace @codenomad/ui`
- `npx tsx --test packages/ui/src/stores/session-message-fallback.test.ts`
- `npm run build --workspace @codenomad/tauri-app`

## Notes
- `npm run typecheck --workspace @neuralnomads/codenomad` currently fails on the moving `dev` base because of unrelated server dependency/type drift, not because of this change
- touched large files worth future refactor attention:
  - `packages/server/src/workspaces/manager.ts`
  - `packages/ui/src/stores/session-api.ts`
  - `packages/ui/src/stores/session-state.ts`