### PR TITLE
fix(ui): handle session created SSE events

### DIFF
--- a/packages/ui/src/lib/sse-manager.ts
+++ b/packages/ui/src/lib/sse-manager.ts
@@ -68,12 +68,15 @@ interface ServerInstanceDisposedEvent {
   }
 }
 
+type EventSessionCreated = Omit<EventSessionUpdated, "type"> & { type: "session.created" }
+
 type SSEEvent =
   | MessageUpdateEvent
   | MessageRemovedEvent
   | MessagePartUpdatedEvent
   | MessagePartRemovedEvent
   | MessagePartDeltaEvent
+  | EventSessionCreated
   | EventSessionUpdated
   | EventSessionCompacted
   | EventSessionError
@@ -149,6 +152,9 @@ class SSEManager {
         this.onMessagePartRemoved?.(instanceId, event as MessagePartRemovedEvent)
         break
       case "session.updated":
+        this.onSessionUpdate?.(instanceId, event as EventSessionUpdated)
+        break
+      case "session.created":
         this.onSessionUpdate?.(instanceId, event as EventSessionUpdated)
         break
       case "session.compacted":

--- a/packages/ui/src/stores/session-events.ts
+++ b/packages/ui/src/stores/session-events.ts
@@ -62,7 +62,7 @@ import {
   type SessionRetryState,
   type SessionStatus,
 } from "../types/session"
-import { ensureSessionParentExpanded, sessions, setSessions, syncInstanceSessionIndicator, withSession } from "./session-state"
+import { ensureSessionParentExpanded, prependSessionListId, sessions, setSessions, syncInstanceSessionIndicator, withSession } from "./session-state"
 import { normalizeMessagePart } from "./message-v2/normalizers"
 import { updateSessionInfo } from "./message-v2/session-info"
 import { tGlobal } from "../lib/i18n"
@@ -544,6 +544,8 @@ function handleSessionUpdate(instanceId: string, event: EventSessionUpdated): vo
     setSessionRevertV2(instanceId, info.id, info.revert ?? null)
     if (newSession.parentId) {
       drainAutoAcceptPermissionsForInstance(instanceId)
+    } else {
+      prependSessionListId(instanceId, newSession.id)
     }
 
     log.info(`[SSE] New session created: ${info.id}`, newSession)


### PR DESCRIPTION
## Summary
- Route `session.created` SSE events through the existing session update handler.
- Prepend newly-created root sessions to the session list pagination ids so they appear in the sidebar immediately.

Fixes #560

## Validation
- `npm run typecheck --workspace packages/ui`