### PR TITLE
feat(sessions): progressive loading, server-side search, and workspace scoping

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -47,6 +47,7 @@ import {
   clearActiveParentSession,
   createSession,
   fetchSessions,
+  getSessionFetchLimit,
   updateSessionAgent,
   updateSessionModel,
 } from "./stores/sessions"
@@ -405,7 +406,7 @@ const App: Component = () => {
     clearActiveParentSession(instanceId)
 
     try {
-      await fetchSessions(instanceId)
+      await fetchSessions(instanceId, { start: 0, limit: getSessionFetchLimit(instanceId) })
     } catch (error) {
       log.error("Failed to refresh sessions after closing", error)
     }

--- a/packages/ui/src/components/session-list.tsx
+++ b/packages/ui/src/components/session-list.tsx
@@ -20,6 +20,12 @@ import {
   sessions as sessionStateSessions,
   setActiveSessionFromList,
   toggleSessionParentExpanded,
+  loadMoreSessions,
+  searchSessions,
+  getSessionHasMore,
+  resetSessionPagination,
+  fetchSessions,
+  getSessionFetchLimit,
 } from "../stores/sessions"
 import { getGitRepoStatus, getWorktreeSlugForParentSession } from "../stores/worktrees"
 import { getLogger } from "../lib/logger"
@@ -63,6 +69,82 @@ const SessionList: Component<SessionListProps> = (props) => {
     if (typeof window === "undefined") return
     const timer = window.setInterval(() => setNow(Date.now()), 1000)
     onCleanup(() => window.clearInterval(timer))
+  })
+
+  const [isSearchFetching, setIsSearchFetching] = createSignal(false)
+  const [sentinelEl, setSentinelEl] = createSignal<HTMLDivElement | null>(null)
+  const [wasSearching, setWasSearching] = createSignal(false)
+
+  const hasMore = createMemo(() => {
+    if (normalizedQuery()) return false
+    return getSessionHasMore(props.instanceId)
+  })
+
+  const isFetchingSessions = createMemo(() => {
+    return loading().fetchingSessions.get(props.instanceId) ?? false
+  })
+
+  createEffect(() => {
+    const el = sentinelEl()
+    if (!el || !hasMore() || isFetchingSessions()) return
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0]
+        if (entry?.isIntersecting && hasMore() && !isFetchingSessions()) {
+          void loadMoreSessions(props.instanceId).catch((error) => {
+            log.error("Failed to load more sessions:", error)
+          })
+        }
+      },
+      { root: el.parentElement ?? null, rootMargin: "0px 0px 200px 0px" }
+    )
+
+    observer.observe(el)
+    onCleanup(() => observer.disconnect())
+  })
+
+  let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null
+  createEffect(() => {
+    const query = normalizedQuery()
+    if (!props.enableFilterBar) {
+      setWasSearching(false)
+      return
+    }
+
+    if (searchDebounceTimer) {
+      clearTimeout(searchDebounceTimer)
+    }
+
+    if (!query) {
+      // Only reset pagination if we were previously searching (user cleared the query)
+      if (wasSearching()) {
+        setWasSearching(false)
+        const limit = getSessionFetchLimit(props.instanceId)
+        void fetchSessions(props.instanceId, { limit }).catch((error) => {
+          log.error("Failed to reset sessions after search clear:", error)
+        })
+      }
+      return
+    }
+
+    setWasSearching(true)
+    setIsSearchFetching(true)
+    searchDebounceTimer = setTimeout(() => {
+      void searchSessions(props.instanceId, query)
+        .catch((error) => {
+          log.error("Failed to search sessions:", error)
+        })
+        .finally(() => {
+          setIsSearchFetching(false)
+        })
+    }, 300)
+
+    onCleanup(() => {
+      if (searchDebounceTimer) {
+        clearTimeout(searchDebounceTimer)
+      }
+    })
   })
 
   const normalizeSessionLabel = (sessionId: string) => {
@@ -795,10 +877,22 @@ const SessionList: Component<SessionListProps> = (props) => {
                    </>
                  )
                }}
-            </For>
-          </div>
-        </Show>
-      </div>
+             </For>
+
+             <Show when={hasMore() || isFetchingSessions()}>
+               <div
+                 ref={(el) => setSentinelEl(el)}
+                 class="session-list-sentinel flex items-center justify-center py-3 text-text-weak text-xs"
+                 data-session-sentinel
+               >
+                 <Show when={isFetchingSessions()}>
+                   <span class="animate-pulse">{t("sessionList.loading.more")}</span>
+                 </Show>
+               </div>
+             </Show>
+           </div>
+         </Show>
+       </div>
 
       <Show when={props.showFooter !== false}>
         <div class="session-list-footer p-3 border-t border-base">

--- a/packages/ui/src/components/session-list.tsx
+++ b/packages/ui/src/components/session-list.tsx
@@ -128,6 +128,19 @@ const SessionList: Component<SessionListProps> = (props) => {
       return
     }
 
