### PR TITLE
Improve compact mobile UI controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - When adding new component styles, place them beside their peers in the scoped subdirectory (e.g., `src/styles/messaging/new-part.css`) and import them from the corresponding aggregator file.
 - Prefer smaller, focused style files (≈150 lines or less) over large monoliths. Split by component or feature area if a file grows beyond that size.
 - Co-locate reusable UI patterns (buttons, selectors, dropdowns, etc.) under `src/styles/components/` and avoid redefining the same utility classes elsewhere.
+- Never use rounded corners in UI styling; keep corners square unless the user explicitly requests otherwise for a specific change.
 - Document any new styling conventions or directory additions in this file so future changes remain consistent.
 
 ## Coding Principles

--- a/packages/ui/src/components/context-meter.tsx
+++ b/packages/ui/src/components/context-meter.tsx
@@ -7,6 +7,7 @@ interface ContextMeterProps {
   usedLabel: string
   availableLabel: string
   class?: string
+  centerValue?: boolean
 }
 
 const LABEL_CLASS = "uppercase text-[10px] tracking-wide text-muted"
@@ -104,18 +105,32 @@ export const ContextMeter: Component<ContextMeterProps> = (props) => {
 
   const tooltipText = () => `Context Used: ${percentLabel()}`
 
+  const valuePill = () => (
+    <div class={containerClass}>
+      <span class={LABEL_CLASS}>{props.usedLabel}</span>
+      <span class="font-semibold text-primary tabular-nums">{props.formatTokens(used())}</span>
+      <span class="text-muted">/</span>
+      <span class={LABEL_CLASS}>{props.availableLabel}</span>
+      <span class="font-semibold text-primary tabular-nums">
+        {available() !== null ? props.formatTokens(available() as number) : "--"}
+      </span>
+    </div>
+  )
+
+  if (props.centerValue) {
+    return (
+      <div class="grid grid-cols-[22px_auto_22px] items-center gap-2" title={tooltipText()}>
+        <div class="flex justify-end">{circle()}</div>
+        {valuePill()}
+        <span aria-hidden="true" />
+      </div>
+    )
+  }
+
   return (
     <div class="inline-flex items-center gap-2" title={tooltipText()}>
       {circle()}
-      <div class={containerClass}>
-        <span class={LABEL_CLASS}>{props.usedLabel}</span>
-        <span class="font-semibold text-primary tabular-nums">{props.formatTokens(used())}</span>
-        <span class="text-muted">/</span>
-        <span class={LABEL_CLASS}>{props.availableLabel}</span>
-        <span class="font-semibold text-primary tabular-nums">
-          {available() !== null ? props.formatTokens(available() as number) : "--"}
-        </span>
-      </div>
+      {valuePill()}
     </div>
   )
 }

