### PR TITLE
feat(ui): support bracket math delimiters

### DIFF
--- a/docs/superpowers/specs/2026-07-14-bracket-math-delimiters-design.md
+++ b/docs/superpowers/specs/2026-07-14-bracket-math-delimiters-design.md
@@ -1,0 +1,38 @@
+# Bracket Math Delimiters Design
+
+## Goal
+
+Support inline `\(...\)` and display `\[...\]` math in CodeNomad Markdown while preserving existing `$...$` and `$$...$$` behavior. No unrelated Markdown changes.
+
+## Approach
+
+Keep `marked-katex-extension` as owner of dollar-delimited math. Add two small parser-native Marked extensions in `packages/ui/src/lib/markdown.ts`:
+
+- Inline rule: recognize `\(...\)` and render with KaTeX `displayMode: false`.
+- Block rule: recognize `\[...\]` and render with KaTeX `displayMode: true`.
+
+Both rules will use `katex.renderToString()` with the same error policy as the existing integration: `throwOnError: false` and `strict: "ignore"`. Parser-native rules avoid source rewriting, ignore fenced/code content through Marked's normal lexer flow, and preserve unmatched delimiters as plain Markdown text.
+
+## Integration
+
+Register the two rules beside the existing `markedKatex(...)` registration in `setupRenderer()`. Existing renderer setup, syntax highlighting, HTML handling, styles, and component APIs remain unchanged. No new runtime dependency is needed because KaTeX is already a direct UI dependency.
+
+## Edge Cases
+
+- `\\(` and `\\[` remain escaped literal text rather than opening math.
+- Inline math must close with `\)` before a line break.
+- Display math may span lines and must close with `\]`.
+- Empty or unmatched delimiter pairs remain text.
+- Existing dollar delimiter boundary behavior remains controlled by `marked-katex-extension` with `nonStandard: true`.
+
+## Tests
+
+Add focused Markdown rendering regression tests covering:
+
+- `\(x^2\)` renders inline KaTeX.
+- `\[x^2\]` renders display KaTeX, including multiline content.
+- `$x^2$` and `$$x^2$$` still render.
+- Delimiters inside inline and fenced code remain literal.
+- Escaped, empty, and unmatched bracket delimiters remain literal.
+
+Run the repository's confirmed UI test command, UI typecheck, and inspect the final diff.

--- a/packages/ui/src/lib/markdown.test.ts
+++ b/packages/ui/src/lib/markdown.test.ts
@@ -18,6 +18,18 @@ describe("renderMarkdown bracket math delimiters", () => {
     assert.match(html, /<span class="katex-display">/)
   })
 
