### PR TITLE
fix(ui): raise worktree modal z-index above mobile session drawer

### DIFF
--- a/packages/ui/src/components/worktree-selector.tsx
+++ b/packages/ui/src/components/worktree-selector.tsx
@@ -422,8 +422,8 @@ export default function WorktreeSelector(props: WorktreeSelectorProps) {
 
       <Dialog open={createOpen()} onOpenChange={(open) => !open && setCreateOpen(false)}>
         <Dialog.Portal>
-          <Dialog.Overlay class="modal-overlay" />
-          <div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <Dialog.Overlay class="modal-overlay z-[60]" />
+          <div class="fixed inset-0 z-[1310] flex items-center justify-center p-4">
             <Dialog.Content class="modal-surface w-full max-w-md p-6 flex flex-col gap-5">
               <div>
                 <Dialog.Title class="text-xl font-semibold text-primary">Create worktree</Dialog.Title>
@@ -494,8 +494,8 @@ export default function WorktreeSelector(props: WorktreeSelectorProps) {
 
       <Dialog open={deleteOpen()} onOpenChange={(open) => !open && closeDeleteDialog()}>
         <Dialog.Portal>
-          <Dialog.Overlay class="modal-overlay" />
-          <div class="fixed inset-0 z-50 flex items-center justify-center p-3 md:p-4">
+          <Dialog.Overlay class="modal-overlay z-[60]" />
+          <div class="fixed inset-0 z-[1310] flex items-center justify-center p-3 md:p-4">
             <Dialog.Content class="modal-surface w-[clamp(640px,45vw,960px)] max-w-[calc(100vw-2rem)] max-h-[calc(100vh-2rem)] overflow-y-auto p-4 flex flex-col gap-3">
               <div>
                 <Dialog.Title class="text-xl font-semibold text-primary">Delete worktree</Dialog.Title>


### PR DESCRIPTION
## Summary

- On mobile, opening **Create worktree** (or **Delete worktree**) from inside the session sidebar drawer made the modal invisible — the user could tap the button but the dialog never appeared on screen.
- Root cause: the session sidebar is rendered on phones as an MUI `<Drawer>` at `zIndex: 60` with `width: 100vw` (see `packages/ui/src/components/instance/instance-shell2.tsx` around lines 602–626). The Kobalte `Dialog` overlays in `worktree-selector.tsx` used `.modal-overlay` (`z-index: 50`) plus a Tailwind `z-50` centering wrapper. Because 50 < 60, the full-width drawer completely occluded the modal.
- Fix: raise both dialog overlays to `z-[60]` and both content-wrapping divs to `z-[1310]`, matching the exact precedent already used by `packages/ui/src/components/alert-dialog.tsx` (lines 117–119) for the same scenario.

## Scope

- Four lines changed across two `Dialog.Portal` blocks in `packages/ui/src/components/worktree-selector.tsx` (create dialog + delete dialog).
- No other classes touched, no shared CSS or token changes, no behavior/copy/i18n changes, no other modal affected.

```diff
-          <Dialog.Overlay class="modal-overlay" />
-          <div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <Dialog.Overlay class="modal-overlay z-[60]" />
+          <div class="fixed inset-0 z-[1310] flex items-center justify-center p-4">
```
(applied to both create + delete dialogs)

## Verification

- `npm run typecheck` (covers `@codenomad/ui` and the electron-app workspace) passes with exit 0.
- Repository defines no `lint` script, so typecheck is the available static-analysis gate.
- Visual: open the session drawer on a phone-sized viewport, tap the worktree selector, tap **Create worktree** — modal is now visible and interactive above the drawer. Same for the delete dialog. Desktop behavior is unchanged because nothing else in the app stacks between z-index 50 and 1310 in the same context.

## Follow-up (not in this PR)

Consider introducing a shared `z-modal` design token so the magic numbers `60` / `1310` aren't duplicated across `alert-dialog.tsx` and `worktree-selector.tsx`. Out of scope here.