### PR TITLE
feat(windows): update CodeNomad from the in-app notification

### DIFF
--- a/packages/tauri-app/src-tauri/src/main.rs
+++ b/packages/tauri-app/src-tauri/src/main.rs
@@ -9,6 +9,7 @@ mod desktop_event_transport;
 mod linux_tls;
 mod managed_node;
 mod shutdown;
+mod windows_update;
 
 use cli_manager::{CliProcessManager, CliStatus};
 use desktop_event_transport::{
@@ -656,7 +657,8 @@ fn main() {
             client_state::client_state_set_restore_enabled,
             client_state::client_state_clear,
             client_state::client_state_renderer_flushed,
-            client_state::client_state_navigation_flushed
+            client_state::client_state_navigation_flushed,
+            windows_update::install_stable_update
         ])
         .on_menu_event(|app_handle, event| {
             match event.id().0.as_str() {

--- a/packages/tauri-app/src-tauri/src/windows_update.rs
+++ b/packages/tauri-app/src-tauri/src/windows_update.rs
@@ -1,0 +1,29 @@
+use std::process::Command;
+
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+
+#[tauri::command]
+pub fn install_stable_update() -> Result<(), String> {
+    let mut command = Command::new("winget");
+    command.args([
+        "upgrade",
+        "--exact",
+        "--id",
+        "NeuralNomadsAI.CodeNomad",
+        "--source",
+        "winget",
+        "--silent",
+        "--accept-source-agreements",
+        "--accept-package-agreements",
+        "--disable-interactivity",
+    ]);
+
+    #[cfg(windows)]
+    command.creation_flags(0x08000000);
+
+    command
+        .spawn()
+        .map(|_| ())
+        .map_err(|err| format!("Unable to start the WinGet update: {err}"))
+}

--- a/packages/tauri-app/src-tauri/src/windows_update.rs
+++ b/packages/tauri-app/src-tauri/src/windows_update.rs
@@ -4,26 +4,35 @@ use std::process::Command;
 use std::os::windows::process::CommandExt;
 
 #[tauri::command]
-pub fn install_stable_update() -> Result<(), String> {
-    let mut command = Command::new("winget");
-    command.args([
-        "upgrade",
-        "--exact",
-        "--id",
-        "NeuralNomadsAI.CodeNomad",
-        "--source",
-        "winget",
-        "--silent",
-        "--accept-source-agreements",
-        "--accept-package-agreements",
-        "--disable-interactivity",
-    ]);
+pub async fn install_stable_update() -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(|| {
+        let mut command = Command::new("winget");
+        command.args([
+            "upgrade",
+            "--exact",
+            "--id",
+            "NeuralNomadsAI.CodeNomad",
+            "--source",
+            "winget",
+            "--silent",
+            "--accept-source-agreements",
+            "--accept-package-agreements",
+            "--disable-interactivity",
+        ]);
 
-    #[cfg(windows)]
-    command.creation_flags(0x08000000);
+        #[cfg(windows)]
+        command.creation_flags(0x08000000);
 
-    command
-        .spawn()
-        .map(|_| ())
-        .map_err(|err| format!("Unable to start the WinGet update: {err}"))
+        let status = command
+            .status()
+            .map_err(|err| format!("Unable to start the WinGet update: {err}"))?;
+
+        if status.success() {
+            Ok(())
+        } else {
+            Err(format!("WinGet update failed with status {status}"))
+        }
+    })
+    .await
+    .map_err(|err| format!("Unable to monitor the WinGet update: {err}"))?
 }

--- a/packages/ui/src/components/toast-history-panel.tsx
+++ b/packages/ui/src/components/toast-history-panel.tsx
@@ -21,9 +21,9 @@ import {
   deleteToastHistoryItem,
   markAllToastHistoryAsRead,
   markToastHistoryAsRead,
+  runToastAction,
   subscribeToastHistory,
 } from "../lib/notifications"
-import { isTauriHost } from "../lib/runtime-env"
 
 // ==================== Types ====================
 
@@ -188,8 +188,8 @@ const ToastHistoryPanel: Component<ToastHistoryPanelProps> = (props) => {
     }
 
     // Open action link if exists
-    if (item.action?.href) {
-      void handleOpenAction(item.action.href);
+    if (item.action) {
+      void runToastAction(item.action);
     }
   };
 
@@ -208,21 +208,6 @@ const ToastHistoryPanel: Component<ToastHistoryPanelProps> = (props) => {
   const handleMarkAllAsRead = () => {
     markAllToastHistoryAsRead();
   };
-
-  // Open external link
-  async function handleOpenAction(href: string): Promise<void> {
-    if (isTauriHost()) {
-      try {
-        const { openUrl } = await import("@tauri-apps/plugin-opener");
-        await openUrl(href);
-        return;
-      } catch (error) {
-        console.warn("[toast-history] unable to open via system opener", error);
-      }
-    }
-
-    window.open(href, "_blank", "noopener,noreferrer");
-  }
 
   // Stop click propagation from backdrop to panel
   const handleBackdropClick = (event: MouseEvent) => {
@@ -383,8 +368,8 @@ const ToastHistoryPanel: Component<ToastHistoryPanelProps> = (props) => {
                                   class="toast-history-item-action inline-flex items-center gap-1 text-xs mt-1"
                                   onClick={(e) => {
                                     e.stopPropagation();
-                                    if (item.action?.href) {
-                                      void handleOpenAction(item.action.href);
+                                    if (item.action) {
+                                      void runToastAction(item.action);
                                     }
                                   }}
                                 >

--- a/packages/ui/src/components/toast-history-panel.tsx
+++ b/packages/ui/src/components/toast-history-panel.tsx
@@ -182,14 +182,8 @@ const ToastHistoryPanel: Component<ToastHistoryPanelProps> = (props) => {
 
   // Handle item click
   const handleItemClick = (item: IToastHistoryItem) => {
-    // Mark as read
     if (!item.read) {
       markToastHistoryAsRead(item.id);
-    }
-
-    // Open action link if exists
-    if (item.action) {
-      void runToastAction(item.action);
     }
   };
 

--- a/packages/ui/src/lib/notifications.tsx
+++ b/packages/ui/src/lib/notifications.tsx
@@ -11,17 +11,19 @@ export type ToastHandle = {
 
 type ToastPosition = "top-left" | "top-right" | "top-center" | "bottom-left" | "bottom-right" | "bottom-center"
 
+export type ToastAction = {
+  label: string
+  href: string
+  onClick?: () => void | Promise<void>
+}
+
 export type ToastPayload = {
   title?: string
   message: string
   variant: ToastVariant
   duration?: number
   position?: ToastPosition
-  action?: {
-    label: string
-    href: string
-    onClick?: () => void | Promise<void>
-  }
+  action?: ToastAction
 }
 
 // ==================== Toast History Types ====================
@@ -43,10 +45,7 @@ export interface IToastHistoryItem {
   /** Read state (clicked) */
   read: boolean;
   /** Action link (optional) */
-  action?: {
-    label: string;
-    href: string;
-  };
+  action?: ToastAction;
 }
 
 /**
@@ -298,6 +297,20 @@ async function openExternalUrl(url: string): Promise<void> {
   }
 }
 
+export async function runToastAction(action: ToastAction): Promise<void> {
+  if (!action.onClick) {
+    await openExternalUrl(action.href)
+    return
+  }
+
+  try {
+    await action.onClick()
+  } catch (error) {
+    console.warn("[notifications] action failed; opening fallback link", error)
+    await openExternalUrl(action.href)
+  }
+}
+
 // ==================== Variant Accent Styles ====================
 
 const variantAccent: Record<
@@ -382,7 +395,7 @@ export function showToastNotification(payload: ToastPayload): ToastHandle {
               <button
                 type="button"
                 class="mt-3 inline-flex items-center text-xs font-semibold uppercase tracking-wide text-sky-300 hover:text-sky-200"
-                onClick={() => void (payload.action!.onClick?.() ?? openExternalUrl(payload.action!.href))}
+                onClick={() => void runToastAction(payload.action!)}
               >
                 {payload.action.label}
               </button>

--- a/packages/ui/src/lib/notifications.tsx
+++ b/packages/ui/src/lib/notifications.tsx
@@ -20,6 +20,7 @@ export type ToastPayload = {
   action?: {
     label: string
     href: string
+    onClick?: () => void | Promise<void>
   }
 }
 
@@ -381,7 +382,7 @@ export function showToastNotification(payload: ToastPayload): ToastHandle {
               <button
                 type="button"
                 class="mt-3 inline-flex items-center text-xs font-semibold uppercase tracking-wide text-sky-300 hover:text-sky-200"
-                onClick={() => void openExternalUrl(payload.action!.href)}
+                onClick={() => void (payload.action!.onClick?.() ?? openExternalUrl(payload.action!.href))}
               >
                 {payload.action.label}
               </button>

--- a/packages/ui/src/stores/releases.ts
+++ b/packages/ui/src/stores/releases.ts
@@ -1,9 +1,11 @@
 import { createEffect, createSignal } from "solid-js"
+import { invoke } from "@tauri-apps/api/core"
 import type { ServerMeta, SupportMeta } from "../../../server/src/api-types"
 import { getServerMeta } from "../lib/server-meta"
 import { showToastNotification, ToastHandle } from "../lib/notifications"
 import { getLogger } from "../lib/logger"
 import { tGlobal } from "../lib/i18n"
+import { isLocalWindow, isTauriHost } from "../lib/runtime-env"
 import { hasInstances, showFolderSelection } from "./ui"
 
 const log = getLogger("actions")
@@ -61,6 +63,7 @@ function ensureVisibilityEffect() {
           ? {
               label: tGlobal("releases.upgradeRequired.action.getUpdate"),
               href: support.latestServerUrl,
+              onClick: isTauriHost() && isLocalWindow() && navigator.userAgent.includes("Windows") ? () => invoke("install_stable_update") : undefined,
             }
           : undefined,
       })


### PR DESCRIPTION
## Summary

- launch the official CodeNomad WinGet upgrade from the upgrade-required notification in the local Windows Tauri client
- keep non-Windows, Electron and development release actions on their existing release links
- wait for WinGet without blocking the async runtime and propagate launch or non-zero exit failures back to the UI
- open the official release URL when the native update action fails
- preserve the same explicit update action in the live toast and notification history

## Update behavior

- run an exact silent upgrade for the NeuralNomadsAI.CodeNomad package from the WinGet source
- do not force a reinstall or downgrade
- do not attempt to restart CodeNomad after a successful update; the installer owns application shutdown and replacement

## Validation

- npm run typecheck in packages/ui
- npm run build in packages/ui
- cargo test in packages/tauri-app/src-tauri (20 tests)