### PR TITLE
fix(ui): remove scope=project from session list requests

### DIFF
--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -53,10 +53,17 @@ import { clearCacheForSession } from "../lib/global-cache"
 import { getLogger } from "../lib/logger"
 import { requestData } from "../lib/opencode-api"
 import { getRootClient } from "./opencode-client"
-import { getWorktreeSlugForSession, migrateLegacyWorktreeMapToSessionMetadata, pruneStaleLegacyWorktreeMapEntries, removeLegacyParentSessionMapping, setWorktreeSlugForParentSession } from "./worktrees"
+import {
+  getWorktreeSlugForSession,
+  getWorktrees,
+  migrateLegacyWorktreeMapToSessionMetadata,
+  pruneStaleLegacyWorktreeMapEntries,
+  removeLegacyParentSessionMapping,
+  setWorktreeSlugForParentSession,
+} from "./worktrees"
 import { getOpenCodeWorkspaceIdForSession } from "./opencode-workspaces"
 import { hydrateSessionMetadataWithClient } from "./session-metadata"
-import { PROJECT_SESSION_LIST_LIMIT, buildProjectSessionListOptions } from "./session-list-options"
+import { PROJECT_SESSION_LIST_LIMIT, buildProjectSessionListOptions, filterProjectScopedSessions } from "./session-list-options"
 
 const log = getLogger("api")
 
