### PR TITLE
fix(ui): raise worktree modal z-index above mobile session drawer (re-submission of #463)

### DIFF
--- a/packages/ui/src/components/worktree-selector.tsx
+++ b/packages/ui/src/components/worktree-selector.tsx
@@ -422,8 +422,8 @@ export default function WorktreeSelector(props: WorktreeSelectorProps) {
 
       <Dialog open={createOpen()} onOpenChange={(open) => !open && setCreateOpen(false)}>
         <Dialog.Portal>
-          <Dialog.Overlay class="modal-overlay" />
-          <div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <Dialog.Overlay class="modal-overlay z-[60]" />
+          <div class="fixed inset-0 z-[1310] flex items-center justify-center p-4">
             <Dialog.Content class="modal-surface w-full max-w-md p-6 flex flex-col gap-5">
               <div>
                 <Dialog.Title class="text-xl font-semibold text-primary">Create worktree</Dialog.Title>
@@ -494,8 +494,8 @@ export default function WorktreeSelector(props: WorktreeSelectorProps) {
 
       <Dialog open={deleteOpen()} onOpenChange={(open) => !open && closeDeleteDialog()}>
         <Dialog.Portal>
-          <Dialog.Overlay class="modal-overlay" />
-          <div class="fixed inset-0 z-50 flex items-center justify-center p-3 md:p-4">
+          <Dialog.Overlay class="modal-overlay z-[60]" />
+          <div class="fixed inset-0 z-[1310] flex items-center justify-center p-3 md:p-4">
             <Dialog.Content class="modal-surface w-[clamp(640px,45vw,960px)] max-w-[calc(100vw-2rem)] max-h-[calc(100vh-2rem)] overflow-y-auto p-4 flex flex-col gap-3">
               <div>
                 <Dialog.Title class="text-xl font-semibold text-primary">Delete worktree</Dialog.Title>


### PR DESCRIPTION
## Summary

Re-submission of [#463](https://github.com/NeuralNomadsAI/CodeNomad/pull/463) with added visual evidence after the maintainer suggested the bug might already be fixed on `dev`. I checked current `origin/dev` (HEAD `00bfe52`, includes #459 "tappable instance/project tab bar while session drawer is open") and the underlying file `packages/ui/src/components/worktree-selector.tsx` is **byte-identical** to the previous PR base — the modal stacking issue is still present. This PR is rebased on `origin/dev` HEAD so reviewers see exactly the same base as `dev`.

## The bug

On phone layouts, opening **Create worktree** (or **Delete worktree**) from inside the session sidebar drawer renders the modal **behind** the drawer. The user can tap "Create worktree" but the dialog never becomes visible or interactive. This is the only way to reach the worktree picker on mobile (it lives in the sidebar), so the feature is effectively unreachable.

## Root cause (verified against `origin/dev` HEAD)

**1. Session sidebar drawer** — `packages/ui/src/components/instance/instance-shell2.tsx` lines 649–656:
```tsx
<Drawer variant="temporary" open={leftOpen()} ...
  sx={{
    zIndex: 60,
    "& .MuiDrawer-paper": {
      width: isPhoneLayout() ? "100vw" : `${sessionSidebarWidth()}px`,
      ...
```
Drawer occupies **full 100vw** at **`zIndex: 60`** on phones.

**2. Worktree create/delete dialogs** — `packages/ui/src/components/worktree-selector.tsx` lines 425–426 and 497–498:
```tsx
<Dialog.Overlay class="modal-overlay" />
<div class="fixed inset-0 z-50 flex items-center justify-center p-4">
```
Overlay uses `.modal-overlay` (CSS `z-index: 50`) and content wrapper uses Tailwind `z-50`.

`50 < 60` → on a phone-sized viewport the full-width drawer **occludes the entire modal**.

## Why #459 doesn't cover this case

#459 fixes pointer events on the **instance/project tab bar** (the strip above the drawer paper). It modifies `instance-shell2.tsx` to close floating drawers on tab interaction, but it does **not** change drawer z-index, the modal z-index in `worktree-selector.tsx`, or worktree-dialog open behavior. I confirmed by diffing `origin/dev:packages/ui/src/components/worktree-selector.tsx` against the earlier PR base — file is **byte-identical** (same blob hash `a3d3f209`).

## Visual evidence

A minimal isolated repro (vanilla HTML + CSS that mirrors the exact stacking from `origin/dev`) is published at:

**[omercnet/CodeNomad:repros/463-mobile-worktree-modal](https://github.com/omercnet/CodeNomad/tree/repros/463-mobile-worktree-modal)**

Screenshots at iPhone 13 (390x844) and Pixel 7 (412x915) viewports via headless Playwright, 2x DPR:

### Bug — modal hidden behind drawer (origin/dev today)

![Bug iPhone 13](https://raw.githubusercontent.com/omercnet/CodeNomad/repros/463-mobile-worktree-modal/bug-iphone13.png)

### Fix — modal rendered on top (this PR)

![Fix iPhone 13](https://raw.githubusercontent.com/omercnet/CodeNomad/repros/463-mobile-worktree-modal/fix-iphone13.png)

Pixel-level confirmation:
- Bug screenshot center pixel: `rgb(35, 35, 39)` = drawer paper color (`--surface-secondary`). Drawer covers the entire viewport, modal is not visible.
- Fix screenshot over modal surface region: `rgb(26, 26, 29)` = modal surface color (`--surface-base`). Modal renders on top of drawer.

See the repro branch README for the full breakdown, the two HTML files, and both viewport pairs.

## Fix

Four lines across two `Dialog.Portal` blocks in `worktree-selector.tsx`. Mirrors the exact precedent in `packages/ui/src/components/alert-dialog.tsx` lines 117–119:

```diff
-          <Dialog.Overlay class="modal-overlay" />
-          <div class="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <Dialog.Overlay class="modal-overlay z-[60]" />
+          <div class="fixed inset-0 z-[1310] flex items-center justify-center p-4">
```

Applied to both the create dialog and the delete dialog. No other classes touched, no shared CSS/token changes, no behavior/copy/i18n changes, no other modal affected.

## Verification

- `npm run typecheck` (covers `@codenomad/ui` and the electron-app workspace) → exit 0.
- Repository defines no `lint` script, so typecheck is the available static-analysis gate.
- Visual: see screenshots above; full source for the repro is on the linked branch.

## Alternative considered

A different design would be to auto-close the drawer when the worktree dialog opens (analogous to how #459 closes floating drawers on tab switches). That would also work, but it's a bigger behavioral change and inconsistent with how `alert-dialog.tsx` handles the same stacking — happy to take that direction if you'd prefer it.

## Refs

- Previous PR (closed by maintainer): #463
- Issue commented but not yet read: my evidence comment on [#463](https://github.com/NeuralNomadsAI/CodeNomad/pull/463#issuecomment-4467970631)
- Unrelated CI workflow fix (already merged): #466