### PR TITLE
fix: disable wake-lock on Electron + Wayland to prevent system crash

### DIFF
--- a/packages/electron-app/electron/main/ipc.ts
+++ b/packages/electron-app/electron/main/ipc.ts
@@ -89,6 +89,14 @@ export function setupCliIPC(mainWindow: BrowserWindow, cliManager: CliProcessMan
     return directories
   })
 
+  ipcMain.handle("platform:getInfo", async (): Promise<{ sessionType?: string; platform: string }> => {
+    // Expose session type for Wayland detection (Issue #441)
+    return {
+      sessionType: process.env.XDG_SESSION_TYPE,
+      platform: process.platform,
+    }
+  })
+
   ipcMain.handle("power:setWakeLock", async (_event, enabled: boolean): Promise<{ enabled: boolean }> => {
     const next = Boolean(enabled)
     if (next) {

--- a/packages/electron-app/electron/preload/index.cjs
+++ b/packages/electron-app/electron/preload/index.cjs
@@ -33,6 +33,7 @@ const localElectronAPI = {
       return null
     }
   },
+  getPlatformInfo: () => ipcRenderer.invoke("platform:getInfo"),
   requestMicrophoneAccess: () => ipcRenderer.invoke("media:requestMicrophoneAccess"),
   setWakeLock: (enabled) => ipcRenderer.invoke("power:setWakeLock", Boolean(enabled)),
   showNotification: (payload) => ipcRenderer.invoke("notifications:show", payload),

--- a/packages/ui/src/lib/native/wake-lock.ts
+++ b/packages/ui/src/lib/native/wake-lock.ts
@@ -9,9 +9,63 @@ let inFlight: Promise<boolean> | null = null
 
 let applied = false
 
-function hasAnyWakeLockSupport(): boolean {
+/**
+ * Detect if we're running on Wayland.
+ * Electron on Wayland has a critical bug where screen lock causes system hang (Issue #441).
+ */
+async function isWaylandSession(): Promise<boolean> {
   if (typeof window === "undefined") return false
+  
+  // Electron exposes platform info through getPlatformInfo
+  const api = (window as any).electronAPI
+  if (api?.getPlatformInfo) {
+    try {
+      const platformInfo = await api.getPlatformInfo()
+      // Check XDG_SESSION_TYPE environment variable
+      if (platformInfo?.sessionType === "wayland") {
+        return true
+      }
+    } catch (error) {
+      log.log("[wake-lock] Failed to get platform info", error)
+    }
+  }
+  
+  // Fallback: check user agent for Wayland hints
+  if (typeof navigator !== "undefined") {
+    const ua = navigator.userAgent.toLowerCase()
+    // Electron on Wayland often includes "wayland" in user agent
+    if (ua.includes("wayland")) {
+      return true
+    }
+  }
+  
+  return false
+}
+
+// Cache Wayland detection result to avoid repeated async calls
+let waylandDetectionCache: Promise<boolean> | null = null
+function getWaylandDetection(): Promise<boolean> {
+  if (waylandDetectionCache === null) {
+    waylandDetectionCache = isWaylandSession()
+  }
+  return waylandDetectionCache
+}
+
+async function hasAnyWakeLockSupport(): Promise<boolean> {
+  if (typeof window === "undefined") return false
+  
+  // CRITICAL: Disable wake-lock on Electron + Wayland due to screen lock crash (Issue #441)
+  // When user locks screen while wake-lock is active, system hangs and requires hard reboot
   if (isElectronHost()) {
+    const isWayland = await getWaylandDetection()
+    if (isWayland) {
+      log.log(
+        "[wake-lock] Disabled on Wayland due to critical screen lock crash (Issue #441). " +
+        "Use X11 session for wake-lock support, or use Tauri build instead."
+      )
+      return false
+    }
+    
     const api = (window as any).electronAPI
     if (api?.setWakeLock) return true
   }
@@ -39,7 +93,8 @@ async function setElectronWakeLock(enabled: boolean): Promise<boolean> {
 
 async function setTauriWakeLock(enabled: boolean): Promise<boolean> {
   try {
-    if (!hasAnyWakeLockSupport()) {
+    const hasSupport = await hasAnyWakeLockSupport()
+    if (!hasSupport) {
       return false
     }
 
@@ -95,8 +150,11 @@ export function setWakeLockDesired(nextDesired: boolean): Promise<boolean> {
       }
 
       // If we tried to enable but there is no support, avoid re-trying forever.
-      if (desired && !hasAnyWakeLockSupport()) {
-        applied = false
+      if (desired) {
+        const hasSupport = await hasAnyWakeLockSupport()
+        if (!hasSupport) {
+          applied = false
+        }
       }
     }
   })()


### PR DESCRIPTION
## Summary

Fixes critical system crash when screen lock is triggered while wake-lock is active on KDE Wayland + Electron.

## Problem

When using CodeNomad on Electron + Wayland, locking the screen while wake-lock is active causes a complete system hang requiring hard reboot.

**Root cause**: Electron's `powerSaveBlocker` on Wayland conflicts with session lock D-Bus calls to `org.freedesktop.login1`, causing systemd-logind deadlock.

## Solution

Detect Wayland session via `XDG_SESSION_TYPE` environment variable and disable wake-lock specifically on Electron + Wayland combination.

## Changes

- **IPC Handler**: Added `platform:getInfo` in `electron/main/ipc.ts` to expose `XDG_SESSION_TYPE`
- **Preload API**: Exposed `getPlatformInfo()` in `electron/preload/index.cjs`
- **Platform Detection**: Added `isWaylandSession()` with caching in `ui/lib/native/wake-lock.ts`
- **Conditional Disable**: Modified `hasAnyWakeLockSupport()` to return `false` on Electron + Wayland
- **User Guidance**: Added warning log with workarounds

## Testing

✅ **X11 Session** (screenshot: `pictures/x11_20260514_180851.png`):
- Confirmed session type: `Type=x11`
- Wake-lock activated successfully
- Screen lock tested with `Ctrl+Alt+L`
- System remained responsive, no crash
- CodeNomad continued functioning

✅ **Wayland Session**:
- Wake-lock automatically disabled
- Warning logged to console
- No crash occurs (wake-lock never activated)

## Platform Support

| Platform | Wake-Lock |
|----------|-----------|
| Electron + X11 | ✅ Enabled |
| Electron + Wayland | ❌ Disabled (crash prevention) |
| Tauri + X11/Wayland | ✅ Enabled |

## Workarounds for Electron + Wayland Users

1. Switch to X11 session for wake-lock support
2. Use Tauri build (better Wayland support)
3. Disable system auto-sleep in settings

Closes #441