### PR TITLE
fix(ui): prevent accidental prompt clear from tab focus

### DIFF
--- a/packages/ui/src/components/prompt-input.tsx
+++ b/packages/ui/src/components/prompt-input.tsx
@@ -463,8 +463,26 @@ export default function PromptInput(props: PromptInputProps) {
     textareaRef?.focus()
   }
 
+  function clearTextareaWithUndo() {
+    const textarea = textareaRef
+    if (!textarea || textarea.disabled) return false
+
+    textarea.focus()
+    textarea.setSelectionRange(0, textarea.value.length)
+
+    const cleared = typeof document !== "undefined" && document.execCommand("delete")
+    if (!cleared || textarea.value.length > 0) {
+      textarea.value = ""
+    }
+
+    textarea.dispatchEvent(new Event("input", { bubbles: true }))
+    return cleared
+  }
+
   function handleClearPrompt() {
-    clearPrompt()
+    if (!clearTextareaWithUndo()) {
+      clearPrompt()
+    }
     clearHistoryDraft()
     resetHistoryNavigation()
     setShowPicker(false)
@@ -747,6 +765,12 @@ export default function PromptInput(props: PromptInputProps) {
                 autocomplete="off"
                 style={inputHeight() !== null ? { height: `${inputHeight()}px`, "min-height": `${inputHeight()}px`, "overflow-y": "auto" } : undefined}
               />
+              <div class="prompt-expand-button-inline">
+                <ExpandButton
+                  expandState={expandState}
+                  onToggleExpand={handleExpandToggle}
+                />
+              </div>
               <button
                 type="button"
                 class="prompt-clear-button prompt-clear-button-inline"
@@ -757,12 +781,6 @@ export default function PromptInput(props: PromptInputProps) {
               >
                 <X class="h-4 w-4" aria-hidden="true" />
               </button>
-              <div class="prompt-expand-button-inline">
-                <ExpandButton
-                  expandState={expandState}
-                  onToggleExpand={handleExpandToggle}
-                />
-              </div>
               <Show when={shouldShowOverlay()}>
                 <div class={`prompt-input-overlay keyboard-hints ${mode() === "shell" ? "shell-mode" : ""}`}>
                   <Show

--- a/packages/ui/src/components/prompt-input.tsx
+++ b/packages/ui/src/components/prompt-input.tsx
@@ -470,7 +470,12 @@ export default function PromptInput(props: PromptInputProps) {
     textarea.focus()
     textarea.setSelectionRange(0, textarea.value.length)
 
-    const cleared = typeof document !== "undefined" && document.execCommand("delete")
+    let cleared = false
+    try {
+      cleared = typeof document !== "undefined" && typeof document.execCommand === "function" && document.execCommand("delete")
+    } catch {
+      cleared = false
+    }
     if (!cleared || textarea.value.length > 0) {
       textarea.value = ""
     }

--- a/packages/ui/src/components/prompt-input.tsx
+++ b/packages/ui/src/components/prompt-input.tsx
@@ -485,11 +485,11 @@ export default function PromptInput(props: PromptInputProps) {
   }
 
   function handleClearPrompt() {
+    resetHistoryNavigation()
     if (!clearTextareaWithUndo()) {
       clearPrompt()
     }
     clearHistoryDraft()
-    resetHistoryNavigation()
     setShowPicker(false)
     setPickerMode("mention")
     setAtPosition(null)


### PR DESCRIPTION
## Summary
- Fixes #460 by changing the prompt control DOM order so tabbing from the textarea reaches expand before clear.
- Clears prompt text through the textarea native delete path so Cmd/Ctrl+Z can restore cleared text where the browser supports native undo.
- Keeps the existing app-state fallback for environments where native editing commands are unavailable or throw.

## Validation
- npm run typecheck --workspace @codenomad/ui
- Reviewed fallback behavior: `document.execCommand` is checked for callability and wrapped in `try/catch`, so unavailable native editing commands still fall back to app-state clearing.

## Manual QA Notes
- In a supported desktop/browser host: type text, click clear, then press Cmd/Ctrl+Z and confirm text restores.
- Type text, press Tab and confirm focus moves to expand before clear; pressing Tab again reaches clear.