### PR TITLE
fix(ui): 060 keep session-list refresh icon visibly spinning on active session

### DIFF
--- a/packages/ui/src/components/session-list.tsx
+++ b/packages/ui/src/components/session-list.tsx
@@ -6,6 +6,7 @@ import { Bot, User, Copy, Trash2, Pencil, ShieldAlert, ChevronDown, Search, Squa
 import KeyboardHint from "./keyboard-hint"
 import SessionRenameDialog from "./session-rename-dialog"
 import { keyboardRegistry } from "../lib/keyboard-registry"
+import { MIN_RELOAD_SPINNER_MS, withMinimumDuration } from "../lib/min-duration"
 import { showToastNotification } from "../lib/notifications"
 import { useI18n } from "../lib/i18n"
 import { showConfirmDialog } from "../stores/alerts"
@@ -237,7 +238,16 @@ const SessionList: Component<SessionListProps> = (props) => {
     })
 
     try {
-      await loadMessages(props.instanceId, sessionId, { force: true })
+      // Hold the spinner for at least MIN_RELOAD_SPINNER_MS so the user can
+      // perceive the animation even when the underlying reload resolves
+      // very quickly (e.g. cached responses, or the in-flight dedupe path
+      // in loadMessages reusing an already-running fetch). Without this
+      // floor, the spinner can flash imperceptibly on the currently active
+      // session — task 060.
+      await withMinimumDuration(
+        loadMessages(props.instanceId, sessionId, { force: true }),
+        MIN_RELOAD_SPINNER_MS,
+      )
     } catch (error) {
       log.error(`Failed to reload session ${sessionId}:`, error)
       showToastNotification({ message: t("sessionList.reload.error"), variant: "error" })

--- a/packages/ui/src/lib/min-duration.test.ts
+++ b/packages/ui/src/lib/min-duration.test.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { MIN_RELOAD_SPINNER_MS, withMinimumDuration } from "./min-duration.ts"
+
+/**
+ * Regression tests for the bug "session list refresh icon does not animate
+ * for the currently active session" (task 060).
+ *
+ * The user-visible symptom is that clicking the reload icon on the active
+ * session shows no spinner because the underlying `loadMessages(..., { force: true })`
+ * can resolve in the same microtask (silent early-return on in-flight reload).
+ * `withMinimumDuration` is the floor that guarantees the spinner remains
+ * visible long enough to be perceived regardless of how fast the work resolves.
+ *
+ * These tests exercise the pure helper with injectable time and delay so
+ * they do not depend on real wall-clock time. They use the existing
+ * `node:test` runner (no vitest in this repo) and are wired to follow the
+ * same pattern as `packages/ui/src/components/tool-call/question-active.test.ts`.
+ */
+
+interface Frame {
+  resolve: () => void
+  scheduledAt: number
+}
+
+/**
+ * Minimal virtual clock. `advance(ms)` moves time forward and resolves any
+ * delays whose deadlines have been reached, in insertion order, so callers
+ * can deterministically drive the helper.
+ */
+function createVirtualClock(start = 1_000_000) {
+  let nowMs = start
+  const frames: Array<Frame & { deadline: number }> = []
+
+  function now(): number {
+    return nowMs
+  }
+
+  function delay(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      frames.push({ resolve, scheduledAt: nowMs, deadline: nowMs + ms })
+    })
+  }
+
+  async function advance(ms: number): Promise<void> {
+    nowMs += ms
+    // Flush any frames whose deadline is now in the past, in deadline order.
+    frames.sort((a, b) => a.deadline - b.deadline)
+    while (frames.length > 0 && frames[0]!.deadline <= nowMs) {
+      const frame = frames.shift()!
+      frame.resolve()
+      // Yield to the microtask queue so awaiters can observe the resolution
+      // before we continue advancing.
+      await Promise.resolve()
+    }
+  }
+
+  return { now, delay, advance, pending: () => frames.length }
+}
+
+describe("withMinimumDuration", () => {
+  it("holds a fast-resolving promise until the minimum duration has elapsed", async () => {
+    const clock = createVirtualClock()
+
+    const work = Promise.resolve("done")
+    const wrapped = withMinimumDuration(work, 450, { now: clock.now, delay: clock.delay })
+
+    // The inner work has already resolved, so the helper has scheduled a
+    // delay for the remaining 450ms. Advancing time by less than that must
+    // not settle the wrapper.
+    await clock.advance(449)
+    let settled = false
+    void wrapped.then(
+      () => {
+        settled = true
+      },
+      () => {
+        settled = true
+      },
+    )
+    // Give the microtask queue a chance to observe any incorrect early-resolve.
+    await Promise.resolve()
+    await Promise.resolve()
+    assert.equal(settled, false, "wrapper resolved before minimum duration elapsed")
+
+    // Push time over the threshold; the wrapper must now resolve with the
+    // original value.
+    await clock.advance(1)
+    const value = await wrapped
+    assert.equal(value, "done")
+  })
+
+  it("forwards a slow-resolving promise immediately once it resolves (no extra delay)", async () => {
+    const clock = createVirtualClock()
+
+    let resolveWork: ((value: string) => void) | null = null
+    const work = new Promise<string>((resolve) => {
+      resolveWork = resolve
+    })
+    const wrapped = withMinimumDuration(work, 450, { now: clock.now, delay: clock.delay })
+
+    // Advance well past the minimum-duration threshold while the work is
+    // still pending.
+    await clock.advance(900)
+
+    // Now resolve the work. The wrapper must surface the value without
+    // scheduling any additional delay (elapsed > minMs at this point).
+    resolveWork!("late-done")
+    const value = await wrapped
+    assert.equal(value, "late-done")
+    assert.equal(clock.pending(), 0, "no pending delays should remain")
+  })
+
+  it("propagates a fast rejection but holds it until the minimum duration has elapsed", async () => {
+    const clock = createVirtualClock()
+
+    const failure = new Error("boom")
+    const work = Promise.reject(failure)
+    const wrapped = withMinimumDuration(work, 450, { now: clock.now, delay: clock.delay })
+
+    // Attach a catch handler immediately so the unhandled-rejection guard
+    // does not abort the test runner. The handler must not see the
+    // rejection before the minimum duration has elapsed.
+    let observed: unknown = null
+    const observation = wrapped.catch((err) => {
+      observed = err
+    })
+
+    await clock.advance(449)
+    await Promise.resolve()
+    await Promise.resolve()
+    assert.equal(observed, null, "rejection surfaced before minimum duration elapsed")
+
+    await clock.advance(1)
+    await observation
+    assert.equal(observed, failure)
+  })
+
+  it("propagates a slow rejection immediately once the work rejects (no extra delay)", async () => {
+    const clock = createVirtualClock()
+
+    let rejectWork: ((reason: unknown) => void) | null = null
+    const work = new Promise<string>((_resolve, reject) => {
+      rejectWork = reject
+    })
+    const wrapped = withMinimumDuration(work, 450, { now: clock.now, delay: clock.delay })
+
+    await clock.advance(900)
+    const failure = new Error("late-boom")
+    rejectWork!(failure)
+
+    let observed: unknown = null
+    await wrapped.catch((err) => {
+      observed = err
+    })
+    assert.equal(observed, failure)
+    assert.equal(clock.pending(), 0, "no pending delays should remain")
+  })
+
+  it("returns the underlying promise unchanged when minMs is non-positive", async () => {
+    const clock = createVirtualClock()
+    const work = Promise.resolve(42)
+    const wrapped = withMinimumDuration(work, 0, { now: clock.now, delay: clock.delay })
+    assert.equal(await wrapped, 42)
+    assert.equal(clock.pending(), 0, "no delays should be scheduled when minMs <= 0")
+  })
+
+  it("exports a default minimum duration suitable for the reload spinner", () => {
+    // Codified to lock in a UX-tuned value; bumping requires a deliberate
+    // edit to the constant.
+    assert.equal(typeof MIN_RELOAD_SPINNER_MS, "number")
+    assert.ok(MIN_RELOAD_SPINNER_MS >= 300, "minimum should not feel like a flicker")
+    assert.ok(MIN_RELOAD_SPINNER_MS <= 1000, "minimum should not feel sluggish")
+  })
+})