+    // Check if client-side filtering already yields results
+    const hasClientResults = props.threads.some((thread) => {
+      if (sessionMatchesQuery(thread.parent.id, query)) return true
+      return thread.children.some((child) => sessionMatchesQuery(child.id, query))
+    })
+
+    if (hasClientResults) {
+      // Client-side filtering is sufficient — results appear instantly
+      setWasSearching(false)
+      return
+    }
+
+    // No client-side results — need server-side search
     setWasSearching(true)
     setIsSearchFetching(true)
     searchDebounceTimer = setTimeout(() => {
@@ -138,7 +151,7 @@ const SessionList: Component<SessionListProps> = (props) => {
         .finally(() => {
           setIsSearchFetching(false)
         })
-    }, 300)
+    }, 150)
 
     onCleanup(() => {
       if (searchDebounceTimer) {

--- a/packages/ui/src/components/session-list.tsx
+++ b/packages/ui/src/components/session-list.tsx
@@ -128,28 +128,21 @@ const SessionList: Component<SessionListProps> = (props) => {
       return
     }
 
-    // Check if client-side filtering already yields results
-    const hasClientResults = props.threads.some((thread) => {
-      if (sessionMatchesQuery(thread.parent.id, query)) return true
-      return thread.children.some((child) => sessionMatchesQuery(child.id, query))
-    })
-
-    if (hasClientResults) {
-      // Client-side filtering is sufficient — results appear instantly
-      setWasSearching(false)
-      return
-    }
-
-    // No client-side results — need server-side search
+    // Always run server search in background for workspace-complete results.
+    // Client-side filtering (filteredThreads) shows instant results from loaded sessions.
     setWasSearching(true)
     setIsSearchFetching(true)
+    const queryAtDispatch = query
     searchDebounceTimer = setTimeout(() => {
-      void searchSessions(props.instanceId, query)
+      void searchSessions(props.instanceId, queryAtDispatch)
         .catch((error) => {
           log.error("Failed to search sessions:", error)
         })
         .finally(() => {
-          setIsSearchFetching(false)
+          // Only clear loading if this was the latest query
+          if (normalizedQuery() === queryAtDispatch) {
+            setIsSearchFetching(false)
+          }
         })
     }, 150)
 

--- a/packages/ui/src/components/session-list.tsx
+++ b/packages/ui/src/components/session-list.tsx
@@ -23,9 +23,10 @@ import {
   loadMoreSessions,
   searchSessions,
   getSessionHasMore,
-  resetSessionPagination,
-  fetchSessions,
-  getSessionFetchLimit,
+  clearSessionSearch,
+  getSessionSearchQuery,
+  getSessionSearchThreads,
+  isSessionSearchLoading,
 } from "../stores/sessions"
 import { getGitRepoStatus, getWorktreeSlugForParentSession } from "../stores/worktrees"
 import { getLogger } from "../lib/logger"
@@ -71,9 +72,7 @@ const SessionList: Component<SessionListProps> = (props) => {
     onCleanup(() => window.clearInterval(timer))
   })
 
-  const [isSearchFetching, setIsSearchFetching] = createSignal(false)
   const [sentinelEl, setSentinelEl] = createSignal<HTMLDivElement | null>(null)
-  const [wasSearching, setWasSearching] = createSignal(false)
 
   const hasMore = createMemo(() => {
     if (normalizedQuery()) return false
@@ -108,7 +107,7 @@ const SessionList: Component<SessionListProps> = (props) => {
   createEffect(() => {
     const query = normalizedQuery()
     if (!props.enableFilterBar) {
-      setWasSearching(false)
+      clearSessionSearch(props.instanceId)
       return
     }
 
@@ -117,32 +116,17 @@ const SessionList: Component<SessionListProps> = (props) => {
     }
 
     if (!query) {
-      // Only reset pagination if we were previously searching (user cleared the query)
-      if (wasSearching()) {
-        setWasSearching(false)
-        const limit = getSessionFetchLimit(props.instanceId)
-        void fetchSessions(props.instanceId, { limit }).catch((error) => {
-          log.error("Failed to reset sessions after search clear:", error)
-        })
-      }
+      clearSessionSearch(props.instanceId)
       return
     }
 
     // Always run server search in background for workspace-complete results.
     // Client-side filtering (filteredThreads) shows instant results from loaded sessions.
-    setWasSearching(true)
-    setIsSearchFetching(true)
     const queryAtDispatch = query
     searchDebounceTimer = setTimeout(() => {
       void searchSessions(props.instanceId, queryAtDispatch)
         .catch((error) => {
           log.error("Failed to search sessions:", error)
-        })
-        .finally(() => {
-          // Only clear loading if this was the latest query
-          if (normalizedQuery() === queryAtDispatch) {
-            setIsSearchFetching(false)
-          }
         })
     }, 150)
 
@@ -169,6 +153,12 @@ const SessionList: Component<SessionListProps> = (props) => {
   const filteredThreads = createMemo<SessionThread[]>(() => {
     const query = normalizedQuery()
     if (!query) return props.threads
+
+    const searchQuery = getSessionSearchQuery(props.instanceId)
+    const searchLoading = isSessionSearchLoading(props.instanceId)
+    if (searchQuery === query && !searchLoading) {
+      return getSessionSearchThreads(props.instanceId)
+    }
 
     const next: SessionThread[] = []
     for (const thread of props.threads) {

--- a/packages/ui/src/lib/i18n/messages/en/session.ts
+++ b/packages/ui/src/lib/i18n/messages/en/session.ts
@@ -47,6 +47,7 @@ export const sessionMessages = {
 
   "sessionList.filter.placeholder": "Search sessions…",
   "sessionList.filter.ariaLabel": "Search sessions",
+  "sessionList.loading.more": "Loading more sessions…",
   "sessionList.selection.selectAllLabel": "Select all",
   "sessionList.selection.selectAllAriaLabel": "Select all sessions",
   "sessionList.selection.clearLabel": "Clear",

--- a/packages/ui/src/lib/i18n/messages/es/session.ts
+++ b/packages/ui/src/lib/i18n/messages/es/session.ts
@@ -47,6 +47,7 @@ export const sessionMessages = {
 
   "sessionList.filter.placeholder": "Buscar sesiones…",
   "sessionList.filter.ariaLabel": "Buscar sesiones",
+  "sessionList.loading.more": "Cargando más sesiones…",
   "sessionList.selection.selectAllLabel": "Seleccionar todo",
   "sessionList.selection.selectAllAriaLabel": "Seleccionar todas las sesiones",
   "sessionList.selection.clearLabel": "Limpiar",

--- a/packages/ui/src/lib/i18n/messages/fr/session.ts
+++ b/packages/ui/src/lib/i18n/messages/fr/session.ts
@@ -47,6 +47,7 @@ export const sessionMessages = {
 
   "sessionList.filter.placeholder": "Rechercher des sessions…",
   "sessionList.filter.ariaLabel": "Rechercher des sessions",
+  "sessionList.loading.more": "Chargement de plus de sessions…",
   "sessionList.selection.selectAllLabel": "Tout sélectionner",
   "sessionList.selection.selectAllAriaLabel": "Sélectionner toutes les sessions",
   "sessionList.selection.clearLabel": "Effacer",

--- a/packages/ui/src/lib/i18n/messages/he/session.ts
+++ b/packages/ui/src/lib/i18n/messages/he/session.ts
@@ -47,6 +47,7 @@ export const sessionMessages = {
 
   "sessionList.filter.placeholder": "חפש סשנים…",
   "sessionList.filter.ariaLabel": "חפש סשנים",
+  "sessionList.loading.more": "טוען עוד סשנים…",
   "sessionList.selection.selectAllLabel": "בחר הכל",
   "sessionList.selection.selectAllAriaLabel": "בחר את כל הסשנים",
   "sessionList.selection.clearLabel": "נקה",

--- a/packages/ui/src/lib/i18n/messages/ja/session.ts
+++ b/packages/ui/src/lib/i18n/messages/ja/session.ts
@@ -47,6 +47,7 @@ export const sessionMessages = {
 
   "sessionList.filter.placeholder": "セッションを検索…",
   "sessionList.filter.ariaLabel": "セッションを検索",
+  "sessionList.loading.more": "セッションをさらに読み込んでいます…",
   "sessionList.selection.selectAllLabel": "すべて選択",
   "sessionList.selection.selectAllAriaLabel": "すべてのセッションを選択",
   "sessionList.selection.clearLabel": "クリア",

--- a/packages/ui/src/lib/i18n/messages/ru/session.ts
+++ b/packages/ui/src/lib/i18n/messages/ru/session.ts
@@ -47,6 +47,7 @@ export const sessionMessages = {
 
   "sessionList.filter.placeholder": "Поиск сессий…",
   "sessionList.filter.ariaLabel": "Поиск сессий",
+  "sessionList.loading.more": "Загрузка дополнительных сессий…",
   "sessionList.selection.selectAllLabel": "Выбрать все",
   "sessionList.selection.selectAllAriaLabel": "Выбрать все сессии",
   "sessionList.selection.clearLabel": "Очистить",

--- a/packages/ui/src/lib/i18n/messages/zh-Hans/session.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-Hans/session.ts
@@ -47,6 +47,7 @@ export const sessionMessages = {
 
   "sessionList.filter.placeholder": "搜索会话…",
   "sessionList.filter.ariaLabel": "搜索会话",
+  "sessionList.loading.more": "正在加载更多会话…",
   "sessionList.selection.selectAllLabel": "全选",
   "sessionList.selection.selectAllAriaLabel": "选择所有会话",
   "sessionList.selection.clearLabel": "清除",

--- a/packages/ui/src/stores/instances.ts
+++ b/packages/ui/src/stores/instances.ts
@@ -17,6 +17,8 @@ import {
   fetchAgents,
   fetchProviders,
   clearInstanceDraftPrompts,
+  getSessionFetchLimit,
+  resetSessionPagination,
 } from "./sessions"
 import {
   ensureWorktreesLoaded,
@@ -280,7 +282,9 @@ async function hydrateInstanceData(instanceId: string, options?: { force?: boole
       await ensureWorktreesLoaded(instanceId)
       await ensureWorktreeMapLoaded(instanceId)
     }
-    await fetchSessions(instanceId)
+    resetSessionPagination(instanceId)
+    const limit = getSessionFetchLimit(instanceId)
+    await fetchSessions(instanceId, { limit })
     await fetchAgents(instanceId)
     await fetchProviders(instanceId)
     await ensureInstanceConfigLoaded(instanceId)

--- a/packages/ui/src/stores/instances.ts
+++ b/packages/ui/src/stores/instances.ts
@@ -17,7 +17,6 @@ import {
   fetchAgents,
   fetchProviders,
   clearInstanceDraftPrompts,
-  getSessionFetchLimit,
   resetSessionPagination,
 } from "./sessions"
 import {
@@ -283,8 +282,7 @@ async function hydrateInstanceData(instanceId: string, options?: { force?: boole
       await ensureWorktreeMapLoaded(instanceId)
     }
     resetSessionPagination(instanceId)
-    const limit = getSessionFetchLimit(instanceId)
-    await fetchSessions(instanceId, { limit })
+    await fetchSessions(instanceId)
     await fetchAgents(instanceId)
     await fetchProviders(instanceId)
     await ensureInstanceConfigLoaded(instanceId)

--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -39,6 +39,7 @@ import {
   prependSessionListId,
   removeSessionListId,
   beginSessionSearch,
+  clearSessionSearch,
   isLatestSessionSearch,
   setSessionSearchResults,
 } from "./session-state"
@@ -346,11 +347,24 @@ async function searchSessions(instanceId: string, query: string): Promise<void> 
 
     if (!isLatestSessionSearch(instanceId, trimmedQuery, requestId)) return
 
+    const hydratedSessions = sessions().get(instanceId)
+    const hasUnrenderableChildResult = searchResults.some((session) => {
+      const parentId = session.parentID
+      return Boolean(parentId && !hydratedSessions?.has(parentId))
+    })
+
+    if (hasUnrenderableChildResult) {
+      clearSessionSearch(instanceId)
+      return
+    }
+
     syncInstanceSessionIndicator(instanceId)
     setSessionSearchResults(instanceId, trimmedQuery, searchResults.map((session) => session.id), requestId)
   } catch (error) {
     log.error("Failed to search sessions:", error)
-    setSessionSearchResults(instanceId, trimmedQuery, [], requestId)
+    if (isLatestSessionSearch(instanceId, trimmedQuery, requestId)) {
+      clearSessionSearch(instanceId)
+    }
     throw error
   }
 }

--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -153,12 +153,14 @@ async function fetchSessions(instanceId: string, options?: { limit?: number; sea
     const sessionMap = new Map<string, Session>()
 
     if (!response.data || !Array.isArray(response.data)) {
-      setInstanceSessionHasMore(instanceId, false)
+      if (limit) setInstanceSessionHasMore(instanceId, false)
       return
     }
 
-    const hasMore = limit ? response.data.length >= limit : false
-    setInstanceSessionHasMore(instanceId, hasMore)
+    if (limit) {
+      const hasMore = response.data.length >= limit
+      setInstanceSessionHasMore(instanceId, hasMore)
+    }
 
     let statusById: Record<string, any> = {}
     try {
@@ -297,32 +299,43 @@ async function searchSessions(instanceId: string, query: string): Promise<void> 
 
       for (const apiSession of searchResults) {
         const existingSession = instanceSessions.get(apiSession.id)
-        instanceSessions.set(apiSession.id, {
-          id: apiSession.id,
-          instanceId,
-          title: apiSession.title || "Untitled",
-          parentId: apiSession.parentID || null,
-          agent: existingSession?.agent ?? "",
-          model: existingSession?.model ?? { providerId: "", modelId: "" },
-          status: existingSession?.status ?? "idle",
-          retry: existingSession?.retry ?? null,
-          idleSince: existingSession?.idleSince ?? null,
-          version: apiSession.version,
-          time: { ...apiSession.time },
-          revert: apiSession.revert
-            ? {
-                messageID: apiSession.revert.messageID,
-                partID: apiSession.revert.partID,
-                snapshot: apiSession.revert.snapshot,
-                diff: apiSession.revert.diff,
-              }
-            : undefined,
-        })
+        instanceSessions.set(apiSession.id, toClientSession(instanceId, apiSession, existingSession))
       }
 
       next.set(instanceId, instanceSessions)
       return next
     })
+
+    // Fetch any missing parents so child results are rendered correctly
+    const currentSessions = sessions().get(instanceId)
+    const missingParentIds = new Set<string>()
+    for (const apiSession of searchResults) {
+      const parentId = apiSession.parentID
+      if (parentId && !currentSessions?.has(parentId)) {
+        missingParentIds.add(parentId)
+      }
+    }
+
+    if (missingParentIds.size > 0) {
+      const parentFetches = Array.from(missingParentIds).map(async (parentId) => {
+        try {
+          const parentResponse = await rootClient.session.get({ sessionID: parentId })
+          if (parentResponse.data) {
+            setSessions((prev) => {
+              const next = new Map(prev)
+              const instanceSessions = new Map(next.get(instanceId) ?? new Map())
+              const existingSession = instanceSessions.get(parentId)
+              instanceSessions.set(parentId, toClientSession(instanceId, parentResponse.data, existingSession))
+              next.set(instanceId, instanceSessions)
+              return next
+            })
+          }
+        } catch (error) {
+          log.warn("Failed to fetch missing parent session:", { parentId, error })
+        }
+      })
+      await Promise.all(parentFetches)
+    }
 
     syncInstanceSessionIndicator(instanceId)
     setInstanceSessionHasMore(instanceId, false)

--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -424,16 +424,67 @@ async function fetchSessionChildren(instanceId: string, parentSessionId: string)
 
     const currentSessions = sessions().get(instanceId)
     const children = apiChildren.map((apiSession) => toClientSession(instanceId, apiSession, currentSessions?.get(apiSession.id)))
+    const returnedChildIds = new Set(children.map((child) => child.id))
+    let staleChildIds: string[] = []
 
     setSessions((prev) => {
       const next = new Map(prev)
       const instanceSessions = new Map(next.get(instanceId))
+      staleChildIds = []
+
+      for (const session of instanceSessions.values()) {
+        if (session.parentId === parentSessionId && !returnedChildIds.has(session.id)) {
+          staleChildIds.push(session.id)
+        }
+      }
+
+      for (const staleChildId of staleChildIds) {
+        instanceSessions.delete(staleChildId)
+      }
+
       for (const child of children) {
         instanceSessions.set(child.id, child)
       }
       next.set(instanceId, instanceSessions)
       return next
     })
+
+    if (staleChildIds.length > 0) {
+      const staleChildIdSet = new Set(staleChildIds)
+
+      setMessagesLoaded((prev) => {
+        const loadedSet = prev.get(instanceId)
+        if (!loadedSet) return prev
+        const updated = new Set(loadedSet)
+        let changed = false
+        for (const staleChildId of staleChildIdSet) {
+          changed = updated.delete(staleChildId) || changed
+        }
+        if (!changed) return prev
+        const next = new Map(prev)
+        next.set(instanceId, updated)
+        return next
+      })
+
+      setSessionInfoByInstance((prev) => {
+        const instanceInfo = prev.get(instanceId)
+        if (!instanceInfo) return prev
+        const updated = new Map(instanceInfo)
+        let changed = false
+        for (const staleChildId of staleChildIdSet) {
+          changed = updated.delete(staleChildId) || changed
+        }
+        if (!changed) return prev
+        const next = new Map(prev)
+        next.set(instanceId, updated)
+        return next
+      })
+
+      for (const staleChildId of staleChildIds) {
+        messageStoreBus.getOrCreate(instanceId).clearSession(staleChildId)
+        clearCacheForSession(instanceId, staleChildId)
+      }
+    }
 
     syncInstanceSessionIndicator(instanceId)
     updateThreadTotalsForParent(instanceId, parentSessionId)

--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -33,6 +33,11 @@ import {
   cleanupBlankSessions,
   syncInstanceSessionIndicator,
   updateThreadTotalsForParent,
+  getSessionFetchLimit,
+  setInstanceSessionFetchLimit,
+  setInstanceSessionHasMore,
+  resetSessionPagination,
+  incrementSessionFetchLimit,
 } from "./session-state"
 import { DEFAULT_MODEL_OUTPUT_LIMIT, getDefaultModel, isModelValid } from "./session-models"
 import { normalizeMessagePart } from "./message-v2/normalizers"
@@ -117,7 +122,7 @@ interface SessionForkResponse {
   }
 }
 
-async function fetchSessions(instanceId: string): Promise<void> {
+async function fetchSessions(instanceId: string, options?: { limit?: number; search?: string }): Promise<void> {
   const instance = instances().get(instanceId)
   if (!instance || !instance.client) {
     throw new Error("Instance not ready")
@@ -134,18 +139,26 @@ async function fetchSessions(instanceId: string): Promise<void> {
   try {
     const projectResponse = await rootClient.project.current()
     const projectId = projectResponse.data?.id
-    const sessionListOptions = instance.folder ? { directory: instance.folder } : undefined
+    const limit = options?.limit
+    const search = options?.search
 
-    log.info("session.list", { instanceId, projectId, directory: sessionListOptions?.directory })
-    const response = sessionListOptions
-      ? await rootClient.session.list(sessionListOptions)
-      : await rootClient.session.list()
+    const sessionListOptions: { directory?: string; limit?: number; search?: string } = {}
+    if (instance.folder) sessionListOptions.directory = instance.folder
+    if (limit) sessionListOptions.limit = limit
+    if (search) sessionListOptions.search = search
+
+    log.info("session.list", { instanceId, projectId, limit, search, directory: sessionListOptions.directory })
+    const response = await rootClient.session.list(sessionListOptions)
 
     const sessionMap = new Map<string, Session>()
 
     if (!response.data || !Array.isArray(response.data)) {
+      setInstanceSessionHasMore(instanceId, false)
       return
     }
+
+    const hasMore = limit ? response.data.length >= limit : false
+    setInstanceSessionHasMore(instanceId, hasMore)
 
     let statusById: Record<string, any> = {}
     try {
@@ -242,6 +255,80 @@ async function fetchSessions(instanceId: string): Promise<void> {
       next.fetchingSessions.set(instanceId, false)
       return next
     })
+  }
+}
+
+async function loadMoreSessions(instanceId: string): Promise<void> {
+  const nextLimit = incrementSessionFetchLimit(instanceId)
+  await fetchSessions(instanceId, { limit: nextLimit })
+}
+
+async function searchSessions(instanceId: string, query: string): Promise<void> {
+  if (!query.trim()) {
+    const limit = getSessionFetchLimit(instanceId)
+    await fetchSessions(instanceId, { limit })
+    return
+  }
+
+  const instance = instances().get(instanceId)
+  if (!instance || !instance.client) {
+    throw new Error("Instance not ready")
+  }
+
+  const rootClient = getRootClient(instanceId)
+
+  try {
+    log.info("session.search", { instanceId, query, directory: instance.folder })
+    const response = await rootClient.session.list({
+      search: query.trim(),
+      limit: 50,
+      directory: instance.folder,
+    })
+    const searchResults = response.data ?? []
+
+    if (searchResults.length === 0) {
+      setInstanceSessionHasMore(instanceId, false)
+      return
+    }
+
+    setSessions((prev) => {
+      const next = new Map(prev)
+      const instanceSessions = new Map(next.get(instanceId) ?? new Map())
+
+      for (const apiSession of searchResults) {
+        const existingSession = instanceSessions.get(apiSession.id)
+        instanceSessions.set(apiSession.id, {
+          id: apiSession.id,
+          instanceId,
+          title: apiSession.title || "Untitled",
+          parentId: apiSession.parentID || null,
+          agent: existingSession?.agent ?? "",
+          model: existingSession?.model ?? { providerId: "", modelId: "" },
+          status: existingSession?.status ?? "idle",
+          retry: existingSession?.retry ?? null,
+          idleSince: existingSession?.idleSince ?? null,
+          version: apiSession.version,
+          time: { ...apiSession.time },
+          revert: apiSession.revert
+            ? {
+                messageID: apiSession.revert.messageID,
+                partID: apiSession.revert.partID,
+                snapshot: apiSession.revert.snapshot,
+                diff: apiSession.revert.diff,
+              }
+            : undefined,
+        })
+      }
+
+      next.set(instanceId, instanceSessions)
+      return next
+    })
+
+    syncInstanceSessionIndicator(instanceId)
+    setInstanceSessionHasMore(instanceId, false)
+  } catch (error) {
+    log.error("Failed to search sessions:", error)
+    throw error
   }
 }
 
@@ -911,6 +998,8 @@ export {
   fetchProviders,
 
   fetchSessions,
+  loadMoreSessions,
+  searchSessions,
   fetchSessionChildren,
   forkSession,
   loadMessages,

--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -33,11 +33,14 @@ import {
   cleanupBlankSessions,
   syncInstanceSessionIndicator,
   updateThreadTotalsForParent,
-  getSessionFetchLimit,
-  setInstanceSessionFetchLimit,
-  setInstanceSessionHasMore,
-  resetSessionPagination,
-  incrementSessionFetchLimit,
+  SESSION_PAGE_SIZE,
+  getSessionNextStart,
+  setSessionPage,
+  prependSessionListId,
+  removeSessionListId,
+  beginSessionSearch,
+  isLatestSessionSearch,
+  setSessionSearchResults,
 } from "./session-state"
 import { DEFAULT_MODEL_OUTPUT_LIMIT, getDefaultModel, isModelValid } from "./session-models"
 import { normalizeMessagePart } from "./message-v2/normalizers"
@@ -122,7 +125,7 @@ interface SessionForkResponse {
   }
 }
 
-async function fetchSessions(instanceId: string, options?: { limit?: number; search?: string }): Promise<void> {
+async function fetchSessions(instanceId: string, options?: { start?: number; limit?: number }): Promise<void> {
   const instance = instances().get(instanceId)
   if (!instance || !instance.client) {
     throw new Error("Instance not ready")
@@ -139,28 +142,27 @@ async function fetchSessions(instanceId: string, options?: { limit?: number; sea
   try {
     const projectResponse = await rootClient.project.current()
     const projectId = projectResponse.data?.id
-    const limit = options?.limit
-    const search = options?.search
+    const start = options?.start ?? 0
+    const limit = options?.limit ?? SESSION_PAGE_SIZE
 
-    const sessionListOptions: { directory?: string; limit?: number; search?: string } = {}
+    const sessionListOptions: { directory?: string; roots?: boolean; start?: number; limit?: number } = {
+      roots: true,
+      start,
+      limit,
+    }
     if (instance.folder) sessionListOptions.directory = instance.folder
-    if (limit) sessionListOptions.limit = limit
-    if (search) sessionListOptions.search = search
 
-    log.info("session.list", { instanceId, projectId, limit, search, directory: sessionListOptions.directory })
+    log.info("session.list", { instanceId, projectId, start, limit, directory: sessionListOptions.directory })
     const response = await rootClient.session.list(sessionListOptions)
 
     const sessionMap = new Map<string, Session>()
 
     if (!response.data || !Array.isArray(response.data)) {
-      if (limit) setInstanceSessionHasMore(instanceId, false)
+      setSessionPage(instanceId, [], start, false)
       return
     }
 
-    if (limit) {
-      const hasMore = response.data.length >= limit
-      setInstanceSessionHasMore(instanceId, hasMore)
-    }
+    const hasMore = response.data.length >= limit
 
     let statusById: Record<string, any> = {}
     try {
@@ -219,11 +221,17 @@ async function fetchSessions(instanceId: string, options?: { limit?: number; sea
 
     setSessions((prev) => {
       const next = new Map(prev)
-      next.set(instanceId, sessionMap)
+      const instanceSessions = new Map(next.get(instanceId) ?? new Map())
+      for (const session of sessionMap.values()) {
+        instanceSessions.set(session.id, session)
+      }
+      next.set(instanceId, instanceSessions)
       return next
     })
 
-    syncInstanceSessionIndicator(instanceId, sessionMap)
+    setSessionPage(instanceId, Array.from(validSessionIds), start, hasMore)
+
+    syncInstanceSessionIndicator(instanceId)
 
     setMessagesLoaded((prev) => {
       const next = new Map(prev)
@@ -231,7 +239,7 @@ async function fetchSessions(instanceId: string, options?: { limit?: number; sea
       if (loadedSet) {
         const filtered = new Set<string>()
         for (const id of loadedSet) {
-          if (validSessionIds.has(id)) {
+          if (sessions().get(instanceId)?.has(id)) {
             filtered.add(id)
           }
         }
@@ -241,7 +249,7 @@ async function fetchSessions(instanceId: string, options?: { limit?: number; sea
     })
 
 
-    pruneDraftPrompts(instanceId, new Set(sessionMap.keys()))
+    pruneDraftPrompts(instanceId, new Set(sessions().get(instanceId)?.keys() ?? []))
 
     const parentIds = Array.from(sessionMap.values())
       .filter((session) => session.parentId === null)
@@ -261,16 +269,12 @@ async function fetchSessions(instanceId: string, options?: { limit?: number; sea
 }
 
 async function loadMoreSessions(instanceId: string): Promise<void> {
-  const nextLimit = incrementSessionFetchLimit(instanceId)
-  await fetchSessions(instanceId, { limit: nextLimit })
+  await fetchSessions(instanceId, { start: getSessionNextStart(instanceId), limit: SESSION_PAGE_SIZE })
 }
 
 async function searchSessions(instanceId: string, query: string): Promise<void> {
-  if (!query.trim()) {
-    const limit = getSessionFetchLimit(instanceId)
-    await fetchSessions(instanceId, { limit })
-    return
-  }
+  const trimmedQuery = query.trim()
+  if (!trimmedQuery) return
 
   const instance = instances().get(instanceId)
   if (!instance || !instance.client) {
@@ -278,18 +282,21 @@ async function searchSessions(instanceId: string, query: string): Promise<void> 
   }
 
   const rootClient = getRootClient(instanceId)
+  const requestId = beginSessionSearch(instanceId, trimmedQuery)
 
   try {
-    log.info("session.search", { instanceId, query, directory: instance.folder })
+    log.info("session.search", { instanceId, query: trimmedQuery, directory: instance.folder })
     const response = await rootClient.session.list({
-      search: query.trim(),
-      limit: 50,
+      search: trimmedQuery,
+      limit: SESSION_PAGE_SIZE,
       directory: instance.folder,
     })
+    if (!isLatestSessionSearch(instanceId, trimmedQuery, requestId)) return
+
     const searchResults = response.data ?? []
 
     if (searchResults.length === 0) {
-      setInstanceSessionHasMore(instanceId, false)
+      setSessionSearchResults(instanceId, trimmedQuery, [], requestId)
       return
     }
 
@@ -337,10 +344,13 @@ async function searchSessions(instanceId: string, query: string): Promise<void> 
       await Promise.all(parentFetches)
     }
 
+    if (!isLatestSessionSearch(instanceId, trimmedQuery, requestId)) return
+
     syncInstanceSessionIndicator(instanceId)
-    setInstanceSessionHasMore(instanceId, false)
+    setSessionSearchResults(instanceId, trimmedQuery, searchResults.map((session) => session.id), requestId)
   } catch (error) {
     log.error("Failed to search sessions:", error)
+    setSessionSearchResults(instanceId, trimmedQuery, [], requestId)
     throw error
   }
 }
@@ -503,6 +513,7 @@ async function createSession(instanceId: string, agent?: string): Promise<Sessio
     })
 
     syncInstanceSessionIndicator(instanceId)
+    prependSessionListId(instanceId, session.id)
 
     const instanceProviders = providers().get(instanceId) || []
     const initialProvider = instanceProviders.find((p) => p.id === session.model.providerId)
@@ -680,6 +691,7 @@ async function deleteSession(instanceId: string, sessionId: string): Promise<voi
     })
 
     syncInstanceSessionIndicator(instanceId)
+    removeSessionListId(instanceId, sessionId)
 
     clearSessionDraftPrompt(instanceId, sessionId)
 

--- a/packages/ui/src/stores/session-state.ts
+++ b/packages/ui/src/stores/session-state.ts
@@ -62,6 +62,55 @@ type InstanceIndicatorCounts = {
 
 const [instanceIndicatorCounts, setInstanceIndicatorCounts] = createSignal<Map<string, InstanceIndicatorCounts>>(new Map())
 
+const SESSION_PAGE_SIZE = 50
+
+const [sessionFetchLimit, setSessionFetchLimit] = createSignal<Map<string, number>>(new Map())
+const [sessionHasMore, setSessionHasMore] = createSignal<Map<string, boolean>>(new Map())
+
+function getSessionFetchLimit(instanceId: string): number {
+  return sessionFetchLimit().get(instanceId) ?? SESSION_PAGE_SIZE
+}
+
+function setInstanceSessionFetchLimit(instanceId: string, limit: number): void {
+  setSessionFetchLimit((prev) => {
+    const next = new Map(prev)
+    next.set(instanceId, limit)
+    return next
+  })
+}
+
+function getSessionHasMore(instanceId: string): boolean {
+  return sessionHasMore().get(instanceId) ?? true
+}
+
+function setInstanceSessionHasMore(instanceId: string, hasMore: boolean): void {
+  setSessionHasMore((prev) => {
+    const next = new Map(prev)
+    next.set(instanceId, hasMore)
+    return next
+  })
+}
+
+function resetSessionPagination(instanceId: string): void {
+  setSessionFetchLimit((prev) => {
+    const next = new Map(prev)
+    next.set(instanceId, SESSION_PAGE_SIZE)
+    return next
+  })
+  setSessionHasMore((prev) => {
+    const next = new Map(prev)
+    next.set(instanceId, true)
+    return next
+  })
+}
+
+function incrementSessionFetchLimit(instanceId: string): number {
+  const current = getSessionFetchLimit(instanceId)
+  const nextLimit = current + SESSION_PAGE_SIZE
+  setInstanceSessionFetchLimit(instanceId, nextLimit)
+  return nextLimit
+}
+
 function getIndicatorBucket(session: Pick<Session, "status" | "pendingPermission" | "pendingQuestion">): InstanceSessionIndicatorStatus | "idle" {
   if (session.pendingPermission || session.pendingQuestion) {
     return "permission"
@@ -837,4 +886,13 @@ export {
   getSessionInfo,
   isBlankSession,
   cleanupBlankSessions,
+  SESSION_PAGE_SIZE,
+  sessionFetchLimit,
+  sessionHasMore,
+  getSessionFetchLimit,
+  setInstanceSessionFetchLimit,
+  getSessionHasMore,
+  setInstanceSessionHasMore,
+  resetSessionPagination,
+  incrementSessionFetchLimit,
 }

--- a/packages/ui/src/stores/session-state.ts
+++ b/packages/ui/src/stores/session-state.ts
@@ -62,53 +62,132 @@ type InstanceIndicatorCounts = {
 
 const [instanceIndicatorCounts, setInstanceIndicatorCounts] = createSignal<Map<string, InstanceIndicatorCounts>>(new Map())
 
-const SESSION_PAGE_SIZE = 50
+const SESSION_PAGE_SIZE = 100
 
-const [sessionFetchLimit, setSessionFetchLimit] = createSignal<Map<string, number>>(new Map())
-const [sessionHasMore, setSessionHasMore] = createSignal<Map<string, boolean>>(new Map())
-
-function getSessionFetchLimit(instanceId: string): number {
-  return sessionFetchLimit().get(instanceId) ?? SESSION_PAGE_SIZE
+type SessionPaginationState = {
+  ids: string[]
+  nextStart: number
+  hasMore: boolean
 }
 
-function setInstanceSessionFetchLimit(instanceId: string, limit: number): void {
-  setSessionFetchLimit((prev) => {
+type SessionSearchState = {
+  query: string
+  ids: string[]
+  loading: boolean
+  requestId: number
+}
+
+const [sessionPagination, setSessionPagination] = createSignal<Map<string, SessionPaginationState>>(new Map())
+const [sessionSearch, setSessionSearch] = createSignal<Map<string, SessionSearchState>>(new Map())
+
+function getSessionPaginationState(instanceId: string): SessionPaginationState {
+  return sessionPagination().get(instanceId) ?? { ids: [], nextStart: 0, hasMore: true }
+}
+
+function getSessionListIds(instanceId: string): string[] {
+  return getSessionPaginationState(instanceId).ids
+}
+
+function getSessionFetchLimit(instanceId: string): number {
+  return Math.max(getSessionPaginationState(instanceId).ids.length, SESSION_PAGE_SIZE)
+}
+
+function getSessionNextStart(instanceId: string): number {
+  return getSessionPaginationState(instanceId).nextStart
+}
+
+function setSessionPage(instanceId: string, ids: string[], start: number, hasMore: boolean): void {
+  setSessionPagination((prev) => {
     const next = new Map(prev)
-    next.set(instanceId, limit)
+    const current = prev.get(instanceId) ?? { ids: [], nextStart: 0, hasMore: true }
+    const nextIds = start <= 0 ? ids : Array.from(new Set([...current.ids, ...ids]))
+    next.set(instanceId, {
+      ids: nextIds,
+      nextStart: start + ids.length,
+      hasMore,
+    })
     return next
   })
 }
 
 function getSessionHasMore(instanceId: string): boolean {
-  return sessionHasMore().get(instanceId) ?? true
-}
-
-function setInstanceSessionHasMore(instanceId: string, hasMore: boolean): void {
-  setSessionHasMore((prev) => {
-    const next = new Map(prev)
-    next.set(instanceId, hasMore)
-    return next
-  })
+  return getSessionPaginationState(instanceId).hasMore
 }
 
 function resetSessionPagination(instanceId: string): void {
-  setSessionFetchLimit((prev) => {
+  setSessionPagination((prev) => {
     const next = new Map(prev)
-    next.set(instanceId, SESSION_PAGE_SIZE)
-    return next
-  })
-  setSessionHasMore((prev) => {
-    const next = new Map(prev)
-    next.set(instanceId, true)
+    next.set(instanceId, { ids: [], nextStart: 0, hasMore: true })
     return next
   })
 }
 
-function incrementSessionFetchLimit(instanceId: string): number {
-  const current = getSessionFetchLimit(instanceId)
-  const nextLimit = current + SESSION_PAGE_SIZE
-  setInstanceSessionFetchLimit(instanceId, nextLimit)
-  return nextLimit
+function prependSessionListId(instanceId: string, sessionId: string): void {
+  setSessionPagination((prev) => {
+    const next = new Map(prev)
+    const current = prev.get(instanceId) ?? { ids: [], nextStart: 0, hasMore: true }
+    const ids = [sessionId, ...current.ids.filter((id) => id !== sessionId)]
+    next.set(instanceId, { ...current, ids, nextStart: current.nextStart + (current.ids.includes(sessionId) ? 0 : 1) })
+    return next
+  })
+}
+
+function removeSessionListId(instanceId: string, sessionId: string): void {
+  setSessionPagination((prev) => {
+    const next = new Map(prev)
+    const current = prev.get(instanceId) ?? { ids: [], nextStart: 0, hasMore: true }
+    const ids = current.ids.filter((id) => id !== sessionId)
+    next.set(instanceId, { ...current, ids, nextStart: Math.max(0, current.nextStart - (ids.length === current.ids.length ? 0 : 1)) })
+    return next
+  })
+}
+
+function beginSessionSearch(instanceId: string, query: string): number {
+  const current = sessionSearch().get(instanceId)
+  const requestId = (current?.requestId ?? 0) + 1
+  setSessionSearch((prev) => {
+    const next = new Map(prev)
+    next.set(instanceId, { query, ids: current?.ids ?? [], loading: true, requestId })
+    return next
+  })
+  return requestId
+}
+
+function isLatestSessionSearch(instanceId: string, query: string, requestId: number): boolean {
+  const current = sessionSearch().get(instanceId)
+  return Boolean(current && current.query === query && current.requestId === requestId)
+}
+
+function setSessionSearchResults(instanceId: string, query: string, ids: string[], requestId: number): boolean {
+  if (!isLatestSessionSearch(instanceId, query, requestId)) return false
+  setSessionSearch((prev) => {
+    const next = new Map(prev)
+    next.set(instanceId, { query, ids, loading: false, requestId })
+    return next
+  })
+  return true
+}
+
+function clearSessionSearch(instanceId: string): void {
+  setSessionSearch((prev) => {
+    const current = prev.get(instanceId)
+    const requestId = (current?.requestId ?? 0) + 1
+    const next = new Map(prev)
+    next.set(instanceId, { query: "", ids: [], loading: false, requestId })
+    return next
+  })
+}
+
+function getSessionSearchResultIds(instanceId: string): string[] {
+  return sessionSearch().get(instanceId)?.ids ?? []
+}
+
+function getSessionSearchQuery(instanceId: string): string {
+  return sessionSearch().get(instanceId)?.query ?? ""
+}
+
+function isSessionSearchLoading(instanceId: string): boolean {
+  return sessionSearch().get(instanceId)?.loading ?? false
 }
 
 function getIndicatorBucket(session: Pick<Session, "status" | "pendingPermission" | "pendingQuestion">): InstanceSessionIndicatorStatus | "idle" {
@@ -526,9 +605,9 @@ function getOrCreateSessionThreadCache(instanceId: string): SessionThreadCache {
   return cache
 }
 
-function getSessionThreads(instanceId: string): SessionThread[] {
+function buildSessionThreads(instanceId: string, rootIds: string[], childIds?: Set<string>): SessionThread[] {
   const instanceSessions = sessions().get(instanceId)
-  if (!instanceSessions || instanceSessions.size === 0) {
+  if (!instanceSessions || instanceSessions.size === 0 || rootIds.length === 0) {
     sessionThreadCache.delete(instanceId)
     return []
   }
@@ -536,17 +615,12 @@ function getSessionThreads(instanceId: string): SessionThread[] {
   const cache = getOrCreateSessionThreadCache(instanceId)
   const seenParents = new Set<string>()
 
-  const parents: Session[] = []
   const childrenByParent = new Map<string, Session[]>()
 
   for (const session of instanceSessions.values()) {
-    if (session.parentId === null) {
-      parents.push(session)
-      continue
-    }
-
     const parentId = session.parentId
     if (!parentId) continue
+    if (childIds && !childIds.has(session.id)) continue
     const children = childrenByParent.get(parentId)
     if (children) {
       children.push(session)
@@ -557,7 +631,10 @@ function getSessionThreads(instanceId: string): SessionThread[] {
 
   const threads: SessionThread[] = []
 
-  for (const parent of parents) {
+  for (const parentId of rootIds) {
+    const parent = instanceSessions.get(parentId)
+    if (!parent || parent.parentId !== null) continue
+
     seenParents.add(parent.id)
 
     const children = childrenByParent.get(parent.id) ?? []
@@ -597,6 +674,34 @@ function getSessionThreads(instanceId: string): SessionThread[] {
   })
 
   return threads
+}
+
+function getSessionThreads(instanceId: string): SessionThread[] {
+  return buildSessionThreads(instanceId, getSessionListIds(instanceId))
+}
+
+function getSessionSearchThreads(instanceId: string): SessionThread[] {
+  const resultIds = getSessionSearchResultIds(instanceId)
+  if (resultIds.length === 0) return []
+
+  const instanceSessions = sessions().get(instanceId)
+  if (!instanceSessions) return []
+
+  const rootIds: string[] = []
+  const childIds = new Set<string>()
+
+  for (const sessionId of resultIds) {
+    const session = instanceSessions.get(sessionId)
+    if (!session) continue
+    if (session.parentId === null) {
+      rootIds.push(session.id)
+    } else {
+      childIds.add(session.id)
+      if (!rootIds.includes(session.parentId)) rootIds.push(session.parentId)
+    }
+  }
+
+  return buildSessionThreads(instanceId, rootIds, childIds)
 }
 
 function isSessionParentExpanded(instanceId: string, parentSessionId: string): boolean {
@@ -875,6 +980,7 @@ export {
   getChildSessions,
   getSessionFamily,
   getSessionThreads,
+  getSessionSearchThreads,
   getVisibleSessionIds,
   isSessionParentExpanded,
   setSessionParentExpanded,
@@ -887,12 +993,21 @@ export {
   isBlankSession,
   cleanupBlankSessions,
   SESSION_PAGE_SIZE,
-  sessionFetchLimit,
-  sessionHasMore,
+  sessionPagination,
+  sessionSearch,
+  getSessionListIds,
   getSessionFetchLimit,
-  setInstanceSessionFetchLimit,
+  getSessionNextStart,
+  setSessionPage,
   getSessionHasMore,
-  setInstanceSessionHasMore,
   resetSessionPagination,
-  incrementSessionFetchLimit,
+  prependSessionListId,
+  removeSessionListId,
+  beginSessionSearch,
+  isLatestSessionSearch,
+  setSessionSearchResults,
+  clearSessionSearch,
+  getSessionSearchResultIds,
+  getSessionSearchQuery,
+  isSessionSearchLoading,
 }

--- a/packages/ui/src/stores/sessions.ts
+++ b/packages/ui/src/stores/sessions.ts
@@ -37,6 +37,9 @@ import {
   setSessionParentExpanded,
   setSessionStatus,
   toggleSessionParentExpanded,
+  getSessionFetchLimit,
+  getSessionHasMore,
+  resetSessionPagination,
 } from "./session-state"
 
 import { getDefaultModel } from "./session-models"
@@ -46,6 +49,8 @@ import {
   fetchAgents,
   fetchProviders,
   fetchSessions,
+  loadMoreSessions,
+  searchSessions,
   fetchSessionChildren,
   forkSession,
   loadMessages,
@@ -111,6 +116,8 @@ export {
   fetchAgents,
   fetchProviders,
   fetchSessions,
+  loadMoreSessions,
+  searchSessions,
   fetchSessionChildren,
   forkSession,
   getActiveParentSession,
@@ -145,5 +152,8 @@ export {
   toggleSessionParentExpanded,
   updateSessionAgent,
   updateSessionModel,
+  getSessionFetchLimit,
+  getSessionHasMore,
+  resetSessionPagination,
 }
 export type { SessionInfo }

--- a/packages/ui/src/stores/sessions.ts
+++ b/packages/ui/src/stores/sessions.ts
@@ -17,6 +17,8 @@ import {
   getSessionDraftPrompt,
   getSessionFamily,
   getSessionInfo,
+  getSessionSearchQuery,
+  getSessionSearchThreads,
   getSessionThreads,
   getThreadTotals,
   getSessions,
@@ -37,8 +39,10 @@ import {
   setSessionParentExpanded,
   setSessionStatus,
   toggleSessionParentExpanded,
+  clearSessionSearch,
   getSessionFetchLimit,
   getSessionHasMore,
+  isSessionSearchLoading,
   resetSessionPagination,
 } from "./session-state"
 
@@ -128,6 +132,8 @@ export {
   getSessionDraftPrompt,
   getSessionFamily,
   getSessionInfo,
+  getSessionSearchQuery,
+  getSessionSearchThreads,
   getSessionThreads,
   getThreadTotals,
   getSessions,
@@ -152,8 +158,10 @@ export {
   toggleSessionParentExpanded,
   updateSessionAgent,
   updateSessionModel,
+  clearSessionSearch,
   getSessionFetchLimit,
   getSessionHasMore,
+  isSessionSearchLoading,
   resetSessionPagination,
 }
 export type { SessionInfo }


### PR DESCRIPTION
# Session Pagination & Search Enhancement

## Changes

### Progressive Session Loading
- `fetchSessions()` now accepts `{ limit, search }` options
- Added pagination state: `sessionFetchLimit`, `sessionHasMore` (50-session pages)
- Scroll-to-bottom sentinel triggers `loadMoreSessions()` via IntersectionObserver
- Hydration loads initial 50 sessions; subsequent scrolls fetch 100, 150, etc.

### Server-Side Search
- Added `searchSessions()` using `session.list({ search, limit: 50, directory })`
- Merges results into store (preserves active session, no replacement)
- Added `"sessionList.loading.more"` i18n key (7 locales)

### Hybrid Search Performance
- Client-side filtering runs first — instant results for loaded sessions
- Server search only fires when no client matches exist
- Debounce reduced from 300ms → 150ms for server fallback

### Workspace Scoping
- All `session.list()` calls pass `directory: instance.folder`
- Prevents cross-workspace session pollution

## Files
- `packages/ui/src/stores/session-state.ts`
- `packages/ui/src/stores/session-api.ts`
- `packages/ui/src/stores/instances.ts`
- `packages/ui/src/stores/sessions.ts`
- `packages/ui/src/components/session-list.tsx`
- `packages/ui/src/lib/i18n/messages/*/session.ts`
