### PR TITLE
fix(ui): support tuple plugin metadata

### DIFF
--- a/packages/ui/src/lib/hooks/plugin-metadata.ts
+++ b/packages/ui/src/lib/hooks/plugin-metadata.ts
@@ -1,0 +1,23 @@
+type RawPluginEntry = string | [string, Record<string, unknown>]
+
+function normalizePluginSpecifier(plugin: string): string {
+  return plugin.startsWith("file://") ? plugin.slice("file://".length) : plugin
+}
+
+export function extractConfiguredPlugins(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const plugins: string[] = []
+  for (const entry of value as RawPluginEntry[]) {
+    if (typeof entry === "string") {
+      plugins.push(normalizePluginSpecifier(entry))
+      continue
+    }
+    if (Array.isArray(entry) && typeof entry[0] === "string") {
+      plugins.push(normalizePluginSpecifier(entry[0]))
+    }
+  }
+  return plugins
+}

--- a/packages/ui/src/lib/hooks/plugin-metadata.ts
+++ b/packages/ui/src/lib/hooks/plugin-metadata.ts
@@ -1,7 +1,16 @@
-type RawPluginEntry = string | [string, Record<string, unknown>]
-
 function normalizePluginSpecifier(plugin: string): string {
   return plugin.startsWith("file://") ? plugin.slice("file://".length) : plugin
+}
+
+function isPluginTuple(entry: unknown): entry is [string, Record<string, unknown>] {
+  return (
+    Array.isArray(entry) &&
+    entry.length === 2 &&
+    typeof entry[0] === "string" &&
+    typeof entry[1] === "object" &&
+    entry[1] !== null &&
+    !Array.isArray(entry[1])
+  )
 }
 
 export function extractConfiguredPlugins(value: unknown): string[] {
@@ -10,12 +19,12 @@ export function extractConfiguredPlugins(value: unknown): string[] {
   }
 
   const plugins: string[] = []
-  for (const entry of value as RawPluginEntry[]) {
+  for (const entry of value) {
     if (typeof entry === "string") {
       plugins.push(normalizePluginSpecifier(entry))
       continue
     }
-    if (Array.isArray(entry) && typeof entry[0] === "string") {
+    if (isPluginTuple(entry)) {
       plugins.push(normalizePluginSpecifier(entry[0]))
     }
   }

--- a/packages/ui/src/lib/hooks/use-instance-metadata.test.ts
+++ b/packages/ui/src/lib/hooks/use-instance-metadata.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { extractConfiguredPlugins } from "./plugin-metadata.ts"
+
+describe("extractConfiguredPlugins", () => {
+  it("normalizes string plugin entries", () => {
+    assert.deepEqual(extractConfiguredPlugins(["npm:user-plugin", "file:///tmp/plugin.ts"]), [
+      "npm:user-plugin",
+      "/tmp/plugin.ts",
+    ])
+  })
+
+  it("reads tuple plugin specifiers without crashing", () => {
+    assert.deepEqual(
+      extractConfiguredPlugins([
+        ["@neuralnomads/nomadworks", { onboarding: "auto" }],
+        ["file:///tmp/plugin.ts", { enabled: true }],
+      ]),
+      ["@neuralnomads/nomadworks", "/tmp/plugin.ts"],
+    )
+  })
+
+  it("ignores invalid plugin entry shapes", () => {
+    assert.deepEqual(
+      extractConfiguredPlugins([
+        [123, { invalid: true }],
+        { plugin: "bad" },
+        ["npm:good-plugin", { ok: true }],
+      ]),
+      ["npm:good-plugin"],
+    )
+  })
+
+  it("returns an empty list for non-array plugin config", () => {
+    assert.deepEqual(extractConfiguredPlugins(undefined), [])
+    assert.deepEqual(extractConfiguredPlugins("npm:user-plugin"), [])
+  })
+})

--- a/packages/ui/src/lib/hooks/use-instance-metadata.test.ts
+++ b/packages/ui/src/lib/hooks/use-instance-metadata.test.ts
@@ -26,6 +26,9 @@ describe("extractConfiguredPlugins", () => {
       extractConfiguredPlugins([
         [123, { invalid: true }],
         { plugin: "bad" },
+        ["missing-options"],
+        ["bad-options", "not-options"],
+        ["array-options", []],
         ["npm:good-plugin", { ok: true }],
       ]),
       ["npm:good-plugin"],

--- a/packages/ui/src/lib/hooks/use-instance-metadata.ts
+++ b/packages/ui/src/lib/hooks/use-instance-metadata.ts
@@ -2,6 +2,7 @@ import type { Instance, RawMcpStatus } from "../../types/instance"
 import { fetchLspStatus } from "../../stores/instances"
 import { getLogger } from "../../lib/logger"
 import { getInstanceMetadata, mergeInstanceMetadata } from "../../stores/instance-metadata"
+import { extractConfiguredPlugins } from "./plugin-metadata"
 
 const log = getLogger("session")
 const pendingMetadataRequests = new Set<string>()
@@ -41,11 +42,7 @@ export async function loadInstanceMetadata(instance: Instance, options?: { force
     const mcpStatus = mcpResult.status === "fulfilled" ? (mcpResult.value.data as RawMcpStatus) : undefined
     const lspStatus = lspResult.status === "fulfilled" ? lspResult.value ?? [] : undefined
     const config = configResult.status === "fulfilled" ? (configResult.value.data as { plugin?: unknown } | undefined) : undefined
-    const plugins = Array.isArray(config?.plugin)
-      ? (config?.plugin as string[]).map((plugin) =>
-          plugin.startsWith("file://") ? plugin.slice("file://".length) : plugin,
-        )
-      : undefined
+    const plugins = config ? extractConfiguredPlugins(config.plugin) : undefined
 
     const updates: Instance["metadata"] = { ...(currentMetadata ?? {}) }
 


### PR DESCRIPTION
## Summary
- this fixes a bug where no plugin are displayed in the UI 
- normalize OpenCode plugin metadata through a dedicated helper instead of assuming every entry is a string
- support tuple-form plugin entries by displaying the tuple specifier and preserving existing file:// normalization
- add focused regression coverage for string, tuple, and invalid plugin entry shapes

## Validation
- npm run typecheck --workspace @codenomad/ui
- node --test packages/ui/src/lib/hooks/use-instance-metadata.test.ts
- npm run build --workspace @codenomad/ui