+  it("splits prose around adjacent single-line and multiline display math", async () => {
+    const singleLine = await renderMarkdown("before\n\\[x^2\\]\nafter", { suppressHighlight: true })
+    const multiline = await renderMarkdown("before\n\\[\nx^2\n\\]\nafter", { suppressHighlight: true })
+
+    for (const html of [singleLine, multiline]) {
+      assert.match(html, /^<p>before<\/p>\n<span class="katex-display">/)
+      assert.match(html, /<p>after<\/p>\n$/)
+      assert.doesNotMatch(html, /<br>/)
+      assert.doesNotMatch(html, /katex-error/)
+    }
+  })
+
   it("preserves dollar-delimited math", async () => {
     const inline = await renderMarkdown("$x^2$", { suppressHighlight: true })
     const display = await renderMarkdown("$$x^2$$", { suppressHighlight: true })
@@ -47,11 +59,16 @@ describe("renderMarkdown bracket math delimiters", () => {
   it("does not hijack bracket delimiters in inline code or dollar math", async () => {
     const code = await renderMarkdown("`\\[x\\]`", { suppressHighlight: true })
     const multilineCode = await renderMarkdown("`a\n\\[x\\]`", { suppressHighlight: true })
+    const multilineDoubleCode = await renderMarkdown("``a\n\\[x\\]``", { suppressHighlight: true })
+    const escapedBackticks = await renderMarkdown("\\`a\n\\[x\\]\nafter\\`", { suppressHighlight: true })
     const inlineDollar = await renderMarkdown(String.raw`$\[x\]$`, { suppressHighlight: true })
     const displayDollar = await renderMarkdown(String.raw`$$\[x\]$$`, { suppressHighlight: true })
 
     assert.equal(code, '<p><code class="inline-code">\\[x\\]</code></p>\n')
     assert.equal(multilineCode, '<p><code class="inline-code">a \\[x\\]</code></p>\n')
+    assert.equal(multilineDoubleCode, '<p><code class="inline-code">a \\[x\\]</code></p>\n')
+    assert.match(escapedBackticks, /<span class="katex-display">/)
+    assert.doesNotMatch(escapedBackticks, /katex-error/)
     assert.match(inlineDollar, /^<p><span class="katex-error"/)
     assert.doesNotMatch(inlineDollar, /katex-display/)
     assert.match(displayDollar, /^<p><span class="katex-error"/)
@@ -74,5 +91,24 @@ describe("renderMarkdown bracket math delimiters", () => {
     assert.doesNotMatch(html, /class="katex/)
     assert.match(html, /\\\(x\^2\\\)/)
     assert.match(html, /\\\[x\^2\]/)
+  })
+
+  it("leaves line-start and mid-paragraph invalid display delimiters literal", async () => {
+    const html = await renderMarkdown("\\\\[x\\]\n\\[\]\n\\[x\na \\[\] b\na \\[x", { suppressHighlight: true })
+
+    assert.doesNotMatch(html, /class="katex/)
+    assert.doesNotMatch(html, /katex-error/)
+  })
+
+  it("does not split paragraphs for whitespace-only display delimiters", async () => {
+    const singleLine = await renderMarkdown("before\n\\[   \\]\nafter", { suppressHighlight: true })
+    const multiline = await renderMarkdown("before\n\\[\n \t\n\\]\nafter", { suppressHighlight: true })
+
+    for (const html of [singleLine, multiline]) {
+      assert.doesNotMatch(html, /class="katex/)
+      assert.doesNotMatch(html, /katex-error/)
+      assert.match(html, /^<p>before<br>/)
+      assert.match(html, /after<\/p>\n$/)
+    }
   })
 })

--- a/packages/ui/src/lib/markdown.test.ts
+++ b/packages/ui/src/lib/markdown.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { renderMarkdown } from "./markdown"
+
+describe("renderMarkdown bracket math delimiters", () => {
+  it("renders inline bracket math", async () => {
+    const html = await renderMarkdown(String.raw`\(x^2\)`, { suppressHighlight: true })
+
+    assert.match(html, /<span class="katex">/)
+    assert.match(html, /x/)
+  })
+
+  it("renders multiline display bracket math", async () => {
+    const html = await renderMarkdown(String.raw`\[x^
+2\]`, { suppressHighlight: true })
+
+    assert.match(html, /<span class="katex-display">/)
+  })
+
+  it("preserves dollar-delimited math", async () => {
+    const inline = await renderMarkdown("$x^2$", { suppressHighlight: true })
+    const display = await renderMarkdown("$$x^2$$", { suppressHighlight: true })
+
+    assert.match(inline, /<span class="katex">/)
+    assert.match(display, /<span class="katex-display">/)
+  })
+
+  it("leaves bracket delimiters literal in code", async () => {
+    const inline = await renderMarkdown("`\\(x^2\\)`", { suppressHighlight: true })
+    const fenced = await renderMarkdown("```text\n\\[x^2\\]\n```", { suppressHighlight: true })
+
+    assert.doesNotMatch(inline, /class="katex/)
+    assert.match(inline, /\\\(x\^2\\\)/)
+    assert.doesNotMatch(fenced, /class="katex/)
+    assert.match(fenced, /\\\[x\^2\\\]/)
+  })
+
+  it("does not split incomplete or empty display delimiters", async () => {
+    const empty = await renderMarkdown(String.raw`a \[\] b`, { suppressHighlight: true })
+    const unmatched = await renderMarkdown(String.raw`a \[x`, { suppressHighlight: true })
+
+    assert.equal(empty, "<p>a [] b</p>\n")
+    assert.equal(unmatched, "<p>a [x</p>\n")
+  })
+
+  it("does not hijack bracket delimiters in inline code or dollar math", async () => {
+    const code = await renderMarkdown("`\\[x\\]`", { suppressHighlight: true })
+    const multilineCode = await renderMarkdown("`a\n\\[x\\]`", { suppressHighlight: true })
+    const inlineDollar = await renderMarkdown(String.raw`$\[x\]$`, { suppressHighlight: true })
+    const displayDollar = await renderMarkdown(String.raw`$$\[x\]$$`, { suppressHighlight: true })
+
+    assert.equal(code, '<p><code class="inline-code">\\[x\\]</code></p>\n')
+    assert.equal(multilineCode, '<p><code class="inline-code">a \\[x\\]</code></p>\n')
+    assert.match(inlineDollar, /^<p><span class="katex-error"/)
+    assert.doesNotMatch(inlineDollar, /katex-display/)
+    assert.match(displayDollar, /^<p><span class="katex-error"/)
+  })
+
+  it("renders bracket display math after dollar display or bare dollars", async () => {
+    const afterDollarDisplay = await renderMarkdown("$$\nx\n$$\n\n\\[y\\]", { suppressHighlight: true })
+    const afterBareDollars = await renderMarkdown("plain $$\n\n\\[x\\]", { suppressHighlight: true })
+
+    assert.equal((afterDollarDisplay.match(/class="katex-display"/g) ?? []).length, 2)
+    assert.match(afterBareDollars, /class="katex-display"/)
+    assert.doesNotMatch(afterBareDollars, /<br>/)
+  })
+
+  it("leaves escaped, empty, and unmatched bracket delimiters literal", async () => {
+    const html = await renderMarkdown(String.raw`\\(x^2\) \\[x^2\] \(\) \[\] \(x^2 \[x^2`, {
+      suppressHighlight: true,
+    })
+
+    assert.doesNotMatch(html, /class="katex/)
+    assert.match(html, /\\\(x\^2\\\)/)
+    assert.match(html, /\\\[x\^2\]/)
+  })
+})

--- a/packages/ui/src/lib/markdown.ts
+++ b/packages/ui/src/lib/markdown.ts
@@ -1,5 +1,6 @@
-import { marked } from "marked"
+import { marked, type Tokens } from "marked"
 import markedKatex from "marked-katex-extension"
+import katex from "katex"
 import { getLogger } from "./logger"
 import { tGlobal } from "./i18n"
 import type { Highlighter } from "shiki/bundle/full"
@@ -385,6 +386,73 @@ function setupRenderer(isDark: boolean) {
     nonStandard: true,
     strict: "ignore",
   }))
+
+  marked.use({
+    extensions: [
+      {
+        name: "inlineBracketMath",
+        level: "inline",
+        // Find unescaped inline bracket math without scanning beyond the next line.
+        start(src: string) {
+          return src.search(/(?<!\\)\\\(/)
+        },
+        // Tokenize non-empty inline math delimited by \( and \).
+        tokenizer(src: string) {
+          const escaped = /^\\\\\(([^\n]+?)\\\)/.exec(src)
+          if (escaped) {
+            return {
+              type: "inlineBracketMath",
+              raw: escaped[0],
+              text: escaped[0],
+              escaped: true,
+            }
+          }
+
+          const match = /^\\\(([^\n]+?)\\\)/.exec(src)
+          if (!match) return
+
+          return {
+            type: "inlineBracketMath",
+            raw: match[0],
+            text: match[1],
+          }
+        },
+        // Render inline bracket math with the existing KaTeX error policy.
+        renderer(token: Tokens.Generic) {
+          if (token.escaped) return escapeHtml(token.raw)
+
+          return katex.renderToString(token.text, {
+            throwOnError: false,
+            strict: "ignore",
+            displayMode: false,
+          })
+        },
+      },
+      {
+        name: "blockBracketMath",
+        level: "block",
+        // Tokenize non-empty display math delimited by \[ and \], across lines.
+        tokenizer(src: string) {
+          const match = /^\\\[([\s\S]+?)\\\]/.exec(src)
+          if (!match) return
+
+          return {
+            type: "blockBracketMath",
+            raw: match[0],
+            text: match[1],
+          }
+        },
+        // Render display bracket math with the existing KaTeX error policy.
+        renderer(token: Tokens.Generic) {
+          return katex.renderToString(token.text, {
+            throwOnError: false,
+            strict: "ignore",
+            displayMode: true,
+          })
+        },
+      },
+    ],
+  })
 
   const renderer = new marked.Renderer()
 

--- a/packages/ui/src/lib/markdown.ts
+++ b/packages/ui/src/lib/markdown.ts
@@ -1,4 +1,4 @@
-import { marked, type Tokens } from "marked"
+import { marked, type Tokenizer, type Tokens } from "marked"
 import markedKatex from "marked-katex-extension"
 import katex from "katex"
 import { getLogger } from "./logger"
@@ -18,10 +18,36 @@ let rendererSetup = false
 let shikiModulePromise: Promise<typeof import("shiki/bundle/full")> | null = null
 let bundledLanguagesCache: typeof import("shiki/bundle/full")["bundledLanguages"] | null = null
 
-// Math rendering is handled by marked-katex-extension (registered in setupRenderer).
-// Delimiter rules, boundaries, CJK punctuation, and block/inline rendering are
-// all delegated to the maintained extension so we avoid ~200 lines of fragile
-// hand-rolled tokenizer code.
+// Dollar-delimited math is handled by marked-katex-extension; bracket delimiters
+// use the small parser-native rules registered in setupRenderer.
+
+const BRACKET_DISPLAY_MATH_RULE = /^\\\[([\s\S]+?)\\\]/
+
+// Find a complete line-start display delimiter while skipping inline code spans.
+function findBracketDisplayStart(src: string): number {
+  const codeRule = marked.Lexer.rules.inline.gfm.code
+  let index = 0
+
+  while (index < src.length) {
+    const code = codeRule.exec(src.slice(index))
+    let precedingBackslashes = 0
+    for (let cursor = index - 1; src[cursor] === "\\"; cursor--) {
+      precedingBackslashes++
+    }
+    if (code?.index === 0 && precedingBackslashes % 2 === 0) {
+      index += code[0].length
+      continue
+    }
+
+    const bracketMath = BRACKET_DISPLAY_MATH_RULE.exec(src.slice(index))
+    if ((index === 0 || src[index - 1] === "\n") && bracketMath?.[1].trim()) {
+      return index
+    }
+    index++
+  }
+
+  return -1
+}
 
 const ALLOWED_RAW_HTML_TAGS = new Set([
   "a",
@@ -433,8 +459,8 @@ function setupRenderer(isDark: boolean) {
         level: "block",
         // Tokenize non-empty display math delimited by \[ and \], across lines.
         tokenizer(src: string) {
-          const match = /^\\\[([\s\S]+?)\\\]/.exec(src)
-          if (!match) return
+          const match = BRACKET_DISPLAY_MATH_RULE.exec(src)
+          if (!match || !match[1].trim()) return
 
           return {
             type: "blockBracketMath",
@@ -452,6 +478,25 @@ function setupRenderer(isDark: boolean) {
         },
       },
     ],
+    tokenizer: {
+      // Split a paragraph before a valid display delimiter so the block lexer can consume it.
+      paragraph(this: Tokenizer, src: string) {
+        const cap = this.rules.block.paragraph.exec(src)
+        if (!cap) return false
+
+        const bracketStart = findBracketDisplayStart(cap[0])
+        if (bracketStart <= 0) return false
+
+        const raw = cap[0].slice(0, bracketStart)
+        const text = raw.endsWith("\n") ? raw.slice(0, -1) : raw
+        return {
+          type: "paragraph",
+          raw,
+          text,
+          tokens: this.lexer.inline(text),
+        }
+      },
+    },
   })
 
   const renderer = new marked.Renderer()


### PR DESCRIPTION
## Why

LaTeX content commonly uses `\(...\)` and `\[...\]`, but CodeNomad only recognizes `$...$` and `$$...$$` through `marked-katex-extension`.

## What

- Add parser-native Marked rules for inline `\(...\)` and display `\[...\]` formulas.
- Preserve existing dollar math, code spans and fences, escaped delimiters, and unmatched text.
- Add focused regression tests and document the delimiter design.