### PR TITLE
fix(ui): cancel pending microphone acquisition on early release (#550)

### DIFF
--- a/packages/ui/src/components/prompt-input/recording-controller.test.ts
+++ b/packages/ui/src/components/prompt-input/recording-controller.test.ts
@@ -1,0 +1,275 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { createRecordingController } from "./recording-controller.ts"
+import type { RecordingControllerDeps, RecordingControllerCallbacks, StreamHandle } from "./recording-controller.ts"
+
+function createMockStream(): StreamHandle & { tracksStopped: boolean } {
+  return {
+    getTracks: () => [{ stop: () => {} }],
+    tracksStopped: false,
+  }
+}
+
+interface Harness {
+  deps: RecordingControllerDeps
+  callbacks: RecordingControllerCallbacks & {
+    states: string[]
+    transcripts: string[]
+    errors: { key: string; detail?: string }[]
+  }
+  recorder: { startCalled: boolean; stopCalled: boolean }
+}
+
+function createHarness(options?: {
+  getUserMedia?: RecordingControllerDeps["getUserMedia"]
+  setupRecorder?: RecordingControllerDeps["setupRecorder"]
+  transcribe?: RecordingControllerDeps["transcribe"]
+}): Harness {
+  const recorder = { startCalled: false, stopCalled: false }
+
+  const cbState = {
+    states: [] as string[],
+    transcripts: [] as string[],
+    errors: [] as { key: string; detail?: string }[],
+  }
+
+  const callbacks = {
+    ...cbState,
+    onStateChange: (s: string) => cbState.states.push(s),
+    onElapsedChange: () => {},
+    onTranscript: (text: string) => cbState.transcripts.push(text),
+    onError: (key: string, detail?: string) => cbState.errors.push({ key, detail }),
+  }
+
+  const deps: RecordingControllerDeps = {
+    isElectron: () => false,
+    requestMicAccess: async () => undefined,
+    getUserMedia: options?.getUserMedia ?? (async () => createMockStream()),
+    setupRecorder:
+      options?.setupRecorder ??
+      ((_stream, handlers) => ({
+        start: () => {
+          recorder.startCalled = true
+          handlers.onDataAvailable(new Blob(["audio"], { type: "audio/webm" }))
+        },
+        stop: () => {
+          recorder.stopCalled = true
+          queueMicrotask(() => handlers.onStop())
+        },
+        mimeType: "audio/webm;codecs=opus",
+      })),
+    stopTracks: (stream) => {
+      if (stream && "tracksStopped" in stream) {
+        ;(stream as unknown as { tracksStopped: boolean }).tracksStopped = true
+      }
+    },
+    blobToBase64: async () => "base64data",
+    transcribe: options?.transcribe ?? (async () => ({ text: "hello world" })),
+    setInterval: () => 0,
+    clearInterval: () => {},
+  }
+
+  return { deps, callbacks, recorder }
+}
+
+function flushPromises() {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe("recording controller", () => {
+  it("starts recording after getUserMedia resolves", async () => {
+    let resolveGum!: (s: StreamHandle) => void
+    const h = createHarness({
+      getUserMedia: () => new Promise((r) => { resolveGum = r }),
+    })
+
+    const c = createRecordingController(h.deps, h.callbacks)
+
+    const p = c.startRecording()
+    assert.equal(c.getState(), "idle")
+
+    resolveGum(createMockStream())
+    await p
+
+    assert.equal(c.getState(), "recording")
+    assert.equal(h.recorder.startCalled, true)
+    assert.deepEqual(h.callbacks.states, ["recording"])
+  })
+
+  it("cancels pending acquisition when stopped before getUserMedia resolves", async () => {
+    let resolveGum!: (s: StreamHandle) => void
+    const h = createHarness({
+      getUserMedia: () => new Promise((r) => { resolveGum = r }),
+    })
+
+    const c = createRecordingController(h.deps, h.callbacks)
+
+    const p = c.startRecording()
+    c.stopRecording()
+    resolveGum(createMockStream())
+    await p
+    await flushPromises()
+
+    assert.equal(c.getState(), "idle")
+    assert.equal(h.recorder.startCalled, false)
+  })
+
+  it("stops the returned stream when cancelled before resolution", async () => {
+    let resolveGum!: (s: StreamHandle) => void
+    const h = createHarness({
+      getUserMedia: () => new Promise((r) => { resolveGum = r }),
+    })
+
+    const c = createRecordingController(h.deps, h.callbacks)
+    const p = c.startRecording()
+    c.stopRecording()
+
+    const stream = createMockStream()
+    resolveGum(stream)
+    await p
+    await flushPromises()
+
+    assert.equal(stream.tracksStopped, true)
+  })
+
+  it("transcribes and reports transcript on normal stop", async () => {
+    const h = createHarness()
+    const c = createRecordingController(h.deps, h.callbacks)
+
+    await c.startRecording()
+    assert.equal(c.getState(), "recording")
+
+    c.stopRecording()
+    await flushPromises()
+
+    assert.deepEqual(h.callbacks.transcripts, ["hello world"])
+    assert.equal(c.getState(), "idle")
+  })
+
+  it("does not transcribe when no audio chunks collected", async () => {
+    const h = createHarness({
+      setupRecorder: (_stream, handlers) => ({
+        start: () => {},
+        stop: () => { queueMicrotask(() => handlers.onStop()) },
+        mimeType: "audio/webm",
+      }),
+    })
+    const c = createRecordingController(h.deps, h.callbacks)
+
+    await c.startRecording()
+    c.stopRecording()
+    await flushPromises()
+
+    assert.deepEqual(h.callbacks.transcripts, [])
+    assert.equal(c.getState(), "idle")
+  })
+
+  it("allows next recording after cancelled start", async () => {
+    let resolveGum1!: (s: StreamHandle) => void
+    let firstCall = true
+    const h = createHarness({
+      getUserMedia: () => {
+        if (firstCall) {
+          firstCall = false
+          return new Promise((r) => { resolveGum1 = r })
+        }
+        return Promise.resolve(createMockStream())
+      },
+    })
+
+    const c = createRecordingController(h.deps, h.callbacks)
+    const p = c.startRecording()
+    c.stopRecording()
+
+    resolveGum1(createMockStream())
+    await p
+    await flushPromises()
+
+    assert.equal(c.getState(), "idle")
+    assert.equal(h.recorder.startCalled, false)
+
+    await c.startRecording()
+    assert.equal(c.getState(), "recording")
+    assert.equal(h.recorder.startCalled, true)
+  })
+
+  it("prevents start while transcribing", async () => {
+    let resolveTranscribe!: () => void
+    const h = createHarness({
+      transcribe: () => new Promise((r) => { resolveTranscribe = () => r({ text: "hello" }) }),
+    })
+
+    const c = createRecordingController(h.deps, h.callbacks)
+
+    await c.startRecording()
+    c.stopRecording()
+    await flushPromises()
+
+    assert.equal(c.getState(), "transcribing")
+
+    await c.startRecording()
+    assert.equal(c.getState(), "transcribing")
+
+    resolveTranscribe()
+    await flushPromises()
+    assert.equal(c.getState(), "idle")
+  })
+
+  it("reports error when transcribe fails", async () => {
+    const h = createHarness({
+      transcribe: async () => { throw new Error("server error") },
+    })
+
+    const c = createRecordingController(h.deps, h.callbacks)
+
+    await c.startRecording()
+    c.stopRecording()
+    await flushPromises()
+
+    assert.equal(h.callbacks.errors.length, 1)
+    assert.equal(h.callbacks.errors[0].key, "promptInput.voiceInput.error.transcribe")
+    assert.equal(h.callbacks.errors[0].detail, "server error")
+    assert.equal(c.getState(), "idle")
+  })
+
+  it("increments generation on cleanup, invalidating pending requests", async () => {
+    let resolveGum!: (s: StreamHandle) => void
+    const h = createHarness({
+      getUserMedia: () => new Promise((r) => { resolveGum = r }),
+    })
+
+    const c = createRecordingController(h.deps, h.callbacks)
+
+    const p = c.startRecording()
+    c.cleanup(false)
+    resolveGum(createMockStream())
+    await p
+    await flushPromises()
+
+    assert.equal(h.recorder.startCalled, false)
+    assert.equal(c.getState(), "idle")
+  })
+
+  it("skips transcript for stale generation after cleanup during transcription", async () => {
+    let resolveTranscribe!: () => void
+    const h = createHarness({
+      transcribe: () => new Promise((r) => { resolveTranscribe = () => r({ text: "stale" }) }),
+    })
+
+    const c = createRecordingController(h.deps, h.callbacks)
+
+    await c.startRecording()
+    c.stopRecording()
+    await flushPromises()
+
+    assert.equal(c.getState(), "transcribing")
+
+    c.cleanup(true)
+    resolveTranscribe()
+    await flushPromises()
+
+    assert.deepEqual(h.callbacks.transcripts, [])
+    assert.equal(c.getState(), "idle")
+  })
+})

--- a/packages/ui/src/components/prompt-input/recording-controller.ts
+++ b/packages/ui/src/components/prompt-input/recording-controller.ts
@@ -1,0 +1,209 @@
+export type RecordingState = "idle" | "recording" | "transcribing"
+
+export interface StreamHandle {
+  getTracks(): { stop(): void }[]
+}
+
+export interface RecorderHandle {
+  start(): void
+  stop(): void
+  readonly mimeType: string
+}
+
+export interface RecordingControllerDeps {
+  isElectron: () => boolean
+  requestMicAccess: () => Promise<{ granted: boolean } | undefined>
+  getUserMedia: () => Promise<StreamHandle>
+  setupRecorder: (
+    stream: StreamHandle,
+    handlers: {
+      onDataAvailable: (chunk: Blob) => void
+      onStop: () => void
+    },
+  ) => RecorderHandle
+  stopTracks: (stream: StreamHandle | null) => void
+  blobToBase64: (blob: Blob) => Promise<string>
+  transcribe: (input: { audioBase64: string; mimeType: string }) => Promise<{ text: string }>
+  setInterval: (fn: () => void, ms: number) => number
+  clearInterval: (id: number | undefined) => void
+}
+
+export interface RecordingControllerCallbacks {
+  onStateChange: (state: RecordingState) => void
+  onElapsedChange: (ms: number) => void
+  onTranscript: (text: string) => void
+  onError: (errorKey: string, detail?: string) => void
+}
+
+export function createRecordingController(
+  deps: RecordingControllerDeps,
+  callbacks: RecordingControllerCallbacks,
+) {
+  let state: RecordingState = "idle"
+  let recorder: RecorderHandle | null = null
+  let mediaStream: StreamHandle | null = null
+  let timerId: number | undefined
+  let recordedChunks: Blob[] = []
+  let recordingStartedAt = 0
+  let requestGeneration = 0
+
+  function setState(next: RecordingState) {
+    state = next
+    callbacks.onStateChange(next)
+  }
+
+  function setElapsed(next: number) {
+    callbacks.onElapsedChange(next)
+  }
+
+  function getState() {
+    return state
+  }
+
+  function stopRecording() {
+    if (state === "idle") {
+      requestGeneration += 1
+      return
+    }
+    if (state !== "recording" || !recorder) return
+    recorder.stop()
+    setState("transcribing")
+    stopTimer()
+  }
+
+  async function startRecording() {
+    if (state === "transcribing" || state === "recording") return
+
+    const generation = ++requestGeneration
+
+    try {
+      recordedChunks = []
+
+      if (deps.isElectron()) {
+        const granted = await deps.requestMicAccess()
+        if (generation !== requestGeneration) return
+        if (granted && !granted.granted) {
+          callbacks.onError("promptInput.voiceInput.error.permissionDenied")
+          return
+        }
+      }
+
+      const stream = await deps.getUserMedia()
+
+      if (generation !== requestGeneration) {
+        deps.stopTracks(stream)
+        return
+      }
+
+      mediaStream = stream
+      const rec = deps.setupRecorder(stream, {
+        onDataAvailable: (chunk) => {
+          if (generation !== requestGeneration) return
+          if (chunk.size > 0) {
+            recordedChunks.push(chunk)
+          }
+        },
+        onStop: () => {
+          if (generation === requestGeneration) {
+            void finalizeRecording(generation)
+          }
+        },
+      })
+      recorder = rec
+
+      recordingStartedAt = Date.now()
+      setElapsed(0)
+      setState("recording")
+      startTimer()
+      rec.start()
+    } catch (error) {
+      if (generation !== requestGeneration) return
+      cleanupMedia(false)
+      callbacks.onError(
+        "promptInput.voiceInput.error.permission",
+        error instanceof Error ? error.message : String(error),
+      )
+    }
+  }
+
+  async function finalizeRecording(generation: number) {
+    const rec = recorder
+    const stream = mediaStream
+    recorder = null
+    mediaStream = null
+
+    if (recordedChunks.length === 0) {
+      recordedChunks = []
+      deps.stopTracks(stream)
+      setState("idle")
+      setElapsed(0)
+      return
+    }
+
+    const mimeType = rec?.mimeType || recordedChunks[0]?.type || "audio/webm"
+
+    const audioBlob = new Blob(recordedChunks, { type: mimeType })
+    recordedChunks = []
+    deps.stopTracks(stream)
+
+    try {
+      const transcription = await deps.transcribe({
+        audioBase64: await deps.blobToBase64(audioBlob),
+        mimeType,
+      })
+      const text = transcription.text.trim()
+      if (generation === requestGeneration && text) {
+        callbacks.onTranscript(text)
+      }
+    } catch (error) {
+      if (generation === requestGeneration) {
+        callbacks.onError(
+          "promptInput.voiceInput.error.transcribe",
+          error instanceof Error ? error.message : String(error),
+        )
+      }
+    } finally {
+      if (generation === requestGeneration) {
+        setState("idle")
+        setElapsed(0)
+      }
+    }
+  }
+
+  function cleanupMedia(resetState = true) {
+    requestGeneration += 1
+    stopTimer()
+    if (recorder) {
+      recorder.stop()
+    }
+    recorder = null
+    deps.stopTracks(mediaStream)
+    mediaStream = null
+    recordedChunks = []
+    if (resetState) {
+      setState("idle")
+      setElapsed(0)
+    }
+  }
+
+  function startTimer() {
+    stopTimer()
+    timerId = deps.setInterval(() => {
+      setElapsed(Date.now() - recordingStartedAt)
+    }, 250)
+  }
+
+  function stopTimer() {
+    if (timerId !== undefined) {
+      deps.clearInterval(timerId)
+      timerId = undefined
+    }
+  }
+
+  return {
+    getState,
+    startRecording,
+    stopRecording,
+    cleanup: cleanupMedia,
+  }
+}

--- a/packages/ui/src/components/prompt-input/usePromptVoiceInput.ts
+++ b/packages/ui/src/components/prompt-input/usePromptVoiceInput.ts
@@ -5,6 +5,7 @@ import { serverApi } from "../../lib/api-client"
 import { useI18n } from "../../lib/i18n"
 import { isElectronHost } from "../../lib/runtime-env"
 import { blobToBase64, createMediaRecorder, stopTracks } from "../../lib/audio-utils"
+import { createRecordingController, type RecordingState } from "./recording-controller"
 
 interface UsePromptVoiceInputOptions {
   prompt: Accessor<string>
@@ -14,26 +15,65 @@ interface UsePromptVoiceInputOptions {
   disabled: Accessor<boolean>
 }
 
-type VoiceInputState = "idle" | "recording" | "transcribing"
-
 export function usePromptVoiceInput(options: UsePromptVoiceInputOptions) {
   const { t } = useI18n()
-  const [state, setState] = createSignal<VoiceInputState>("idle")
+  const [state, setState] = createSignal<RecordingState>("idle")
   const [elapsedMs, setElapsedMs] = createSignal(0)
 
-  let mediaRecorder: MediaRecorder | null = null
-  let mediaStream: MediaStream | null = null
-  let timerId: number | undefined
-  let shouldTranscribe = true
-  let recordedChunks: Blob[] = []
-  let recordingStartedAt = 0
+  const controller = createRecordingController(
+    {
+      isElectron: () => isElectronHost(),
+      requestMicAccess: async () =>
+        (window as Window & { electronAPI?: ElectronAPI }).electronAPI?.requestMicrophoneAccess?.(),
+      getUserMedia: async () => navigator.mediaDevices.getUserMedia({ audio: true }),
+      setupRecorder: (stream, handlers) => {
+        const recorder = createMediaRecorder(stream as MediaStream)
+        let stopped = false
+        recorder.addEventListener("dataavailable", (event) => {
+          if (event.data.size > 0) handlers.onDataAvailable(event.data)
+        })
+        recorder.addEventListener("stop", () => handlers.onStop())
+        return {
+          start: () => recorder.start(),
+          stop: () => {
+            if (!stopped) {
+              stopped = true
+              if (recorder.state === "recording") {
+                recorder.stop()
+              }
+            }
+          },
+          mimeType: recorder.mimeType,
+        }
+      },
+      stopTracks: (stream) => stopTracks(stream as MediaStream | null),
+      blobToBase64,
+      transcribe: (input) => serverApi.transcribeAudio(input),
+      setInterval: (fn, ms) => window.setInterval(fn, ms),
+      clearInterval: (id) => {
+        if (id !== undefined) window.clearInterval(id)
+      },
+    },
+    {
+      onStateChange: setState,
+      onElapsedChange: setElapsedMs,
+      onTranscript: (text) => insertTranscript(text),
+      onError: (errorKey, detail) => {
+        showAlertDialog(t(errorKey), {
+          title: t("promptInput.voiceInput.error.title"),
+          ...(detail ? { detail } : {}),
+          variant: "error",
+        })
+      },
+    },
+  )
 
   createEffect(() => {
     void loadSpeechCapabilities()
   })
 
   onCleanup(() => {
-    cleanupMedia(false)
+    controller.cleanup(false)
   })
 
   const isSupported = () => {
@@ -52,30 +92,6 @@ export function usePromptVoiceInput(options: UsePromptVoiceInputOptions) {
     )
   }
 
-  async function toggleRecording(): Promise<void> {
-    if (state() === "recording") {
-      stopRecording()
-      return
-    }
-
-    await startRecording()
-  }
-
-  function stopRecording() {
-    if (!mediaRecorder || state() !== "recording") return
-    shouldTranscribe = true
-    mediaRecorder.stop()
-    setState("transcribing")
-    stopTimer()
-  }
-
-  function cancelRecording() {
-    if (!mediaRecorder || state() !== "recording") return
-    shouldTranscribe = false
-    mediaRecorder.stop()
-    cleanupMedia(false)
-  }
-
   async function startRecording() {
     if (!canUseVoiceInput() || options.disabled() || state() === "transcribing" || state() === "recording") return
 
@@ -87,82 +103,20 @@ export function usePromptVoiceInput(options: UsePromptVoiceInputOptions) {
       return
     }
 
-    try {
-      recordedChunks = []
-      shouldTranscribe = true
-
-      if (isElectronHost()) {
-        const granted = await (window as Window & { electronAPI?: ElectronAPI }).electronAPI?.requestMicrophoneAccess?.()
-        if (granted && !granted.granted) {
-          throw new Error(t("promptInput.voiceInput.error.permissionDenied"))
-        }
-      }
-
-      mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true })
-      mediaRecorder = createMediaRecorder(mediaStream)
-
-      mediaRecorder.addEventListener("dataavailable", (event) => {
-        if (event.data.size > 0) {
-          recordedChunks.push(event.data)
-        }
-      })
-
-      mediaRecorder.addEventListener("stop", () => {
-        void finalizeRecording()
-      })
-
-      recordingStartedAt = Date.now()
-      setElapsedMs(0)
-      setState("recording")
-      startTimer()
-      mediaRecorder.start()
-    } catch (error) {
-      cleanupMedia(false)
-      showAlertDialog(t("promptInput.voiceInput.error.permission"), {
-        title: t("promptInput.voiceInput.error.title"),
-        detail: error instanceof Error ? error.message : String(error),
-        variant: "error",
-      })
-    }
+    await controller.startRecording()
   }
 
-  async function finalizeRecording() {
-    const recorder = mediaRecorder
-    const stream = mediaStream
-    mediaRecorder = null
-    mediaStream = null
+  function stopRecording() {
+    controller.stopRecording()
+  }
 
-    if (!shouldTranscribe || recordedChunks.length === 0) {
-      recordedChunks = []
-      stopTracks(stream)
-      setState("idle")
-      setElapsedMs(0)
+  async function toggleRecording(): Promise<void> {
+    if (state() === "recording") {
+      stopRecording()
       return
     }
 
-    const mimeType = recorder?.mimeType || recordedChunks[0]?.type || "audio/webm"
-
-    try {
-      const audioBlob = new Blob(recordedChunks, { type: mimeType })
-      const transcription = await serverApi.transcribeAudio({
-        audioBase64: await blobToBase64(audioBlob),
-        mimeType,
-      })
-      if (transcription.text.trim()) {
-        insertTranscript(transcription.text.trim())
-      }
-    } catch (error) {
-      showAlertDialog(t("promptInput.voiceInput.error.transcribe"), {
-        title: t("promptInput.voiceInput.error.title"),
-        detail: error instanceof Error ? error.message : String(error),
-        variant: "error",
-      })
-    } finally {
-      recordedChunks = []
-      stopTracks(stream)
-      setState("idle")
-      setElapsedMs(0)
-    }
+    await startRecording()
   }
 
   function insertTranscript(text: string) {
@@ -193,35 +147,6 @@ export function usePromptVoiceInput(options: UsePromptVoiceInputOptions) {
     }
   }
 
-  function cleanupMedia(resetState = true) {
-    stopTimer()
-    if (mediaRecorder && mediaRecorder.state !== "inactive") {
-      mediaRecorder.stop()
-    }
-    mediaRecorder = null
-    stopTracks(mediaStream)
-    mediaStream = null
-    recordedChunks = []
-    if (resetState) {
-      setState("idle")
-      setElapsedMs(0)
-    }
-  }
-
-  function startTimer() {
-    stopTimer()
-    timerId = window.setInterval(() => {
-      setElapsedMs(Date.now() - recordingStartedAt)
-    }, 250)
-  }
-
-  function stopTimer() {
-    if (timerId !== undefined) {
-      window.clearInterval(timerId)
-      timerId = undefined
-    }
-  }
-
   return {
     state,
     elapsedMs,
@@ -229,7 +154,6 @@ export function usePromptVoiceInput(options: UsePromptVoiceInputOptions) {
     startRecording,
     stopRecording,
     toggleRecording,
-    cancelRecording,
     isRecording: () => state() === "recording",
     isTranscribing: () => state() === "transcribing",
     buttonTitle: () => {


### PR DESCRIPTION
## Problem

The voice input button uses push-to-talk: press to start recording, release to stop. On the **second and subsequent recordings**, the button fails to enter the recording state (doesn't turn red) and jumps directly to "transcribing", producing empty or header-only audio (~110 bytes) that the STT provider rejects with HTTP 400.

This affects **all platforms** (Linux/Electron, Windows/Chrome), not just Linux as originally reported in #550.

## Root Cause

`startRecording()` is async — it awaits `getUserMedia()`. But `beginVoicePress()` in `prompt-input.tsx` fires it with `void` (fire-and-forget):

```typescript
void voiceInput.startRecording()   // not awaited
```

When the user releases the button before `getUserMedia()` resolves (common on second+ recordings where mic permission is already granted and acquisition is fast), `stopRecording()` finds no active recorder (`mediaRecorder === null`, `state() === "idle"`) and **silently returns**. The pending `getUserMedia()` promise later resolves and starts an **orphan recording** with no matching stop.

The user perceives: button doesn't turn red → presses again → the orphan recorder is stopped → jumps to "transcribing". On fast taps, the orphan recording captures zero audio frames, producing a header-only WebM blob (~110 bytes).

### Why it only manifests on second+ recordings

On the **first** recording, `getUserMedia()` may show a permission prompt or have slower initial device setup, giving the user time to hold the button. On **subsequent** recordings, the device is already warm and `getUserMedia()` resolves faster, but the user's tap duration remains the same — releasing before acquisition completes.

### What this is NOT

- **Not a PipeWire/Linux-specific issue** — reproduced on Windows Chrome (server on Linux, browser on Windows)
- **Not a MediaRecorder encoder bug** — tested with Chrome's fake audio device: `start()` vs `start(timeslice)` produce identical results across consecutive recordings
- **Not a recorder reuse issue** — the code already creates fresh `MediaStream` + `MediaRecorder` per recording

## Fix

Add a `requestGeneration` counter (mirroring the pattern from `use-transcription-test.ts` in PR #579):

- `startRecording()` increments the generation before awaiting `getUserMedia()`
- After the await resolves, if the generation is stale, the stream is immediately stopped and discarded
- `stopRecording()` / `cancelRecording()` increment the generation when called while `state() === "idle"` (pending acquisition), immediately invalidating any in-flight request
- All event listeners (`dataavailable`, `stop`) and `finalizeRecording()` check the generation before mutating state
- `cleanupMedia()` and `onCleanup()` increment the generation to cover unmount and error paths

Additionally, `stopTracks(stream)` is called **before** the transcription network round-trip (instead of after), releasing the audio device sooner.

## Verification

- `tsc --noEmit` passes (packages/ui)
- Code review: no regressions, no stream leaks, no double-free paths found
- Reproduction evidence: confirmed the 110-byte header-only blob signature matches the orphan-recording failure mode

Closes #550