### PR TITLE
ci: increase comment-pr-artifacts polling timeout

### DIFF
--- a/.github/workflows/comment-pr-artifacts.yml
+++ b/.github/workflows/comment-pr-artifacts.yml
@@ -59,8 +59,9 @@ jobs:
 
             const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+            const maxAttempts = 90;
             let matchedRun = null;
-            for (let attempt = 1; attempt <= 30; attempt += 1) {
+            for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
               const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
                 owner,
                 repo,
@@ -78,8 +79,8 @@ jobs:
                 break;
               }
 
-              core.info(`Waiting for PR Build Validation run for ${headSha} (attempt ${attempt}/30)`);
-              await sleep(10000);
+              core.info(`Waiting for PR Build Validation run for ${headSha} (attempt ${attempt}/${maxAttempts})`);
+              await sleep(20000);
             }
 
             if (!matchedRun) {


### PR DESCRIPTION
## Problem

The `Comment PR Artifacts` workflow consistently times out before the `PR Build Validation` run can complete. The build pipeline typically takes 14–25 minutes (especially the Tauri macOS build), but the comment workflow only polled for ~12 minutes (30 attempts × 10-second intervals plus API overhead).

This has been causing the `comment` check to fail on every PR — see PR #463 where it failed 3 consecutive times.

## Fix

- Increase polling attempts from **30 → 90**
- Increase sleep interval from **10s → 20s**
- Effective maximum wait: ~30 minutes of sleep + API overhead ≈ 45+ minutes total

This gives ample headroom for the full build matrix to complete, including slower runners like `build-tauri-macos`.

## Why this needs to merge first

The `comment-pr-artifacts.yml` workflow uses `pull_request_target`, which means it runs **from the base branch (dev)**, not the PR branch. Changes to this file in PR #463 cannot take effect until this fix lands on `dev`. Once merged, the comment workflow will stop timing out on PR #463 and all future PRs.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user to unblock PR #463._