### PR TITLE
fix(ui): keep message-part tool output auto-scroll synced

### DIFF
--- a/packages/ui/src/components/message-part.tsx
+++ b/packages/ui/src/components/message-part.tsx
@@ -277,6 +277,7 @@ export default function MessagePart(props: MessagePartProps) {
             toolCallId={props.part?.id}
             instanceId={props.instanceId}
             sessionId={props.sessionId}
+            onContentRendered={props.onRendered}
           />
         </Suspense>
       </Match>


### PR DESCRIPTION
## Summary
- Pass MessagePart render notifications into ToolCall as onContentRendered.
- Ensures streaming bash output rendered through the generic MessagePart path notifies the outer VirtualFollowList when content grows.

## Validation
- npm run typecheck --workspace @codenomad/ui