--- a/packages/ui/src/components/instance-tabs.tsx
+++ b/packages/ui/src/components/instance-tabs.tsx
@@ -1,4 +1,4 @@
-import { Component, For, Show, createMemo, createSignal } from "solid-js"
+import { Component, For, Show, createMemo, createSignal, onCleanup, onMount } from "solid-js"
 import { Dynamic } from "solid-js/web"
 import {
   DragDropProvider,
@@ -37,15 +37,9 @@ interface SortableAppTabProps {
   onClose: (tabId: string) => void
 }
 
-const SortableAppTab: Component<SortableAppTabProps> = (props) => {
-  const sortable = createSortable(props.tab.id)
-
+const AppTabContent: Component<SortableAppTabProps> = (props) => {
   return (
-    <div
-      ref={sortable}
-      class={`tab-draggable ${sortable.isActiveDraggable ? "tab-draggable-active" : ""}`}
-      data-app-tab-id={props.tab.id}
-    >
+    <>
       {props.tab.kind === "instance" ? (
         <InstanceTab
           instance={props.tab.instance}
@@ -82,14 +76,59 @@ const SortableAppTab: Component<SortableAppTabProps> = (props) => {
           </button>
         </div>
       )}
+    </>
+  )
+}
+
+const SortableAppTab: Component<SortableAppTabProps> = (props) => {
+  const sortable = createSortable(props.tab.id)
+
+  return (
+    <div
+      ref={sortable}
+      class={`tab-draggable ${sortable.isActiveDraggable ? "tab-draggable-active" : ""}`}
+      data-app-tab-id={props.tab.id}
+    >
+      <AppTabContent {...props} />
     </div>
   )
+}
+
+const StaticAppTab: Component<SortableAppTabProps> = (props) => {
+  return (
+    <div class="tab-draggable" data-app-tab-id={props.tab.id}>
+      <AppTabContent {...props} />
+    </div>
+  )
+}
+
+const isTouchOnlyPointer = () => {
+  if (typeof window === "undefined") return false
+  return Boolean(window.matchMedia?.("(pointer: coarse)")?.matches && !window.matchMedia?.("(any-pointer: fine)")?.matches)
 }
 
 const InstanceTabs: Component<InstanceTabsProps> = (props) => {
   const { t } = useI18n()
   const { preferences } = useConfig()
   const tabIds = createMemo(() => props.tabs.map((tab) => tab.id))
+  const [dragReorderEnabled, setDragReorderEnabled] = createSignal(!isTouchOnlyPointer())
+
+  onMount(() => {
+    if (typeof window === "undefined") return
+    const coarseQuery = window.matchMedia?.("(pointer: coarse)")
+    const fineQuery = window.matchMedia?.("(any-pointer: fine)")
+    if (!coarseQuery || !fineQuery) return
+
+    const syncDragReorder = () => setDragReorderEnabled(!isTouchOnlyPointer())
+    syncDragReorder()
+    coarseQuery.addEventListener("change", syncDragReorder)
+    fineQuery.addEventListener("change", syncDragReorder)
+
+    onCleanup(() => {
+      coarseQuery.removeEventListener("change", syncDragReorder)
+      fineQuery.removeEventListener("change", syncDragReorder)
+    })
+  })
 
   /** Whether to show toast history panel */
   const [showToastHistory, setShowToastHistory] = createSignal(false)
@@ -132,22 +171,38 @@ const InstanceTabs: Component<InstanceTabsProps> = (props) => {
           <div class="tab-scroll">
             <div class="tab-strip">
               <div class="tab-strip-tabs">
-                <DragDropProvider collisionDetector={closestCenter} onDragEnd={handleDragEnd}>
-                  <DragDropSensors>
-                    <SortableProvider ids={tabIds()}>
-                      <For each={props.tabs}>
-                        {(tab) => (
-                          <SortableAppTab
-                            tab={tab}
-                            activeTabId={props.activeTabId}
-                            onSelect={props.onSelect}
-                            onClose={props.onClose}
-                          />
-                        )}
-                      </For>
-                    </SortableProvider>
-                  </DragDropSensors>
-                </DragDropProvider>
+                <Show
+                  when={dragReorderEnabled()}
+                  fallback={
+                    <For each={props.tabs}>
+                      {(tab) => (
+                        <StaticAppTab
+                          tab={tab}
+                          activeTabId={props.activeTabId}
+                          onSelect={props.onSelect}
+                          onClose={props.onClose}
+                        />
+                      )}
+                    </For>
+                  }
+                >
+                  <DragDropProvider collisionDetector={closestCenter} onDragEnd={handleDragEnd}>
+                    <DragDropSensors>
+                      <SortableProvider ids={tabIds()}>
+                        <For each={props.tabs}>
+                          {(tab) => (
+                            <SortableAppTab
+                              tab={tab}
+                              activeTabId={props.activeTabId}
+                              onSelect={props.onSelect}
+                              onClose={props.onClose}
+                            />
+                          )}
+                        </For>
+                      </SortableProvider>
+                    </DragDropSensors>
+                  </DragDropProvider>
+                </Show>
               </div>
               <div class="tab-strip-spacer" />
               <Show when={props.tabs.length > 1}>

--- a/packages/ui/src/components/instance/instance-shell2.tsx
+++ b/packages/ui/src/components/instance/instance-shell2.tsx
@@ -30,6 +30,7 @@ import PermissionApprovalModal from "../permission-approval-modal"
 import SessionView from "../session/session-view"
 import MessageSection from "../message-section"
 import PromptAttachmentsBar from "../prompt-input/PromptAttachmentsBar"
+import ActionOverflowMenu, { type ActionOverflowMenuItem } from "../action-overflow-menu"
 import { formatTokenTotal } from "../../lib/formatters"
 import ContextMeter from "../context-meter"
 import { sseManager } from "../../lib/sse-manager"
@@ -156,8 +157,10 @@ const InstanceShell2: Component<InstanceShellProps> = (props) => {
   })
 
   const isPhoneLayout = createMemo(() => layoutMode() === "phone")
-  const compactHeaderLayout = createMemo(() => isPhoneLayout() || compactHeaderQuery())
+  const narrowHeaderLayout = createMemo(() => sessionCenterWidthStep() === "narrow")
+  const compactHeaderLayout = createMemo(() => narrowHeaderLayout() || compactHeaderQuery())
   const mobileFullscreen = createMemo(() => props.mobileFullscreenMode && isPhoneLayout())
+  const showCompactFullscreenButton = createMemo(() => isPhoneLayout() && !props.mobileFullscreenMode)
   const compactPromptLayout = createMemo(() => layoutMode() !== "desktop")
   const leftPinningSupported = createMemo(() => layoutMode() !== "phone")
   const rightPinningSupported = createMemo(() => layoutMode() !== "phone")
@@ -538,6 +541,24 @@ const InstanceShell2: Component<InstanceShellProps> = (props) => {
     if (typeof window === "undefined") return
     window.dispatchEvent(new CustomEvent(OPEN_SESSION_SEARCH_EVENT))
   }
+
+  const narrowHeaderMenuItems = createMemo<ActionOverflowMenuItem[]>(() => {
+    const PreviewIcon = PreviewToggleIcon()
+    return [
+      {
+        key: "search",
+        label: t("instanceShell.chatSearch.openAriaLabel"),
+        icon: <Search class="w-3.5 h-3.5" aria-hidden="true" />,
+        onSelect: handleChatSearchClick,
+      },
+      {
+        key: "preview",
+        label: previewToggleLabel(),
+        icon: <PreviewIcon class="w-3.5 h-3.5" aria-hidden="true" />,
+        onSelect: handlePreviewButtonClick,
+      },
+    ]
+  })
 
   const openBackgroundOutput = (process: BackgroundProcess) => {
     setSelectedBackgroundProcess(process)
@@ -990,15 +1011,14 @@ const InstanceShell2: Component<InstanceShellProps> = (props) => {
                 when={!compactHeaderLayout()}
                 fallback={
                   <div class="flex flex-col w-full gap-1.5">
-                    <div class="flex flex-wrap items-center justify-between gap-2 w-full">
-                      {renderHeaderLeftSlot()}
-
-                      <div class="flex-1 flex items-center justify-center min-w-0">
+                    <div class="grid grid-cols-[1fr_auto_1fr] items-center gap-2 w-full">
+                      <div class="flex min-w-0 items-center gap-2">
+                        {renderHeaderLeftSlot()}
                         {renderSessionHeaderIndicators()}
                       </div>
 
                       <div class="flex flex-wrap items-center justify-center gap-1">
-                        <Show when={!showingInfoView()}>
+                        <Show when={!showingInfoView() && !narrowHeaderLayout()}>
                           <IconButton
                             color="inherit"
                             onClick={handleChatSearchClick}
@@ -1023,55 +1043,85 @@ const InstanceShell2: Component<InstanceShellProps> = (props) => {
                         </span>
                       </div>
 
-                      <div class="flex-1 flex items-center justify-center min-w-0">
+                      <div class="flex flex-1 items-center justify-end gap-1 min-w-0">
                         <span
                           class={`status-indicator ${connectionStatusClass()}`}
                           aria-label={t("instanceShell.connection.ariaLabel", { status: connectionStatusLabel() })}
                         >
                           <span class="status-dot" />
                         </span>
+
+                        <Show when={!isPhoneLayout() && !narrowHeaderLayout()}>
+                          {renderPreviewToggleButton()}
+                        </Show>
+
+                        <Show when={showCompactFullscreenButton() && !narrowHeaderLayout()}>
+                          {renderPreviewToggleButton()}
+                        </Show>
+
+                        <Show when={rightDrawerState() === "floating-closed"}>
+                          <IconButton
+                            ref={setRightToggleButtonEl}
+                            color="inherit"
+                            onClick={handleRightAppBarButtonClick}
+                            aria-label={rightAppBarButtonLabel()}
+                            size="small"
+                            aria-expanded={rightDrawerState() !== "floating-closed"}
+                          >
+                            {rightAppBarButtonIcon()}
+                          </IconButton>
+                        </Show>
                       </div>
-
-                      <Show when={!isPhoneLayout()}>
-                        {renderPreviewToggleButton()}
-                      </Show>
-
-                      <Show when={isPhoneLayout() && !props.mobileFullscreenMode}>
-                        <IconButton
-                          color="inherit"
-                          onClick={props.onEnterMobileFullscreen}
-                          aria-label={t("instanceShell.fullscreen.enter")}
-                          title={t("instanceShell.fullscreen.enter")}
-                          size="small"
-                        >
-                          <Maximize2 class="w-5 h-5" aria-hidden="true" />
-                        </IconButton>
-                        {renderPreviewToggleButton()}
-                      </Show>
-
-                      <Show when={rightDrawerState() === "floating-closed"}>
-                        <IconButton
-                          ref={setRightToggleButtonEl}
-                          color="inherit"
-                          onClick={handleRightAppBarButtonClick}
-                          aria-label={rightAppBarButtonLabel()}
-                          size="small"
-                          aria-expanded={rightDrawerState() !== "floating-closed"}
-                        >
-                          {rightAppBarButtonIcon()}
-                        </IconButton>
-                      </Show>
                     </div>
 
-                    <div class="flex flex-wrap items-center justify-center gap-2 pb-1">
-                      <Show when={!showingInfoView()}>
-                        <ContextMeter
-                          usedTokens={tokenStats().used}
-                          availableTokens={tokenStats().avail}
-                          formatTokens={formatTokenTotal}
-                          usedLabel={t("instanceShell.metrics.usedLabel")}
-                          availableLabel={t("instanceShell.metrics.availableLabel")}
-                        />
+                    <div
+                      class={
+                        narrowHeaderLayout() || showCompactFullscreenButton()
+                          ? "grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2 pb-1"
+                          : "flex flex-wrap items-center justify-center gap-2 pb-1"
+                      }
+                    >
+                      <Show when={narrowHeaderLayout() || showCompactFullscreenButton()}>
+                        <div class="flex min-w-0 items-center justify-start">
+                          <Show when={narrowHeaderLayout() && !showingInfoView()}>
+                            <ActionOverflowMenu
+                              items={narrowHeaderMenuItems()}
+                              label={t("messageItem.actions.more")}
+                              triggerClass="message-action-button"
+                              minItems={1}
+                            />
+                          </Show>
+                        </div>
+                      </Show>
+
+                      <div class="flex items-center justify-center">
+                        <Show when={!showingInfoView()}>
+                          <ContextMeter
+                            usedTokens={tokenStats().used}
+                            availableTokens={tokenStats().avail}
+                            formatTokens={formatTokenTotal}
+                            usedLabel={t("instanceShell.metrics.usedLabel")}
+                            availableLabel={t("instanceShell.metrics.availableLabel")}
+                            centerValue={narrowHeaderLayout() || showCompactFullscreenButton()}
+                          />
+                        </Show>
+                      </div>
+
+                      <Show when={narrowHeaderLayout() || showCompactFullscreenButton()}>
+                        <div class="flex items-center justify-end gap-1">
+                          <Show when={showCompactFullscreenButton()}>
+                            <IconButton
+                              color="inherit"
+                              onClick={props.onEnterMobileFullscreen}
+                              aria-label={t("instanceShell.fullscreen.enter")}
+                              title={t("instanceShell.fullscreen.enter")}
+                              size="small"
+                              sx={{ width: 30, height: 30 }}
+                            >
+                              <Maximize2 class="w-5 h-5" aria-hidden="true" />
+                            </IconButton>
+                          </Show>
+                        </div>
                       </Show>
                     </div>
                 </div>

--- a/packages/ui/src/components/message-section.tsx
+++ b/packages/ui/src/components/message-section.tsx
@@ -1,5 +1,5 @@
 import { Show, createEffect, createMemo, createSignal, onCleanup, on, untrack } from "solid-js"
-import { ChevronDown, ChevronUp, MoreHorizontal, Pause, Search, Trash, X } from "lucide-solid"
+import { ArrowUpDown, ChevronDown, ChevronUp, MoreHorizontal, Pause, Search, Trash, X } from "lucide-solid"
 import Kbd from "./kbd"
 import BrandedEmptyState from "./branded-empty-state"
 import MessageBlock from "./message-block"
@@ -649,10 +649,13 @@ export default function MessageSection(props: MessageSectionProps) {
   const isActive = createMemo(() => props.isActive !== false)
   const [listApi, setListApi] = createSignal<VirtualFollowListApi | null>(null)
   const [listState, setListState] = createSignal<VirtualFollowListState | null>(null)
+  const [scrollControlsOpen, setScrollControlsOpen] = createSignal(false)
+  const [scrollControlsHoverSuppressed, setScrollControlsHoverSuppressed] = createSignal(false)
   const scrollButtonsCount = createMemo(() => listState()?.scrollButtonsCount() ?? 0)
 
   const [streamElement, setStreamElement] = createSignal<HTMLDivElement | undefined>()
   const [streamShellElement, setStreamShellElement] = createSignal<HTMLDivElement | undefined>()
+  let scrollControlsRef: HTMLDivElement | undefined
 
   // Only preferences should force a follow-token re-anchor. Message/session
   // revision churn at the end of a turn (message.updated, session.idle, etc.)
@@ -775,6 +778,40 @@ export default function MessageSection(props: MessageSectionProps) {
   function toggleHoldLongAssistantReplies() {
     updatePreferences({ holdLongAssistantReplies: !holdLongAssistantRepliesEnabled() })
   }
+
+  function closeScrollControls() {
+    setScrollControlsOpen(false)
+  }
+
+  function openScrollControlsFromTrigger(event: PointerEvent) {
+    event.preventDefault()
+    event.stopPropagation()
+    if (scrollControlsOpen()) return
+    setScrollControlsHoverSuppressed(false)
+    setScrollControlsOpen(true)
+  }
+
+  function runScrollControlAction(event: PointerEvent, action: () => void) {
+    event.preventDefault()
+    event.stopPropagation()
+    action()
+    setScrollControlsHoverSuppressed(event.pointerType !== "mouse")
+    closeScrollControls()
+  }
+
+  createEffect(() => {
+    if (!scrollControlsOpen()) return
+    if (typeof document === "undefined") return
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null
+      if (target && scrollControlsRef?.contains(target)) return
+      closeScrollControls()
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown)
+    onCleanup(() => document.removeEventListener("pointerdown", handlePointerDown))
+  })
 
   function isStreamingAssistantTextMessage(messageId: string | null | undefined) {
     if (!messageId) return false
@@ -1378,50 +1415,72 @@ export default function MessageSection(props: MessageSectionProps) {
           registerApi={(api) => setListApi(api)}
           registerState={(state) => setListState(state)}
           renderControls={(state, api) => (
-            <div class="message-scroll-button-wrapper">
+            <div
+              ref={(el) => {
+                scrollControlsRef = el
+              }}
+              class="message-scroll-controls"
+              data-open={scrollControlsOpen() ? "true" : "false"}
+              data-hover-suppressed={scrollControlsHoverSuppressed() ? "true" : "false"}
+              onPointerLeave={(event) => {
+                if (event.pointerType === "mouse") setScrollControlsHoverSuppressed(false)
+              }}
+            >
               <button
                 type="button"
-                class="message-scroll-button"
-                data-active={holdLongAssistantRepliesEnabled() ? "true" : "false"}
-                onClick={toggleHoldLongAssistantReplies}
-                aria-pressed={holdLongAssistantRepliesEnabled()}
-                aria-label={
-                  holdLongAssistantRepliesEnabled()
-                    ? t("messageSection.scroll.disableHoldAriaLabel")
-                    : t("messageSection.scroll.enableHoldAriaLabel")
-                }
-                title={
-                  holdLongAssistantRepliesEnabled()
-                    ? t("messageSection.scroll.disableHoldAriaLabel")
-                    : t("messageSection.scroll.enableHoldAriaLabel")
-                }
+                class="message-scroll-button message-scroll-controls-trigger"
+                onPointerUp={openScrollControlsFromTrigger}
+                aria-label={t("messageSection.scroll.showControlsAriaLabel")}
+                title={t("messageSection.scroll.showControlsAriaLabel")}
               >
-                <Pause class="message-scroll-icon message-scroll-icon--toggle w-4 h-4" aria-hidden="true" />
+                <ArrowUpDown class="message-scroll-icon w-4 h-4" aria-hidden="true" />
               </button>
-              <Show when={state.showScrollTopButton()}>
+
+              <div class="message-scroll-controls-expanded">
                 <button
                   type="button"
                   class="message-scroll-button"
-                  onClick={() => api.scrollToTop()}
-                  aria-label={t("messageSection.scroll.toFirstAriaLabel")}
+                  data-active={holdLongAssistantRepliesEnabled() ? "true" : "false"}
+                  onPointerUp={(event) => runScrollControlAction(event, toggleHoldLongAssistantReplies)}
+                  aria-pressed={holdLongAssistantRepliesEnabled()}
+                  aria-label={
+                    holdLongAssistantRepliesEnabled()
+                      ? t("messageSection.scroll.disableHoldAriaLabel")
+                      : t("messageSection.scroll.enableHoldAriaLabel")
+                  }
+                  title={
+                    holdLongAssistantRepliesEnabled()
+                      ? t("messageSection.scroll.disableHoldAriaLabel")
+                      : t("messageSection.scroll.enableHoldAriaLabel")
+                  }
                 >
-                  <span class="message-scroll-icon" aria-hidden="true">
-                    ↑
-                  </span>
+                  <Pause class="message-scroll-icon message-scroll-icon--toggle w-4 h-4" aria-hidden="true" />
                 </button>
-              </Show>
-              <Show when={state.showScrollBottomButton()}>
-                <button
-                  type="button"
-                  class="message-scroll-button"
-                  onClick={() => api.scrollToBottom({ suppressHold: true })}
-                  aria-label={t("messageSection.scroll.toLatestAriaLabel")}
-                >
-                  <span class="message-scroll-icon" aria-hidden="true">
-                    ↓
-                  </span>
-                </button>
-              </Show>
+                <Show when={state.showScrollTopButton()}>
+                  <button
+                    type="button"
+                    class="message-scroll-button"
+                    onPointerUp={(event) => runScrollControlAction(event, () => api.scrollToTop())}
+                    aria-label={t("messageSection.scroll.toFirstAriaLabel")}
+                  >
+                    <span class="message-scroll-icon" aria-hidden="true">
+                      ↑
+                    </span>
+                  </button>
+                </Show>
+                <Show when={state.showScrollBottomButton()}>
+                  <button
+                    type="button"
+                    class="message-scroll-button"
+                    onPointerUp={(event) => runScrollControlAction(event, () => api.scrollToBottom({ suppressHold: true }))}
+                    aria-label={t("messageSection.scroll.toLatestAriaLabel")}
+                  >
+                    <span class="message-scroll-icon" aria-hidden="true">
+                      ↓
+                    </span>
+                  </button>
+                </Show>
+              </div>
             </div>
           )}
           renderBeforeItems={() => (

--- a/packages/ui/src/components/prompt-input.tsx
+++ b/packages/ui/src/components/prompt-input.tsx
@@ -1,4 +1,4 @@
-import { Suspense, createEffect, createSignal, lazy, on, onCleanup, Show } from "solid-js"
+import { Suspense, createEffect, createSignal, lazy, on, onCleanup, onMount, Show } from "solid-js"
 import { ArrowBigUp, ArrowBigDown, Loader2, Mic, Paperclip, Volume2, X } from "lucide-solid"
 import ExpandButton from "./expand-button"
 import { clearAttachments, removeAttachment } from "../stores/attachments"
@@ -33,6 +33,13 @@ const log = getLogger("actions")
 const LazyUnifiedPicker = lazy(() => import("./unified-picker"))
 const DEFAULT_PROMPT_FIELD_HEIGHT = 104
 const MAX_PROMPT_FIELD_HEIGHT_RATIO = 0.6
+type SessionCenterWidthStep = "narrow" | "medium" | "wide"
+
+function getSessionCenterWidthStep(width: number): SessionCenterWidthStep {
+  if (width < 768) return "narrow"
+  if (width < 1280) return "medium"
+  return "wide"
+}
 
 type ResizeDragState = {
   pointerId: number
@@ -75,7 +82,9 @@ export default function PromptInput(props: PromptInputProps) {
   const [mode, setMode] = createSignal<PromptMode>("normal")
   const [expandState, setExpandState] = createSignal<ExpandState>("normal")
   const [inputHeight, setInputHeight] = createSignal<number | null>(null)
+  const [autoInputHeight, setAutoInputHeight] = createSignal<number | null>(null)
   const [isResizing, setIsResizing] = createSignal(false)
+  const [sessionCenterWidthStep, setSessionCenterWidthStep] = createSignal<SessionCenterWidthStep | null>(null)
   const [isFileBrowserOpen, setIsFileBrowserOpen] = createSignal(false)
   const SELECTION_INSERT_MAX_LENGTH = 2000
   const MAX_READABLE_PICKED_FILE_BYTES = 5 * 1024 * 1024
@@ -90,6 +99,54 @@ export default function PromptInput(props: PromptInputProps) {
       return t("promptInput.placeholder.shell")
     }
     return t("promptInput.placeholder.default")
+  }
+
+  const compactAutosizeEnabled = () => {
+    const widthStep = sessionCenterWidthStep()
+    return props.compactLayout && expandState() === "normal" && inputHeight() === null && widthStep === "narrow"
+  }
+
+  const effectiveInputHeight = () => inputHeight() ?? autoInputHeight()
+
+  const fieldHeightStyle = () => {
+    const height = effectiveInputHeight()
+    if (height === null) return undefined
+    if (inputHeight() !== null) return { height: `${height}px`, "min-height": `${height}px` }
+    return { height: `${height}px` }
+  }
+
+  const textareaHeightStyle = () => {
+    const height = effectiveInputHeight()
+    if (height === null) return undefined
+    const overflowY: "auto" | "hidden" = inputHeight() !== null || height >= DEFAULT_PROMPT_FIELD_HEIGHT ? "auto" : "hidden"
+    if (inputHeight() !== null) {
+      return {
+        height: `${height}px`,
+        "min-height": `${height}px`,
+        "overflow-y": overflowY,
+      }
+    }
+    return { height: `${height}px`, "overflow-y": overflowY }
+  }
+
+  const textareaRows = () => {
+    if (expandState() === "expanded") return props.compactLayout ? 10 : 15
+    return compactAutosizeEnabled() ? 2 : 3
+  }
+
+  const syncCompactAutoHeight = () => {
+    const textarea = textareaRef
+    if (!textarea || !compactAutosizeEnabled()) {
+      setAutoInputHeight(null)
+      return
+    }
+
+    const previousHeight = textarea.style.height
+    textarea.style.height = "auto"
+    const measuredHeight = textarea.scrollHeight
+    textarea.style.height = previousHeight
+    const nextHeight = Math.min(DEFAULT_PROMPT_FIELD_HEIGHT, measuredHeight)
+    setAutoInputHeight(nextHeight)
   }
 
   const promptState = usePromptState({
@@ -111,6 +168,31 @@ export default function PromptInput(props: PromptInputProps) {
     selectPreviousHistory,
     selectNextHistory,
   } = promptState
+
+  onMount(() => {
+    const sessionCenter = wrapperRef?.closest("[data-session-center-width]") as HTMLElement | null
+    if (!sessionCenter) return
+
+    const syncWidthStep = () => {
+      setSessionCenterWidthStep(getSessionCenterWidthStep(sessionCenter.getBoundingClientRect().width))
+    }
+
+    syncWidthStep()
+
+    if (typeof ResizeObserver === "undefined") return
+    const observer = new ResizeObserver(syncWidthStep)
+    observer.observe(sessionCenter)
+    onCleanup(() => observer.disconnect())
+  })
+
+  createEffect(() => {
+    prompt()
+    expandState()
+    inputHeight()
+    props.compactLayout
+    sessionCenterWidthStep()
+    queueMicrotask(syncCompactAutoHeight)
+  })
 
   const {
     attachments,
@@ -703,6 +785,7 @@ export default function PromptInput(props: PromptInputProps) {
       <div
         ref={wrapperRef}
         class={`prompt-input-wrapper relative ${isDragging() ? "border-2" : ""}`}
+        data-compact-layout={props.compactLayout ? "true" : undefined}
         style={
           isDragging()
             ? "border-color: var(--accent-primary); background-color: rgba(0, 102, 255, 0.05);"
@@ -736,8 +819,8 @@ export default function PromptInput(props: PromptInputProps) {
         <div class="prompt-input-main flex flex-1 flex-col">
           <div
             ref={fieldContainerRef}
-            class={`prompt-input-field-container ${expandState() === "expanded" ? "is-expanded" : ""} ${inputHeight() !== null ? "is-resized" : ""}`}
-            style={inputHeight() !== null ? { height: `${inputHeight()}px`, "min-height": `${inputHeight()}px` } : undefined}
+            class={`prompt-input-field-container ${expandState() === "expanded" ? "is-expanded" : ""} ${effectiveInputHeight() !== null ? "is-resized" : ""}`}
+            style={fieldHeightStyle()}
           >
             <div
               class={`prompt-resize-handle ${isResizing() ? "is-resizing" : ""}`}
@@ -752,7 +835,7 @@ export default function PromptInput(props: PromptInputProps) {
 
             <div
               class={`prompt-input-field ${expandState() === "expanded" ? "is-expanded" : ""}`}
-              style={inputHeight() !== null ? { height: `${inputHeight()}px`, "min-height": `${inputHeight()}px` } : undefined}
+              style={fieldHeightStyle()}
             >
               <textarea
                 ref={textareaRef}
@@ -766,12 +849,12 @@ export default function PromptInput(props: PromptInputProps) {
                 onFocus={() => setIsFocused(true)}
                 onBlur={() => setIsFocused(false)}
                 disabled={props.disabled}
-                rows={expandState() === "expanded" ? (props.compactLayout ? 10 : 15) : 3}
+                rows={textareaRows()}
                 spellcheck={false}
                 autocorrect="off"
                 autoCapitalize="off"
                 autocomplete="off"
-                style={inputHeight() !== null ? { height: `${inputHeight()}px`, "min-height": `${inputHeight()}px`, "overflow-y": "auto" } : undefined}
+                style={textareaHeightStyle()}
               />
               <div class="prompt-expand-button-inline">
                 <ExpandButton

--- a/packages/ui/src/components/prompt-input.tsx
+++ b/packages/ui/src/components/prompt-input.tsx
@@ -330,6 +330,11 @@ export default function PromptInput(props: PromptInputProps) {
     return Boolean(window.matchMedia?.("(pointer: coarse)")?.matches)
   }
 
+  const isTouchOnlyPointer = () => {
+    if (typeof window === "undefined") return false
+    return Boolean(window.matchMedia?.("(pointer: coarse)")?.matches && !window.matchMedia?.("(any-pointer: fine)")?.matches)
+  }
+
   createEffect(() => {
     // Scope global "type-to-focus" behavior to the active, visible prompt only.
     if (typeof document === "undefined") return
@@ -532,7 +537,9 @@ export default function PromptInput(props: PromptInputProps) {
         variant: "error",
       })
     } finally {
-      textareaRef?.focus()
+      if (!isTouchOnlyPointer()) {
+        textareaRef?.focus()
+      }
     }
   }
 

--- a/packages/ui/src/lib/i18n/messages/de/messaging.ts
+++ b/packages/ui/src/lib/i18n/messages/de/messaging.ts
@@ -20,6 +20,7 @@ export const messagingMessages = {
   "messageSection.loadError.reload": "Nachrichten neu laden",
   "messageSection.scroll.toFirstAriaLabel": "Zur ersten Nachricht scrollen",
   "messageSection.scroll.toLatestAriaLabel": "Zur neuesten Nachricht scrollen",
+  "messageSection.scroll.showControlsAriaLabel": "Scroll-Steuerung anzeigen",
   "messageSection.scroll.enableHoldAriaLabel": "Halten für lange Assistentenantworten aktivieren",
   "messageSection.scroll.disableHoldAriaLabel": "Halten für lange Assistentenantworten deaktivieren",
   "messageSection.quote.addAsQuote": "Als Zitat hinzufügen",

--- a/packages/ui/src/lib/i18n/messages/en/messaging.ts
+++ b/packages/ui/src/lib/i18n/messages/en/messaging.ts
@@ -20,6 +20,7 @@ export const messagingMessages = {
   "messageSection.loadError.reload": "Reload messages",
   "messageSection.scroll.toFirstAriaLabel": "Scroll to first message",
   "messageSection.scroll.toLatestAriaLabel": "Scroll to latest message",
+  "messageSection.scroll.showControlsAriaLabel": "Show scroll controls",
   "messageSection.scroll.enableHoldAriaLabel": "Enable hold for long assistant replies",
   "messageSection.scroll.disableHoldAriaLabel": "Disable hold for long assistant replies",
   "messageSection.quote.addAsQuote": "Add as quote",

--- a/packages/ui/src/lib/i18n/messages/es/messaging.ts
+++ b/packages/ui/src/lib/i18n/messages/es/messaging.ts
@@ -20,6 +20,7 @@ export const messagingMessages = {
   "messageSection.loadError.reload": "Recargar mensajes",
   "messageSection.scroll.toFirstAriaLabel": "Desplazarse al primer mensaje",
   "messageSection.scroll.toLatestAriaLabel": "Desplazarse al último mensaje",
+  "messageSection.scroll.showControlsAriaLabel": "Mostrar controles de desplazamiento",
   "messageSection.scroll.enableHoldAriaLabel": "Activar pausa para respuestas largas del asistente",
   "messageSection.scroll.disableHoldAriaLabel": "Desactivar pausa para respuestas largas del asistente",
   "messageSection.quote.addAsQuote": "Añadir como cita",

--- a/packages/ui/src/lib/i18n/messages/fr/messaging.ts
+++ b/packages/ui/src/lib/i18n/messages/fr/messaging.ts
@@ -20,6 +20,7 @@ export const messagingMessages = {
   "messageSection.loadError.reload": "Recharger les messages",
   "messageSection.scroll.toFirstAriaLabel": "Aller au premier message",
   "messageSection.scroll.toLatestAriaLabel": "Aller au dernier message",
+  "messageSection.scroll.showControlsAriaLabel": "Afficher les contrôles de défilement",
   "messageSection.scroll.enableHoldAriaLabel": "Activer le maintien pour les longues réponses de l'assistant",
   "messageSection.scroll.disableHoldAriaLabel": "Désactiver le maintien pour les longues réponses de l'assistant",
   "messageSection.quote.addAsQuote": "Ajouter en citation",

--- a/packages/ui/src/lib/i18n/messages/he/messaging.ts
+++ b/packages/ui/src/lib/i18n/messages/he/messaging.ts
@@ -20,6 +20,7 @@ export const messagingMessages = {
   "messageSection.loadError.reload": "טען הודעות מחדש",
   "messageSection.scroll.toFirstAriaLabel": "גלול להודעה הראשונה",
   "messageSection.scroll.toLatestAriaLabel": "גלול להודעה האחרונה",
+  "messageSection.scroll.showControlsAriaLabel": "הצג פקדי גלילה",
   "messageSection.scroll.enableHoldAriaLabel": "הפעל עצירה לתגובות עוזר ארוכות",
   "messageSection.scroll.disableHoldAriaLabel": "כבה עצירה לתגובות עוזר ארוכות",
   "messageSection.quote.addAsQuote": "הוסף כציטוט",

--- a/packages/ui/src/lib/i18n/messages/ja/messaging.ts
+++ b/packages/ui/src/lib/i18n/messages/ja/messaging.ts
@@ -20,6 +20,7 @@ export const messagingMessages = {
   "messageSection.loadError.reload": "メッセージを再読み込み",
   "messageSection.scroll.toFirstAriaLabel": "最初のメッセージへスクロール",
   "messageSection.scroll.toLatestAriaLabel": "最新のメッセージへスクロール",
+  "messageSection.scroll.showControlsAriaLabel": "スクロール操作を表示",
   "messageSection.scroll.enableHoldAriaLabel": "長いアシスタント返信の保持を有効にする",
   "messageSection.scroll.disableHoldAriaLabel": "長いアシスタント返信の保持を無効にする",
   "messageSection.quote.addAsQuote": "引用として追加",

--- a/packages/ui/src/lib/i18n/messages/ne/messaging.ts
+++ b/packages/ui/src/lib/i18n/messages/ne/messaging.ts
@@ -20,6 +20,7 @@ export const messagingMessages = {
   "messageSection.loadError.reload": "सन्देशहरू फेरि लोड गर्नुहोस्",
   "messageSection.scroll.toFirstAriaLabel": "पहिलो सन्देशमा जानुहोस्",
   "messageSection.scroll.toLatestAriaLabel": "भर्खरको सन्देशमा जानुहोस्",
+  "messageSection.scroll.showControlsAriaLabel": "स्क्रोल नियन्त्रणहरू देखाउनुहोस्",
   "messageSection.scroll.enableHoldAriaLabel": "लामो प्रतिक्रियाहरूको लागि होल्ड सक्षम गर्नुहोस्",
   "messageSection.scroll.disableHoldAriaLabel": "लामो प्रतिक्रियाहरूको लागि होल्ड अक्षम गर्नुहोस्",
   "messageSection.quote.addAsQuote": "उद्धरणको रूपमा थप्नुहोस्",

--- a/packages/ui/src/lib/i18n/messages/ru/messaging.ts
+++ b/packages/ui/src/lib/i18n/messages/ru/messaging.ts
@@ -20,6 +20,7 @@ export const messagingMessages = {
   "messageSection.loadError.reload": "Перезагрузить сообщения",
   "messageSection.scroll.toFirstAriaLabel": "Прокрутить к первому сообщению",
   "messageSection.scroll.toLatestAriaLabel": "Прокрутить к последнему сообщению",
+  "messageSection.scroll.showControlsAriaLabel": "Показать элементы прокрутки",
   "messageSection.scroll.enableHoldAriaLabel": "Включить удержание для длинных ответов ассистента",
   "messageSection.scroll.disableHoldAriaLabel": "Выключить удержание для длинных ответов ассистента",
   "messageSection.quote.addAsQuote": "Добавить как цитату",

--- a/packages/ui/src/lib/i18n/messages/zh-Hans/messaging.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-Hans/messaging.ts
@@ -20,6 +20,7 @@ export const messagingMessages = {
   "messageSection.loadError.reload": "重新加载消息",
   "messageSection.scroll.toFirstAriaLabel": "滚动到第一条消息",
   "messageSection.scroll.toLatestAriaLabel": "滚动到最新消息",
+  "messageSection.scroll.showControlsAriaLabel": "显示滚动控件",
   "messageSection.scroll.enableHoldAriaLabel": "启用长助手回复保持",
   "messageSection.scroll.disableHoldAriaLabel": "禁用长助手回复保持",
   "messageSection.quote.addAsQuote": "作为引用添加",

--- a/packages/ui/src/styles/messaging/message-section.css
+++ b/packages/ui/src/styles/messaging/message-section.css
@@ -215,6 +215,35 @@
   align-items: flex-end;
 }
 
+.message-scroll-controls {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  width: 2.75rem;
+  min-height: 2.75rem;
+}
+
+.message-scroll-controls-expanded {
+  position: absolute;
+  inset-inline-end: 0;
+  bottom: 0;
+  display: none;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: flex-end;
+}
+
+.message-scroll-controls:not([data-hover-suppressed="true"]):hover .message-scroll-controls-trigger,
+.message-scroll-controls[data-open="true"] .message-scroll-controls-trigger {
+  display: none;
+}
+
+.message-scroll-controls:not([data-hover-suppressed="true"]):hover .message-scroll-controls-expanded,
+.message-scroll-controls[data-open="true"] .message-scroll-controls-expanded {
+  display: flex;
+}
+
 .message-scroll-button {
   @apply inline-flex items-center justify-center;
   width: 2.75rem;

--- a/packages/ui/src/styles/messaging/prompt-input.css
+++ b/packages/ui/src/styles/messaging/prompt-input.css
@@ -47,6 +47,13 @@
 
 .prompt-input-wrapper {
   --prompt-input-compact-height: 104px;
+  --prompt-input-inline-control-size: 1.75rem;
+  --prompt-input-expand-control-top: 0.5rem;
+  --prompt-input-clear-control-top: 2.5rem;
+  --prompt-input-inline-control-bottom-gap: 0.5rem;
+  --prompt-input-compact-control-fit-height: calc(
+    var(--prompt-input-clear-control-top) + var(--prompt-input-inline-control-size) + var(--prompt-input-inline-control-bottom-gap)
+  );
   @apply grid items-stretch;
   grid-template-columns: minmax(0, 1fr) 72px 64px;
   gap: 0;
@@ -211,14 +218,14 @@
 
 .prompt-clear-button-inline {
   position: absolute;
-  top: 2.5rem;
+  top: var(--prompt-input-clear-control-top);
   inset-inline-end: 0.5rem;
   z-index: 2;
 }
 
 .prompt-expand-button-inline {
   position: absolute;
-  top: 0.5rem;
+  top: var(--prompt-input-expand-control-top);
   inset-inline-end: 0.5rem;
   z-index: 2;
 }
@@ -473,27 +480,17 @@
   }
 }
 
-.session-center-column[data-session-center-width="medium"] .prompt-input-wrapper,
-.session-center-column[data-session-center-width="narrow"] .prompt-input-wrapper {
-  min-height: var(--prompt-input-compact-height);
-}
-
-.session-center-column[data-session-center-width="medium"] .prompt-input-field-container,
-.session-center-column[data-session-center-width="narrow"] .prompt-input-field-container {
-  min-height: var(--prompt-input-compact-height);
-  height: var(--prompt-input-compact-height);
-}
-
-.session-center-column[data-session-center-width="medium"] .prompt-input-field,
-.session-center-column[data-session-center-width="narrow"] .prompt-input-field {
-  height: var(--prompt-input-compact-height);
-}
-
 .session-center-column[data-session-center-width="medium"] .prompt-input-field-container.is-expanded,
 .session-center-column[data-session-center-width="medium"] .prompt-input-field.is-expanded,
 .session-center-column[data-session-center-width="narrow"] .prompt-input-field-container.is-expanded,
 .session-center-column[data-session-center-width="narrow"] .prompt-input-field.is-expanded {
   height: auto;
+}
+
+.session-center-column[data-session-center-width="narrow"] .prompt-input-wrapper[data-compact-layout="true"] .prompt-input-field-container,
+.session-center-column[data-session-center-width="narrow"] .prompt-input-wrapper[data-compact-layout="true"] .prompt-input-field,
+.session-center-column[data-session-center-width="narrow"] .prompt-input-wrapper[data-compact-layout="true"] .prompt-input {
+  min-height: var(--prompt-input-compact-control-fit-height);
 }
 
 .session-center-column[data-session-center-width="narrow"] .prompt-input-wrapper {

--- a/packages/ui/src/styles/messaging/virtual-follow-list.css
+++ b/packages/ui/src/styles/messaging/virtual-follow-list.css
@@ -45,8 +45,8 @@
 
 .virtual-follow-list-controls-container {
   position: absolute;
-  bottom: calc(var(--space-md) + env(safe-area-inset-bottom, 0px));
-  inset-inline-end: var(--space-md);
+  bottom: calc(var(--space-sm) + env(safe-area-inset-bottom, 0px));
+  inset-inline-end: calc(var(--space-sm) + env(safe-area-inset-right, 0px));
   z-index: 20;
 }
 

--- a/packages/ui/src/styles/panels/tabs.css
+++ b/packages/ui/src/styles/panels/tabs.css
@@ -165,7 +165,7 @@
 }
 
 .new-tab-button {
-  @apply inline-flex items-center justify-center w-8 h-8 rounded-md transition-colors;
+  @apply inline-flex items-center justify-center w-8 h-8 flex-shrink-0 rounded-md transition-colors;
   background-color: var(--new-tab-bg);
   color: var(--new-tab-text);
 }

--- a/packages/ui/src/styles/panels/tabs.css
+++ b/packages/ui/src/styles/panels/tabs.css
@@ -19,6 +19,8 @@
 .tab-scroll {
   @apply w-full;
   overflow-x: auto;
+  touch-action: pan-x;
+  -webkit-overflow-scrolling: touch;
 }
 
 .tab-strip {


### PR DESCRIPTION
## Summary
- Refine narrow session header controls, including overflow menu placement and centered command/context controls.
- Autosize the narrow prompt input while preserving desktop/hybrid behavior and avoiding mobile keyboard refocus flicker.
- Improve tab bar behavior at small widths by preventing action button shrink and disabling drag-reorder on touch-only devices.
- Includes earlier branch changes for message scroll control collapse and square-corner styling documentation.

## Validation
- npm run typecheck --workspace @codenomad/ui