@@ -142,7 +149,11 @@ async function fetchV2Sessions(instanceId: string, options: V2SessionListOptions
   const client = getRootClient(instanceId)
   const listOptions = buildProjectSessionListOptions(options)
   const data = await requestData<SessionListResponse>(client.session.list(listOptions), "session.list")
-  return { data }
+  const allowedDirectories = [options.directory, ...getWorktrees(instanceId).map((worktree) => worktree.directory)]
+
+  return {
+    data: filterProjectScopedSessions(data, allowedDirectories),
+  }
 }
 
 function getV2SessionItems(response: ProjectSessionListResponse): SDKSession[] {
@@ -208,7 +219,7 @@ async function fetchSessions(instanceId: string, options?: { reset?: boolean }):
   try {
     const sessionListOptions = instance.folder ? { directory: instance.folder } : {}
 
-    log.info("session.list", { instanceId, limit: PROJECT_SESSION_LIST_LIMIT, directory: sessionListOptions.directory })
+    log.info("session.list", { instanceId, limit: PROJECT_SESSION_LIST_LIMIT, directory: sessionListOptions.directory, scope: "project" })
     const response = await fetchV2Sessions(instanceId, sessionListOptions)
 
     let statusById: Record<string, any> = {}

--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -208,7 +208,7 @@ async function fetchSessions(instanceId: string, options?: { reset?: boolean }):
   try {
     const sessionListOptions = instance.folder ? { directory: instance.folder } : {}
 
-    log.info("session.list", { instanceId, limit: PROJECT_SESSION_LIST_LIMIT, directory: sessionListOptions.directory, scope: "project" })
+    log.info("session.list", { instanceId, limit: PROJECT_SESSION_LIST_LIMIT, directory: sessionListOptions.directory })
     const response = await fetchV2Sessions(instanceId, sessionListOptions)
 
     let statusById: Record<string, any> = {}

--- a/packages/ui/src/stores/session-list-options.ts
+++ b/packages/ui/src/stores/session-list-options.ts
@@ -7,7 +7,6 @@ type ProjectSessionListInput = {
 
 export type ProjectSessionListOptions = ProjectSessionListInput & {
   limit: typeof PROJECT_SESSION_LIST_LIMIT
-  scope: "project"
 }
 
 export function buildProjectSessionListOptions(options: ProjectSessionListInput): ProjectSessionListOptions {
@@ -15,6 +14,5 @@ export function buildProjectSessionListOptions(options: ProjectSessionListInput)
     ...(options.directory ? { directory: options.directory } : {}),
     ...(options.search ? { search: options.search } : {}),
     limit: PROJECT_SESSION_LIST_LIMIT,
-    scope: "project",
   }
 }

--- a/packages/ui/src/stores/session-list-options.ts
+++ b/packages/ui/src/stores/session-list-options.ts
@@ -7,6 +7,22 @@ type ProjectSessionListInput = {
 
 export type ProjectSessionListOptions = ProjectSessionListInput & {
   limit: typeof PROJECT_SESSION_LIST_LIMIT
+  scope: "project"
+}
+
+type SessionDirectorySource = {
+  directory?: string | null
+}
+
+function normalizeSessionDirectory(directory: string | null | undefined): string {
+  const trimmed = directory?.trim()
+  if (!trimmed) return ""
+
+  const slashNormalized = trimmed.replace(/\\/g, "/").replace(/\/+$/, "")
+  const comparable = slashNormalized || "/"
+  const isWindowsPath = /^[A-Za-z]:\//.test(comparable) || comparable.startsWith("//") || trimmed.includes("\\")
+
+  return isWindowsPath ? comparable.toLowerCase() : comparable
 }
 
 export function buildProjectSessionListOptions(options: ProjectSessionListInput): ProjectSessionListOptions {
@@ -14,5 +30,19 @@ export function buildProjectSessionListOptions(options: ProjectSessionListInput)
     ...(options.directory ? { directory: options.directory } : {}),
     ...(options.search ? { search: options.search } : {}),
     limit: PROJECT_SESSION_LIST_LIMIT,
+    scope: "project",
   }
+}
+
+export function filterProjectScopedSessions<T extends SessionDirectorySource>(
+  sessions: T[],
+  allowedDirectories: Array<string | null | undefined>,
+): T[] {
+  const allowed = new Set(allowedDirectories.map(normalizeSessionDirectory).filter(Boolean))
+  if (allowed.size === 0) return sessions
+
+  return sessions.filter((session) => {
+    const directory = normalizeSessionDirectory(session.directory)
+    return !directory || allowed.has(directory)
+  })
 }

--- a/packages/ui/src/stores/session-pagination.test.ts
+++ b/packages/ui/src/stores/session-pagination.test.ts
@@ -5,15 +5,15 @@ import { applySessionPage, getDefaultSessionPaginationState } from "./session-pa
 import { PROJECT_SESSION_LIST_LIMIT, buildProjectSessionListOptions } from "./session-list-options.ts"
 
 describe("project session list loading", () => {
-  it("builds a one-shot project-scoped request without pagination params", () => {
+  it("builds a one-shot directory-scoped request without pagination params", () => {
     const options = buildProjectSessionListOptions({ directory: "/tmp/project", search: "worktree" })
 
     assert.deepEqual(options, {
       directory: "/tmp/project",
       search: "worktree",
       limit: PROJECT_SESSION_LIST_LIMIT,
-      scope: "project",
     })
+    assert.equal("scope" in options, false)
     assert.equal("start" in options, false)
     assert.equal("cursor" in options, false)
   })

--- a/packages/ui/src/stores/session-pagination.test.ts
+++ b/packages/ui/src/stores/session-pagination.test.ts
@@ -2,20 +2,49 @@ import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 
 import { applySessionPage, getDefaultSessionPaginationState } from "./session-pagination-model.ts"
-import { PROJECT_SESSION_LIST_LIMIT, buildProjectSessionListOptions } from "./session-list-options.ts"
+import { PROJECT_SESSION_LIST_LIMIT, buildProjectSessionListOptions, filterProjectScopedSessions } from "./session-list-options.ts"
 
 describe("project session list loading", () => {
-  it("builds a one-shot directory-scoped request without pagination params", () => {
+  it("builds a one-shot project-scoped request without pagination params", () => {
     const options = buildProjectSessionListOptions({ directory: "/tmp/project", search: "worktree" })
 
     assert.deepEqual(options, {
       directory: "/tmp/project",
       search: "worktree",
       limit: PROJECT_SESSION_LIST_LIMIT,
+      scope: "project",
     })
-    assert.equal("scope" in options, false)
     assert.equal("start" in options, false)
     assert.equal("cursor" in options, false)
+  })
+
+  it("filters project-scoped results to the root and known worktree directories", () => {
+    const sessions = [
+      { id: "root", directory: "/repo" },
+      { id: "worktree", directory: "/repo/.codenomad/worktrees/feature" },
+      { id: "sibling", directory: "/other" },
+      { id: "unknown" },
+    ]
+
+    assert.deepEqual(
+      filterProjectScopedSessions(sessions, ["/repo", "/repo/.codenomad/worktrees/feature"]).map((session) => session.id),
+      ["root", "worktree", "unknown"],
+    )
+  })
+
+  it("normalizes Windows paths when filtering project-scoped results", () => {
+    const sessions = [
+      { id: "root", directory: String.raw`C:\Repo` },
+      { id: "worktree", directory: "c:/repo/.codenomad/worktrees/feature/" },
+      { id: "other", directory: String.raw`C:\Other` },
+    ]
+
+    assert.deepEqual(
+      filterProjectScopedSessions(sessions, ["c:/repo/", String.raw`C:\Repo\.codenomad\worktrees\feature`]).map(
+        (session) => session.id,
+      ),
+      ["root", "worktree"],
+    )
   })
 
   it("marks the loaded session list complete because the API does not paginate", () => {


### PR DESCRIPTION
## Problem

PR #565 (commit e29c3a08) added `scope=project` to session list requests to avoid pagination limits. With OpenCode 1.17.x, the `/session` endpoint ignores the `directory` filter when `scope=project` is present and returns **all** sessions from the global SQLite database instead.

This makes the same session appear in every project tab. Deleting a session from one tab deletes it from the shared DB, affecting all of them.

## Reproduction

```
# Pick any opencode workspace port
PORT=4096
curl -s -u "codenomad:$PASSWORD" \
  "http://127.0.0.1:$PORT/session?directory=/home/user/project-a&scope=project" \
  | jq 'length'
# Returns sessions from project-b too — should only return project-a's

curl -s -u "codenomad:$PASSWORD" \
  "http://127.0.0.1:$PORT/session?directory=/home/user/project-a" \
  | jq 'length'
# Correct: only project-a's sessions
```

Related: anomalyco/opencode#33113

## Fix

Drop `scope: "project"` from `buildProjectSessionListOptions()`. The `directory` parameter alone correctly filters sessions to the requested folder on OpenCode 1.17.x. `scope: "project"` can be reintroduced once the backend respects `directory` alongside it.

## Validation

- `directory=/test` → 1 session (correct)
- `directory=/idm` → 1 session (correct)
- Same session no longer appears in multiple project tabs
- Deleting a session in one project no longer affects others