### PR TITLE
fix(server): prevent crash (Sessions stop responding)

### DIFF
--- a/packages/server/src/background-processes/manager.ts
+++ b/packages/server/src/background-processes/manager.ts
@@ -599,8 +599,16 @@ export class BackgroundProcessManager {
     }
 
     if (completion.removeAfterFinalize) {
-      await this.removeFromIndex(workspaceId, record.id)
-      await this.removeProcessDir(workspaceId, record.id)
+      try {
+        await this.removeFromIndex(workspaceId, record.id)
+      } catch {
+        // Workspace may have been deleted, ignore error
+      }
+      try {
+        await this.removeProcessDir(workspaceId, record.id)
+      } catch {
+        // Workspace may have been deleted, ignore error
+      }
 
       this.deps.eventBus.publish({
         type: "instance.event",
@@ -610,9 +618,14 @@ export class BackgroundProcessManager {
       return
     }
 
-    await this.upsertIndex(workspaceId, record)
-    record.outputSizeBytes = await this.getOutputSize(workspaceId, record.id)
-    this.publishUpdate(workspaceId, record)
+    try {
+      await this.upsertIndex(workspaceId, record)
+      record.outputSizeBytes = await this.getOutputSize(workspaceId, record.id)
+      this.publishUpdate(workspaceId, record)
+    } catch (error) {
+      // Workspace may have been deleted, log and continue
+      this.deps.logger.warn({ err: error, workspaceId, processId: record.id }, "Failed to finalize background process record - workspace may have been deleted")
+    }
   }
 
   private shouldSendCompletionPrompt(record: PersistedBackgroundProcess, completion: ProcessCompletion) {


### PR DESCRIPTION
## Problem

Sessions stop responding and become unusable. When you try to interact with them, the server hangs because the BackgroundProcessManager throws:
```
Error: Workspace not found
    at BackgroundProcessManager.finalizeRecord
```

**What happens:**
1. You use CodeNomad normally, sessions work fine
2. Sessions stop responding on their own (become "dead")
3. When you try to use a dead session, it doesn't work
4. Server hangs trying to finalize background processes for workspaces that were automatically cleaned up

**Why workspaces get deleted:**
- Server restarts (PM2, manual, crashes)
- CodeNomad's internal workspace cleanup
- Session timeout/expiration

The bug: `finalizeRecord()` doesn't handle missing workspaces gracefully.

## Impact

**Before fix:**
- Dead sessions are visible but completely unresponsive
- Server hangs when trying to interact with them
- No error message - session just doesn't work
- User experience: sessions randomly stop working

**After fix:**
- Server handles missing workspaces gracefully
- Dead sessions work again ✅ (user verified: "Ya pude usar una sesión muerta")
- Background processes finalize silently when workspace is gone
- No more hanging/unresponsive sessions

## Solution

Wrap finalization operations in try-catch blocks:
- `removeFromIndex()` - lines 602-606
- `removeProcessDir()` - lines 607-611  
- `upsertIndex()` + `publishUpdate()` - lines 621-627

When workspace is missing, operations fail silently with logging instead of throwing and hanging the server.

## Testing

- ✅ TypeScript compilation clean
- ✅ Server runs stable (10+ minutes without hanging)
- ✅ **User confirmed**: dead sessions that were unresponsive now work
- ✅ Code review: error handling follows existing patterns in codebase

## Why This Bug is Frustrating

1. Sessions **randomly stop working** - not user-triggered
2. **No clear cause** - happens after server restarts or internal cleanup
3. **No error message** - just silent unresponsiveness
4. Sessions **look fine** in the UI but are actually broken
5. The fix is simple but the symptom is very confusing

The root cause: background processes try to finalize after their workspace is automatically cleaned up, causing uncaught exceptions that hang the server.