--- a/packages/ui/src/lib/min-duration.ts
+++ b/packages/ui/src/lib/min-duration.ts
@@ -1,0 +1,91 @@
+/**
+ * Minimum visible duration helper.
+ *
+ * Wraps an async `work` promise so the resolved/rejected promise it returns
+ * never settles earlier than `minMs` after invocation. This is used to keep
+ * short-lived spinners visible long enough for the user to perceive them,
+ * even when the underlying work resolves in the same microtask (e.g. cached
+ * loads, dedupe early-returns, localhost dev servers).
+ *
+ * The minimum-duration guard applies to BOTH success and failure paths: a
+ * failed reload should still show the spinner long enough to be perceptible
+ * before any error toast replaces it.
+ *
+ * The `now` and `delay` dependencies are injectable so the helper can be
+ * unit-tested deterministically without sleeping real time. By default they
+ * use `Date.now()` and `setTimeout`.
+ *
+ * Concurrent invocations on the same caller-supplied `work` promise are
+ * intentionally not de-duped here; the caller controls scheduling. This
+ * helper is a thin timing wrapper, nothing more.
+ */
+
+/**
+ * Default minimum visible duration for the session-list reload spinner, in
+ * milliseconds. Tuned to feel responsive but visible — values under ~400ms
+ * tend to feel like a flicker.
+ */
+export const MIN_RELOAD_SPINNER_MS = 450
+
+export interface WithMinimumDurationDeps {
+  /** Returns the current timestamp in milliseconds. Defaults to `Date.now`. */
+  now?: () => number
+  /** Resolves after the given number of milliseconds. Defaults to `setTimeout`. */
+  delay?: (ms: number) => Promise<void>
+}
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+/**
+ * Returns a promise that mirrors `work`'s outcome (value or error) but is
+ * guaranteed not to settle before `minMs` have elapsed since the call.
+ *
+ * When `work` resolves before `minMs`, the result is held until `minMs` is
+ * reached. When `work` resolves after `minMs`, the result is forwarded
+ * immediately. The same applies to rejections.
+ */
+export async function withMinimumDuration<T>(
+  work: Promise<T>,
+  minMs: number,
+  deps?: WithMinimumDurationDeps,
+): Promise<T> {
+  const now = deps?.now ?? Date.now
+  const delay = deps?.delay ?? defaultDelay
+
+  // Guard against pathological inputs — never delay if asked for a
+  // non-positive minimum.
+  if (!(minMs > 0)) {
+    return work
+  }
+
+  const startedAt = now()
+
+  // Settle the work and the elapsed-time guard independently so the wrapper
+  // mirrors the work's outcome (value or error) while still enforcing the
+  // floor on perceived duration.
+  let workValue: T
+  let workError: unknown
+  let workSucceeded = false
+
+  try {
+    workValue = await work
+    workSucceeded = true
+  } catch (error) {
+    workError = error
+  }
+
+  const elapsed = now() - startedAt
+  const remaining = minMs - elapsed
+  if (remaining > 0) {
+    await delay(remaining)
+  }
+
+  if (workSucceeded) {
+    return workValue!
+  }
+  throw workError
+}

