### PR TITLE
fix(ui): allow status panel sections to collapse

### DIFF
--- a/packages/ui/src/components/instance/shell/right-panel/RightPanel.tsx
+++ b/packages/ui/src/components/instance/shell/right-panel/RightPanel.tsx
@@ -101,14 +101,8 @@ interface RightPanelProps {
 
 const RightPanel: Component<RightPanelProps> = (props) => {
   const [rightPanelTab, setRightPanelTab] = createSignal<RightPanelTab>(readStoredRightPanelTab("changes"))
-  const [rightPanelExpandedItems, setRightPanelExpandedItems] = createSignal<string[]>([
-    "yolo-mode",
-    "plan",
-    "background-processes",
-    "mcp",
-    "lsp",
-    "plugins",
-  ])
+  const defaultStatusSectionIds = ["yolo-mode", "session-changes", "plan", "background-processes", "mcp", "lsp", "plugins"]
+  const [rightPanelExpandedItems, setRightPanelExpandedItems] = createSignal<string[]>(defaultStatusSectionIds)
   const [selectedFile, setSelectedFile] = createSignal<string | null>(null)
 
   const [browserPath, setBrowserPath] = createSignal(".")
@@ -737,14 +731,6 @@ const RightPanel: Component<RightPanelProps> = (props) => {
     }
     setRightPanelTab("changes")
   }
-
-  const statusSectionIds = ["yolo-mode", "session-changes", "plan", "background-processes", "mcp", "lsp", "plugins"]
-
-  createEffect(() => {
-    const currentExpanded = new Set(rightPanelExpandedItems())
-    if (statusSectionIds.every((id) => currentExpanded.has(id))) return
-    setRightPanelExpandedItems(statusSectionIds)
-  })
 
   const handleAccordionChange = (values: string[]) => {
     setRightPanelExpandedItems(values)


### PR DESCRIPTION
## Summary
- Stop the right panel from immediately re-opening collapsed Status sections.
- Keep the existing default expanded sections, including session changes.

## Why
Users could click Status sub-panels to collapse them, but the UI immediately expanded them again, making the accordion controls feel broken.

## Validation
- npm run typecheck --workspace @codenomad/ui
- git diff --check
- npm run build --workspace @codenomad/ui