--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -700,6 +700,25 @@ async function fetchProviders(instanceId: string): Promise<void> {
   }
 }
 
+/**
+ * Tracks the in-flight `loadMessages` promise for each `(instanceId, sessionId)`
+ * pair. Used to de-duplicate concurrent calls and — critically — to ensure
+ * that `force: true` callers wait for any in-flight load to finish before
+ * starting their own fresh fetch, rather than silently early-returning.
+ *
+ * Without this registry, a `force: true` reload triggered on the currently
+ * active session (which is the only session reliably in `loadingMessages`
+ * at click time, because of the active-session load effect in `session-view`
+ * and post-compaction reloads in `session-events`) would no-op via the
+ * `isLoading` short-circuit. That made the session-list refresh icon appear
+ * to never animate for the active session (task 060).
+ */
+const inFlightLoadMessages = new Map<string, Promise<void>>()
+
+function loadMessagesKey(instanceId: string, sessionId: string): string {
+  return `${instanceId}:${sessionId}`
+}
+
 async function loadMessages(
   instanceId: string,
   sessionId: string,
@@ -725,9 +744,22 @@ async function loadMessages(
     return
   }
 
-  const isLoading = loading().loadingMessages.get(instanceId)?.has(sessionId)
-  if (isLoading) {
-    return
+  // If a load is already in flight for this session, share its promise.
+  // Non-force callers reuse the result; force callers wait for it to finish
+  // (or fail) and then fall through to start a fresh fetch. This replaces
+  // an earlier short-circuit that silently dropped force:true reloads when
+  // any prior load was in flight — see task 060.
+  const inFlightKey = loadMessagesKey(instanceId, sessionId)
+  const existing = inFlightLoadMessages.get(inFlightKey)
+  if (existing) {
+    if (!force) {
+      await existing
+      return
+    }
+    // Wait for the prior load to settle (success or failure) before
+    // starting a fresh fetch. Swallow the prior error so the new attempt
+    // still runs; the new attempt's outcome is what the caller sees.
+    await existing.catch(() => {})
   }
 
   const instance = instances().get(instanceId)
@@ -757,6 +789,22 @@ async function loadMessages(
     next.loadingMessages.set(instanceId, loadingSet)
     return next
   })
+
+  // Register the work as the new in-flight load before performing any
+  // awaits, so concurrent callers (including subsequent force:true clicks)
+  // observe it and queue against it instead of starting parallel fetches.
+  // The work promise is unregistered in the `finally` block below.
+  let resolveInFlight!: () => void
+  let rejectInFlight!: (reason: unknown) => void
+  const inFlight = new Promise<void>((resolve, reject) => {
+    resolveInFlight = resolve
+    rejectInFlight = reject
+  })
+  inFlightLoadMessages.set(inFlightKey, inFlight)
+  // Avoid unhandled-rejection warnings if no concurrent caller awaits this
+  // shared promise. The original work's error is still surfaced to the
+  // direct caller via the `throw` in the catch block below.
+  inFlight.catch(() => {})
 
   try {
     log.info(`[HTTP] GET /session.${"messages"} for instance ${instanceId}`, { sessionId })
@@ -876,6 +924,7 @@ async function loadMessages(
 
   } catch (error) {
     log.error("Failed to load messages:", error)
+    rejectInFlight(error)
     throw error
   } finally {
     setLoading((prev) => {
@@ -886,6 +935,15 @@ async function loadMessages(
       }
       return next
     })
+    // Always clear our entry from the registry. Only clear if the value
+    // is still ours — a slow finally could otherwise erase a newer
+    // entry registered by an immediately-following call.
+    if (inFlightLoadMessages.get(inFlightKey) === inFlight) {
+      inFlightLoadMessages.delete(inFlightKey)
+    }
+    // Resolve the shared promise so any concurrent waiters (which already
+    // attached their own .catch above for the error case) unblock cleanly.
+    resolveInFlight()
   }
 
   updateSessionInfo(instanceId, sessionId)

--- a/tasks/todo/060-session-list-refresh-icon-animation.md
+++ b/tasks/todo/060-session-list-refresh-icon-animation.md
@@ -1,0 +1,80 @@
+---
+title: Session List Refresh Icon Does Not Animate For Active Session
+complexity: standard
+track: implementation
+slice: ui
+status: active
+assigned_to: developer
+---
+
+# Goal
+
+Fix a reported UI bug: in the session list (left sidebar), the small refresh (reload) icon **does not animate** (no visible spinner) **when the user clicks it on the currently active session**, even though it animates correctly on any non-active session.
+
+# Request Context
+
+The Product Owner reported:
+
+> "Found a bug where the little refresh icon in the session list doesn't animate if it's on the currently active session."
+
+# Investigation Summary (Tech Lead)
+
+Root cause: `loadMessages(..., { force: true })` in `packages/ui/src/stores/session-api.ts` silently early-returns when the target session is already present in the `loadingMessages` set (lines 728–731). The `force: true` flag only invalidates `messagesLoaded`; it does **not** bypass the `isLoading` short-circuit. The currently active session is the only session reliably in `loadingMessages` at click time, because of:
+
+- `packages/ui/src/components/session/session-view.tsx:196` — `createEffect` calling `loadMessages` whenever the active session mounts.
+- `packages/ui/src/stores/session-events.ts:622` — post-compaction reload using `force: true`.
+- Any in-flight refetch already triggered by SSE-driven hydration.
+
+When the user clicks the refresh icon on the active session, `await loadMessages(..., { force: true })` resolves in the same microtask. `handleReloadSession` (`session-list.tsx:229–251`) adds and removes the session id from `reloadingSessionIds` in the same microtask, so the browser never paints a frame with the spinner — the user sees no animation.
+
+CSS is **not** the cause. `.session-item-active` (`session-layout.css:330–343`) and `@keyframes spin` (`utilities.css:142–144`) are clean and have no override that would interfere with `animate-spin` on a descendant `<svg>`.
+
+A second, related defect is that `session-events.ts:622`'s post-compaction reload shares the same silent-drop behavior; after a compaction event, the UI can be left with stale messages until the next user-driven action. The fix below corrects both call sites.
+
+# Scope
+
+In scope:
+
+- `packages/ui/src/stores/session-api.ts` — make `loadMessages({ force: true })` honest: when an in-flight load exists, await it then refetch, instead of silently dropping.
+- `packages/ui/src/components/session-list.tsx#handleReloadSession` — wrap the await so the spinner is held for a minimum visible duration regardless of load speed.
+- `packages/ui/src/lib/min-duration.ts` (new) — pure helper exporting `withMinimumDuration` and `MIN_RELOAD_SPINNER_MS`.
+- `packages/ui/src/lib/min-duration.test.ts` (new) — `node:test`-based regression test for the helper.
+
+Out of scope:
+
+- Visual restyling of the icon.
+- Refactoring of `session-list.tsx` / `session-api.ts` for file-length reduction (both are above 800 lines; flagged separately).
+- Any other reload/refresh affordance in the app (git panel, diff panel, etc.).
+
+# Acceptance Criteria
+
+- AC-1: `loadMessages(instanceId, sessionId, { force: true })` no longer silently early-returns when the target session is already in `loadingMessages`. Instead, it awaits the in-flight request and then performs a fresh fetch. Concurrent `force: true` calls for the same session must serialize, not stack network calls in parallel.
+- AC-2: Existing non-`force` dedupe behavior is preserved: when a load is already in flight and the caller passes `force: false` (or omits it), the call awaits the in-flight promise and returns without an extra fetch.
+- AC-3: `handleReloadSession` in `session-list.tsx` guarantees a minimum visible spinner duration of `MIN_RELOAD_SPINNER_MS` (450 ms) so the spinner is perceptible even when the reload work resolves instantly.
+- AC-4: A new pure helper `withMinimumDuration` lives in `packages/ui/src/lib/min-duration.ts` with injectable `now` / `delay` dependencies so it can be unit-tested without real time.
+- AC-5: A `node:test` regression test in `packages/ui/src/lib/min-duration.test.ts` asserts the helper's behavior across the four cases (fast resolve, slow resolve, fast reject, slow reject) and runs green via `node --experimental-strip-types --test src/lib/min-duration.test.ts` from `packages/ui/`.
+- AC-6: `npm run typecheck --workspace @codenomad/ui` and `npm run build --workspace @codenomad/ui` both pass.
+- AC-7: Any discrepancies encountered are documented per the Discrepancy Resolution Policy.
+
+# Implementation Notes
+
+- The helper signature is `withMinimumDuration<T>(work: Promise<T>, minMs: number, deps?: { now?: () => number; delay?: (ms: number) => Promise<void> }): Promise<T>`. Both success and failure paths must respect the minimum duration (a failed reload should still show the spinner long enough to be perceptible before the toast appears).
+- The in-flight dedupe in `session-api.ts` keys by `${instanceId}:${sessionId}`. Always clean up the map entry in a `finally` to avoid leaks. The `messagesLoaded` invalidation for `force: true` stays ahead of the await so any concurrent non-force caller arriving during the wait correctly observes "not loaded" and queues behind the new fetch.
+- `MIN_RELOAD_SPINNER_MS = 450` is exported from the helper module so it is tunable in one place.
+
+# Discussion Record
+
+- PO reported the bug in chat. PMA scoped it as a `standard / implementation / ui` task (with investigation folded in because no separate Tech Lead subagent is available in this host) and executes it directly.
+- Branch state mid-investigation drifted unexpectedly (a parallel session checked out `fix/mobile-session-list-blocks-tab-switch` and dropped the original task-060 file). PMA stashed the unrelated work and restarted from a clean `origin/dev` branch `fix/session-list-refresh-icon-animation`.
+
+# Notes
+
+- Base branch: `origin/dev`.
+- Branch: `fix/session-list-refresh-icon-animation`.
+- This task does not change product behavior; no SCR required.
+
+# Post Implementation Task Updates
+
+## Developer: Post Implementation Expectations
+
+(to be filled in by the implementing agent before closure)


### PR DESCRIPTION
## Summary

- The session-list refresh icon never visibly animated when clicked on the **currently active session**, even though it animated correctly on every non-active session. Root cause was a `force: true`-ignoring short-circuit in `loadMessages` plus the absence of any minimum-visible-duration floor on the spinner.
- Replaces the buggy `isLoading` short-circuit with an in-flight promise registry so `force: true` reliably awaits any prior load and then refetches, instead of silently no-opping.
- Adds a small pure helper `withMinimumDuration` (default 450 ms) wrapping the reload await so the spinner is guaranteed perceptible regardless of how fast the work resolves.
- Adds a `node:test`-based regression test that locks in the spinner-duration floor across six behavioral cases.

## Root Cause

`packages/ui/src/stores/session-api.ts#loadMessages` had three early-return checks at the top:

1. `force: true` invalidates the `messagesLoaded` set.
2. `alreadyLoaded && !force` returns.
3. `isLoading` returns — **and this check ignored `force: true`**.

Whenever the target session was already in the `loadingMessages` set, `loadMessages` resolved in the same microtask without doing any work. The currently active session is the only session reliably in that set at click time, because:

- `packages/ui/src/components/session/session-view.tsx` triggers a `loadMessages` call inside a `createEffect` whenever the active session mounts or changes.
- `packages/ui/src/stores/session-events.ts` fires a `force: true` reload after every compaction event.
- Any in-flight refetch triggered by SSE hydration leaves the session flagged as loading until the round-trip returns.

Non-active sessions are not in `loadingMessages`, so they hit the real fetch path and the spinner stayed visible for the duration of the network round-trip by accident. The active session got the silent no-op, `handleReloadSession`'s `finally` block cleared `reloadingSessionIds` in the same microtask, and the `<Show>` in `session-list.tsx` never paid out a frame with the animated icon.

CSS was ruled out as a contributor — `.session-item-active` only changes `background-color`, `color`, `font-weight`, `box-shadow`; nothing overrides `animate-spin` or the shared `@keyframes spin`.

## What Changed

### `packages/ui/src/stores/session-api.ts` (+61 / -3)

- Add a module-scoped `inFlightLoadMessages` map keyed by `${instanceId}:${sessionId}`.
- Replace the `isLoading` short-circuit with an in-flight-aware branch:
  - Non-`force` callers continue to dedupe by awaiting the shared promise and returning.
  - `force: true` callers wait for the prior load to settle (`await existing.catch(() => {})`), then fall through to run a fresh fetch.
- Register the new fetch's promise in the map before the first await; resolve / reject it from the existing `try/catch/finally` and clear the entry under a value-identity check so a slow `finally` cannot erase a newer registration.
- Same fix incidentally repairs `packages/ui/src/stores/session-events.ts` line 622 (post-compaction reload), which previously dropped under the same defect and could leave the UI showing stale messages until the next user action.

### `packages/ui/src/components/session-list.tsx` (+11 / -1)

- Import the new helper.
- Wrap the reload `await` in `withMinimumDuration(loadMessages(...), MIN_RELOAD_SPINNER_MS)` so the spinner is held for at least 450 ms regardless of how fast the underlying work resolves. Protects the UX against any future fast path (cached responses, no-op early returns, localhost dev servers) that could otherwise flash the spinner imperceptibly.

### `packages/ui/src/lib/min-duration.ts` (new)

- Pure helper module. Exports `withMinimumDuration<T>(work, minMs, deps?)` and `MIN_RELOAD_SPINNER_MS = 450`.
- `now` and `delay` are injectable so the helper is unit-testable without sleeping real time.
- Both success and failure paths honour the floor so a failed reload still shows the spinner long enough to be perceived before the error toast replaces it.
- Zero internal imports so it is reachable from the project's `node:test` runner.

### `packages/ui/src/lib/min-duration.test.ts` (new, regression test)

- Six `node:test` cases exercising fast resolve, slow resolve, fast reject, slow reject, non-positive `minMs`, and the default-constant bounds.
- Uses an injected virtual clock so the suite finishes in under 5 ms of real time.
- Runnable via `node --experimental-strip-types --test src/lib/min-duration.test.ts` from `packages/ui/`, matching the existing pattern in `packages/ui/src/components/tool-call/question-active.test.ts`.

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Regression test | `node --experimental-strip-types --test src/lib/min-duration.test.ts` (from `packages/ui/`) | 6/6 pass |
| Typecheck | `npx tsc --noEmit -p tsconfig.json` (from `packages/ui/`) | exit 0 |
| Build | `npx vite build` (from `packages/ui/`) | `✓ built in 19.81s`, exit 0 |

No SCR required — `loadMessages`' public contract is being clarified to match its documented intent (`force: true` means "actually refetch"), not redefined. No copy, no styling, no public API changes.

## Scope Notes

- File-length warnings (informational, no refactor in this PR): `packages/ui/src/components/session-list.tsx` is now 851 lines and `packages/ui/src/stores/session-api.ts` is now 975 lines, both above the 800-line warning threshold from `AGENTS.md`.
- The investigation and fix are tracked in `tasks/todo/060-session-list-refresh-icon-animation.md`.