### PR TITLE
feat(ui): make open workspace action explicit

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -35,7 +35,6 @@ import {
 import { recentFolders, useConfig } from "./stores/preferences"
 import {
   createInstance,
-  getExistingInstanceForFolder,
   instances,
   stopInstance,
   disconnectedInstance,
@@ -102,11 +101,6 @@ const App: Component = () => {
   const [escapeInDebounce, setEscapeInDebounce] = createSignal(false)
   const [instanceTabBarHeight, setInstanceTabBarHeight] = createSignal(0)
   const [sidecarPickerOpen, setSidecarPickerOpen] = createSignal(false)
-  const [alreadyOpenFolderChoice, setAlreadyOpenFolderChoice] = createSignal<{
-    folderPath: string
-    binaryPath: string
-    instanceId: string
-  } | null>(null)
   const phoneQuery = useMediaQuery("(max-width: 767px)")
   const isPhoneLayout = createMemo(() => phoneQuery())
 
@@ -288,25 +282,17 @@ const App: Component = () => {
     const projectName = getProjectNameForFolder(folderPath)
     clearLaunchError()
 
-    if (!options?.forceNew) {
-      const existingInstance = getExistingInstanceForFolder(folderPath)
-      if (existingInstance) {
-        recordWorkspaceLaunch(existingInstance.folder, selectedBinary, folderPath)
-        setAlreadyOpenFolderChoice({ folderPath, binaryPath: selectedBinary, instanceId: existingInstance.id })
-        return
-      }
-    }
-
     setIsSelectingFolder(true)
     try {
       const result = await createInstance(folderPath, selectedBinary, projectName, { forceNew: options?.forceNew })
+      recordWorkspaceLaunch(instances().get(result.instanceId)?.folder ?? folderPath, selectedBinary, folderPath)
       if (result.reused) {
-        recordWorkspaceLaunch(instances().get(result.instanceId)?.folder ?? folderPath, selectedBinary, folderPath)
-        setAlreadyOpenFolderChoice({ folderPath, binaryPath: selectedBinary, instanceId: result.instanceId })
+        selectInstanceTab(result.instanceId)
+        setShowFolderSelection(false)
+        log.info("Selected reused instance", { instanceId: result.instanceId, folderPath })
         return
       }
 
-      recordWorkspaceLaunch(instances().get(result.instanceId)?.folder ?? folderPath, selectedBinary, folderPath)
       selectInstanceTab(result.instanceId)
       setShowFolderSelection(false)
 
@@ -324,24 +310,13 @@ const App: Component = () => {
     }
   }
 
-  function dismissAlreadyOpenFolderChoice() {
-    setAlreadyOpenFolderChoice(null)
-  }
-
-  function switchToAlreadyOpenFolder() {
-    const choice = alreadyOpenFolderChoice()
-    if (!choice) return
-    setAlreadyOpenFolderChoice(null)
-    selectInstanceTab(choice.instanceId)
+  function handleSelectExistingInstance(instanceId: string, recentPath: string, binaryPath: string) {
+    const instance = instances().get(instanceId)
+    if (!instance) return
+    recordWorkspaceLaunch(instance.folder, binaryPath, recentPath)
+    selectInstanceTab(instanceId)
     setShowFolderSelection(false)
-    log.info("Selected existing instance", { instanceId: choice.instanceId, folderPath: choice.folderPath })
-  }
-
-  function openAnotherFolderInstance() {
-    const choice = alreadyOpenFolderChoice()
-    if (!choice) return
-    setAlreadyOpenFolderChoice(null)
-    void handleSelectFolder(choice.folderPath, choice.binaryPath, { forceNew: true })
+    log.info("Selected existing instance", { instanceId, folderPath: instance.folder })
   }
 
   function handleLaunchErrorClose() {
@@ -655,6 +630,7 @@ const App: Component = () => {
         >
           <FolderSelectionView
             onSelectFolder={handleSelectFolder}
+            onSelectExistingInstance={handleSelectExistingInstance}
             isLoading={isSelectingFolder()}
             onOpenSidecar={handleOpenSidecarPicker}
           />
@@ -665,6 +641,7 @@ const App: Component = () => {
             <div class="w-full h-full relative">
               <FolderSelectionView
                 onSelectFolder={handleSelectFolder}
+                onSelectExistingInstance={handleSelectExistingInstance}
                 isLoading={isSelectingFolder()}
                 onOpenSidecar={handleOpenSidecarPicker}
                 onClose={() => {
@@ -678,31 +655,6 @@ const App: Component = () => {
 
         <SettingsScreen />
         <SideCarPickerDialog open={sidecarPickerOpen()} onClose={() => setSidecarPickerOpen(false)} onOpenSidecar={handleOpenSidecar} />
-        <Show when={alreadyOpenFolderChoice()}>
-          <Dialog open modal onOpenChange={(open) => !open && dismissAlreadyOpenFolderChoice()}>
-            <Dialog.Portal>
-              <Dialog.Overlay class="modal-overlay z-[60]" />
-              <Dialog.Content class="modal-surface fixed left-1/2 top-1/2 z-[1310] w-full max-w-sm -translate-x-1/2 -translate-y-1/2 p-6 border border-base shadow-2xl" tabIndex={-1}>
-                <Dialog.Title class="text-lg font-semibold text-primary">
-                  {t("folderSelection.recent.alreadyOpenTitle")}
-                </Dialog.Title>
-                <Dialog.Description class="text-sm text-secondary mt-1">
-                  {t("folderSelection.recent.alreadyOpenMessage")}
-                </Dialog.Description>
-
-                <div class="mt-6 flex justify-end gap-3">
-                  <button type="button" class="button-secondary" onClick={openAnotherFolderInstance}>
-                    {t("folderSelection.recent.openAnotherInstance")}
-                  </button>
-                  <button type="button" class="button-primary" onClick={switchToAlreadyOpenFolder}>
-                    {t("folderSelection.recent.switchToOpenProject")}
-                  </button>
-                </div>
-              </Dialog.Content>
-            </Dialog.Portal>
-          </Dialog>
-        </Show>
-
         <AlertDialog />
 
         <Toaster

--- a/packages/ui/src/components/folder-selection-view.tsx
+++ b/packages/ui/src/components/folder-selection-view.tsx
@@ -960,26 +960,71 @@ const FolderSelectionView: Component<FolderSelectionViewProps> = (props) => {
                                 "folder-home-recent-item-action-active":
                                   hoveredRecentActionPath() === folder.path || focusedRecentActionPath() === folder.path,
                               }}
+                              onMouseEnter={() => {
+                                if (isLoading()) return
+                                setFocusMode("recent")
+                                setSelectedIndex(index())
+                              }}
                             >
                               <div class="flex items-center gap-2 w-full px-1">
-                                <button
-                                  data-list-index={index()}
-                                  class="panel-list-item-content flex-1"
-                                  disabled={isLoading()}
-                                  onClick={() => handleFolderSelect(folder.path, true)}
-                                  onMouseEnter={() => {
-                                    if (isLoading()) return
-                                    setFocusMode("recent")
-                                    setSelectedIndex(index())
-                                  }}
-                                >
-                                  <div class="flex items-center justify-between gap-3 w-full">
+                                <div class="panel-list-item-content relative flex-1">
+                                  <button
+                                    data-list-index={index()}
+                                    type="button"
+                                    class="folder-home-recent-primary-action"
+                                    disabled={isLoading()}
+                                    aria-labelledby={projectLabelId()}
+                                    onClick={() => handleFolderSelect(folder.path, true)}
+                                    onFocus={() => {
+                                      setFocusMode("recent")
+                                      setSelectedIndex(index())
+                                    }}
+                                  />
+                                  <div class="relative z-[1] pointer-events-none flex items-center justify-between gap-3 w-full">
                                     <div class="flex-1 min-w-0">
                                       <div class="flex items-center gap-2 mb-1">
                                         <Folder class="w-4 h-4 flex-shrink-0 icon-muted" />
                                         <span id={projectLabelId()} class="text-sm font-medium truncate text-primary">
                                           {projectName()}
                                         </span>
+                                        <Show when={existingInstance()}>
+                                          {(instance) => {
+                                            let ownsHoverState = false
+                                            let ownsFocusState = false
+                                            onCleanup(() => {
+                                              if (ownsHoverState) setRecentActionHovered(folder.path, false)
+                                              if (ownsFocusState) setRecentActionFocused(folder.path, false)
+                                            })
+                                            return (
+                                              <button
+                                                type="button"
+                                                class="folder-home-open-instance-button folder-home-row-action pointer-events-auto"
+                                                disabled={isLoading()}
+                                                aria-labelledby={`${openActionLabelId()} ${projectLabelId()}`}
+                                                title={t("folderSelection.recent.switchToOpenProject")}
+                                                onClick={() => handleExistingInstanceSelect(instance().id, folder.path)}
+                                                onMouseEnter={() => {
+                                                  ownsHoverState = true
+                                                  setRecentActionHovered(folder.path, true)
+                                                }}
+                                                onMouseLeave={() => {
+                                                  ownsHoverState = false
+                                                  setRecentActionHovered(folder.path, false)
+                                                }}
+                                                onFocus={() => {
+                                                  ownsFocusState = true
+                                                  setRecentActionFocused(folder.path, true)
+                                                }}
+                                                onBlur={() => {
+                                                  ownsFocusState = false
+                                                  setRecentActionFocused(folder.path, false)
+                                                }}
+                                              >
+                                                <span id={openActionLabelId()}>{t("folderSelection.recent.openBadge")}</span>
+                                              </button>
+                                            )
+                                          }}
+                                        </Show>
                                       </div>
                                       <div class="flex items-center gap-2 pl-6 text-xs text-muted min-w-0">
                                         <span class="font-mono truncate-start flex-1 min-w-0">
@@ -992,46 +1037,7 @@ const FolderSelectionView: Component<FolderSelectionViewProps> = (props) => {
                                       <kbd class="kbd">↵</kbd>
                                     </Show>
                                   </div>
-                                </button>
-                                <Show when={existingInstance()}>
-                                  {(instance) => {
-                                    let ownsHoverState = false
-                                    let ownsFocusState = false
-                                    onCleanup(() => {
-                                      if (ownsHoverState) setRecentActionHovered(folder.path, false)
-                                      if (ownsFocusState) setRecentActionFocused(folder.path, false)
-                                    })
-                                    return (
-                                      <button
-                                        type="button"
-                                        class="folder-home-open-instance-button folder-home-row-action"
-                                        disabled={isLoading()}
-                                        aria-labelledby={`${openActionLabelId()} ${projectLabelId()}`}
-                                        title={t("folderSelection.recent.switchToOpenProject")}
-                                        onClick={() => handleExistingInstanceSelect(instance().id, folder.path)}
-                                        onMouseEnter={() => {
-                                          ownsHoverState = true
-                                          setRecentActionHovered(folder.path, true)
-                                        }}
-                                        onMouseLeave={() => {
-                                          ownsHoverState = false
-                                          setRecentActionHovered(folder.path, false)
-                                        }}
-                                        onFocus={() => {
-                                          ownsFocusState = true
-                                          setRecentActionFocused(folder.path, true)
-                                        }}
-                                        onBlur={() => {
-                                          ownsFocusState = false
-                                          setRecentActionFocused(folder.path, false)
-                                        }}
-                                      >
-                                        <span id={openActionLabelId()}>{t("folderSelection.recent.openBadge")}</span>
-                                        <ChevronRight class="w-3 h-3" aria-hidden="true" />
-                                      </button>
-                                    )
-                                  }}
-                                </Show>
+                                </div>
                                 <button
                                   onClick={(e) => openProjectRename(folder.path, folder.projectName, e)}
                                   disabled={isLoading()}

--- a/packages/ui/src/components/folder-selection-view.tsx
+++ b/packages/ui/src/components/folder-selection-view.tsx
@@ -30,6 +30,7 @@ type HomeTab = "local" | "servers"
 
 interface FolderSelectionViewProps {
   onSelectFolder: (folder: string, binaryPath?: string, options?: { forceNew?: boolean }) => void
+  onSelectExistingInstance: (instanceId: string, recentPath: string, binaryPath: string) => void
   onOpenSidecar?: () => void
   isLoading?: boolean
   onClose?: () => void
@@ -133,6 +134,7 @@ const FolderSelectionView: Component<FolderSelectionViewProps> = (props) => {
     const isEditingField =
       activeElement &&
       (["INPUT", "TEXTAREA", "SELECT"].includes(activeElement.tagName) || activeElement.isContentEditable || Boolean(insideModal))
+    const isInteractiveControl = activeElement && ["BUTTON", "A"].includes(activeElement.tagName)
 
     if (isEditingField) {
       return
@@ -154,6 +156,8 @@ const FolderSelectionView: Component<FolderSelectionViewProps> = (props) => {
       void handleBrowse()
       return
     }
+
+    if (isInteractiveControl && (e.key === "Enter" || e.key === " ")) return
 
     const listLength = getActiveListLength()
     if (listLength === 0) return
@@ -209,7 +213,7 @@ const FolderSelectionView: Component<FolderSelectionViewProps> = (props) => {
     if (activeTab() === "local") {
       const folder = folders()[index]
       if (folder) {
-        handleFolderSelect(folder.path)
+        handleFolderSelect(folder.path, true)
       }
       return
     }
@@ -309,9 +313,14 @@ const FolderSelectionView: Component<FolderSelectionViewProps> = (props) => {
     return t("time.relative.justNow")
   }
 
-  function handleFolderSelect(path: string) {
+  function handleFolderSelect(path: string, forceNew = false) {
     if (isLoading()) return
-    props.onSelectFolder(path, selectedBinary())
+    props.onSelectFolder(path, selectedBinary(), forceNew ? { forceNew: true } : undefined)
+  }
+
+  function handleExistingInstanceSelect(instanceId: string, recentPath: string) {
+    if (isLoading()) return
+    props.onSelectExistingInstance(instanceId, recentPath, selectedBinary())
   }
 
   function resetCloneDialog() {
@@ -924,6 +933,9 @@ const FolderSelectionView: Component<FolderSelectionViewProps> = (props) => {
                         <For each={folders()}>
                           {(folder, index) => {
                             const existingInstance = () => getExistingInstanceForFolder(folder.path)
+                            const projectName = () => getProjectDisplayName(folder.path, folder.projectName)
+                            const projectLabelId = () => `recent-folder-${index()}-name`
+                            const openActionLabelId = () => `recent-folder-${index()}-open-action`
 
                             return <div
                               class="panel-list-item"
@@ -937,7 +949,7 @@ const FolderSelectionView: Component<FolderSelectionViewProps> = (props) => {
                                   data-list-index={index()}
                                   class="panel-list-item-content flex-1"
                                   disabled={isLoading()}
-                                  onClick={() => handleFolderSelect(folder.path)}
+                                  onClick={() => handleFolderSelect(folder.path, true)}
                                   onMouseEnter={() => {
                                     if (isLoading()) return
                                     setFocusMode("recent")
@@ -948,14 +960,9 @@ const FolderSelectionView: Component<FolderSelectionViewProps> = (props) => {
                                     <div class="flex-1 min-w-0">
                                       <div class="flex items-center gap-2 mb-1">
                                         <Folder class="w-4 h-4 flex-shrink-0 icon-muted" />
-                                        <span class="text-sm font-medium truncate text-primary">
-                                          {getProjectDisplayName(folder.path, folder.projectName)}
+                                        <span id={projectLabelId()} class="text-sm font-medium truncate text-primary">
+                                          {projectName()}
                                         </span>
-                                        <Show when={existingInstance()}>
-                                          <span class="rounded-full border border-base px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-secondary">
-                                            {t("folderSelection.recent.openBadge")}
-                                          </span>
-                                        </Show>
                                       </div>
                                       <div class="flex items-center gap-2 pl-6 text-xs text-muted min-w-0">
                                         <span class="font-mono truncate-start flex-1 min-w-0">
@@ -969,6 +976,21 @@ const FolderSelectionView: Component<FolderSelectionViewProps> = (props) => {
                                     </Show>
                                   </div>
                                 </button>
+                                <Show when={existingInstance()}>
+                                  {(instance) => (
+                                    <button
+                                      type="button"
+                                      class="folder-home-open-instance-button"
+                                      disabled={isLoading()}
+                                      aria-labelledby={`${openActionLabelId()} ${projectLabelId()}`}
+                                      title={t("folderSelection.recent.switchToOpenProject")}
+                                      onClick={() => handleExistingInstanceSelect(instance().id, folder.path)}
+                                    >
+                                      <span id={openActionLabelId()}>{t("folderSelection.recent.openBadge")}</span>
+                                      <ChevronRight class="w-3 h-3" aria-hidden="true" />
+                                    </button>
+                                  )}
+                                </Show>
                                 <button
                                   onClick={(e) => openProjectRename(folder.path, folder.projectName, e)}
                                   disabled={isLoading()}

--- a/packages/ui/src/components/folder-selection-view.tsx
+++ b/packages/ui/src/components/folder-selection-view.tsx
@@ -51,6 +51,8 @@ const FolderSelectionView: Component<FolderSelectionViewProps> = (props) => {
   } = useConfig()
   const { t, locale } = useI18n()
   const [selectedIndex, setSelectedIndex] = createSignal(0)
+  const [hoveredRecentActionPath, setHoveredRecentActionPath] = createSignal<string | null>(null)
+  const [focusedRecentActionPath, setFocusedRecentActionPath] = createSignal<string | null>(null)
   const [focusMode, setFocusMode] = createSignal<"recent" | "new" | null>("recent")
   const [selectedBinary, setSelectedBinary] = createSignal(serverSettings().opencodeBinary || "opencode")
   const [isFolderBrowserOpen, setIsFolderBrowserOpen] = createSignal(false)
@@ -321,6 +323,19 @@ const FolderSelectionView: Component<FolderSelectionViewProps> = (props) => {
   function handleExistingInstanceSelect(instanceId: string, recentPath: string) {
     if (isLoading()) return
     props.onSelectExistingInstance(instanceId, recentPath, selectedBinary())
+  }
+
+  function setRecentActionHovered(path: string, active: boolean) {
+    setHoveredRecentActionPath((current) => active ? path : current === path ? null : current)
+  }
+
+  function setRecentActionFocused(path: string, active: boolean) {
+    setFocusedRecentActionPath((current) => active ? path : current === path ? null : current)
+  }
+
+  function clearRecentActionState(path: string) {
+    setRecentActionHovered(path, false)
+    setRecentActionFocused(path, false)
   }
 
   function resetCloneDialog() {
@@ -938,10 +953,12 @@ const FolderSelectionView: Component<FolderSelectionViewProps> = (props) => {
                             const openActionLabelId = () => `recent-folder-${index()}-open-action`
 
                             return <div
-                              class="panel-list-item"
+                              class="panel-list-item folder-home-recent-item"
                               classList={{
                                 "panel-list-item-highlight": focusMode() === "recent" && selectedIndex() === index(),
                                 "panel-list-item-disabled": isLoading(),
+                                "folder-home-recent-item-action-active":
+                                  hoveredRecentActionPath() === folder.path || focusedRecentActionPath() === folder.path,
                               }}
                             >
                               <div class="flex items-center gap-2 w-full px-1">
@@ -977,33 +994,68 @@ const FolderSelectionView: Component<FolderSelectionViewProps> = (props) => {
                                   </div>
                                 </button>
                                 <Show when={existingInstance()}>
-                                  {(instance) => (
-                                    <button
-                                      type="button"
-                                      class="folder-home-open-instance-button"
-                                      disabled={isLoading()}
-                                      aria-labelledby={`${openActionLabelId()} ${projectLabelId()}`}
-                                      title={t("folderSelection.recent.switchToOpenProject")}
-                                      onClick={() => handleExistingInstanceSelect(instance().id, folder.path)}
-                                    >
-                                      <span id={openActionLabelId()}>{t("folderSelection.recent.openBadge")}</span>
-                                      <ChevronRight class="w-3 h-3" aria-hidden="true" />
-                                    </button>
-                                  )}
+                                  {(instance) => {
+                                    let ownsHoverState = false
+                                    let ownsFocusState = false
+                                    onCleanup(() => {
+                                      if (ownsHoverState) setRecentActionHovered(folder.path, false)
+                                      if (ownsFocusState) setRecentActionFocused(folder.path, false)
+                                    })
+                                    return (
+                                      <button
+                                        type="button"
+                                        class="folder-home-open-instance-button folder-home-row-action"
+                                        disabled={isLoading()}
+                                        aria-labelledby={`${openActionLabelId()} ${projectLabelId()}`}
+                                        title={t("folderSelection.recent.switchToOpenProject")}
+                                        onClick={() => handleExistingInstanceSelect(instance().id, folder.path)}
+                                        onMouseEnter={() => {
+                                          ownsHoverState = true
+                                          setRecentActionHovered(folder.path, true)
+                                        }}
+                                        onMouseLeave={() => {
+                                          ownsHoverState = false
+                                          setRecentActionHovered(folder.path, false)
+                                        }}
+                                        onFocus={() => {
+                                          ownsFocusState = true
+                                          setRecentActionFocused(folder.path, true)
+                                        }}
+                                        onBlur={() => {
+                                          ownsFocusState = false
+                                          setRecentActionFocused(folder.path, false)
+                                        }}
+                                      >
+                                        <span id={openActionLabelId()}>{t("folderSelection.recent.openBadge")}</span>
+                                        <ChevronRight class="w-3 h-3" aria-hidden="true" />
+                                      </button>
+                                    )
+                                  }}
                                 </Show>
                                 <button
                                   onClick={(e) => openProjectRename(folder.path, folder.projectName, e)}
                                   disabled={isLoading()}
-                                  class="p-2 transition-all hover:bg-surface-hover opacity-70 hover:opacity-100 rounded"
+                                  class="folder-home-row-action p-2 transition-all hover:bg-surface-hover opacity-70 hover:opacity-100 rounded"
                                   title={t("folderSelection.recent.rename")}
+                                  onMouseEnter={() => setRecentActionHovered(folder.path, true)}
+                                  onMouseLeave={() => setRecentActionHovered(folder.path, false)}
+                                  onFocus={() => setRecentActionFocused(folder.path, true)}
+                                  onBlur={() => setRecentActionFocused(folder.path, false)}
                                 >
                                   <Pencil class="w-3.5 h-3.5 transition-colors icon-muted" />
                                 </button>
                                 <button
-                                  onClick={(e) => handleRemove(folder.path, e)}
+                                  onClick={(e) => {
+                                    clearRecentActionState(folder.path)
+                                    handleRemove(folder.path, e)
+                                  }}
                                   disabled={isLoading()}
-                                  class="p-2 transition-all hover:bg-red-100 dark:hover:bg-red-900/30 opacity-70 hover:opacity-100 rounded"
+                                  class="folder-home-row-action p-2 transition-all hover:bg-red-100 dark:hover:bg-red-900/30 opacity-70 hover:opacity-100 rounded"
                                   title={t("folderSelection.recent.remove")}
+                                  onMouseEnter={() => setRecentActionHovered(folder.path, true)}
+                                  onMouseLeave={() => setRecentActionHovered(folder.path, false)}
+                                  onFocus={() => setRecentActionFocused(folder.path, true)}
+                                  onBlur={() => setRecentActionFocused(folder.path, false)}
                                 >
                                   <Trash2 class="w-3.5 h-3.5 transition-colors icon-muted hover:text-red-600 dark:hover:text-red-400" />
                                 </button>

--- a/packages/ui/src/lib/i18n/messages/de/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/de/folderSelection.ts
@@ -17,10 +17,7 @@ export const folderSelectionMessages = {
   "folderSelection.recent.rename": "Arbeitsbereich umbenennen",
   "folderSelection.recent.remove": "Aus Liste entfernen",
   "folderSelection.recent.openBadge": "Offen",
-  "folderSelection.recent.alreadyOpenTitle": "Projekt bereits offen",
-  "folderSelection.recent.alreadyOpenMessage": "Wählen Sie, wie dieser Ordner geöffnet werden soll.",
   "folderSelection.recent.switchToOpenProject": "Zum offenen Projekt wechseln",
-  "folderSelection.recent.openAnotherInstance": "Weitere Instanz öffnen",
 
   "folderSelection.browse.title": "Nach Ordner suchen",
   "folderSelection.browse.subtitle": "Wählen Sie einen beliebigen Ordner auf Ihrem Computer aus",

--- a/packages/ui/src/lib/i18n/messages/en/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/en/folderSelection.ts
@@ -17,10 +17,7 @@ export const folderSelectionMessages = {
   "folderSelection.recent.rename": "Rename workspace",
   "folderSelection.recent.remove": "Remove from recent",
   "folderSelection.recent.openBadge": "Open",
-  "folderSelection.recent.alreadyOpenTitle": "Project already open",
-  "folderSelection.recent.alreadyOpenMessage": "Choose how to open this folder.",
   "folderSelection.recent.switchToOpenProject": "Switch to open project",
-  "folderSelection.recent.openAnotherInstance": "Open another instance",
 
   "folderSelection.browse.title": "Browse for Folder",
   "folderSelection.browse.subtitle": "Select any folder on your computer",

--- a/packages/ui/src/lib/i18n/messages/es/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/es/folderSelection.ts
@@ -17,10 +17,7 @@ export const folderSelectionMessages = {
   "folderSelection.recent.rename": "Renombrar workspace",
   "folderSelection.recent.remove": "Eliminar de recientes",
   "folderSelection.recent.openBadge": "Abierta",
-  "folderSelection.recent.alreadyOpenTitle": "Proyecto ya abierto",
-  "folderSelection.recent.alreadyOpenMessage": "Elige cómo abrir esta carpeta.",
   "folderSelection.recent.switchToOpenProject": "Cambiar al proyecto abierto",
-  "folderSelection.recent.openAnotherInstance": "Abrir otra instancia",
 
   "folderSelection.browse.title": "Buscar carpeta",
   "folderSelection.browse.subtitle": "Selecciona cualquier carpeta en tu ordenador",

--- a/packages/ui/src/lib/i18n/messages/fr/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/fr/folderSelection.ts
@@ -17,10 +17,7 @@ export const folderSelectionMessages = {
   "folderSelection.recent.rename": "Renommer l'espace de travail",
   "folderSelection.recent.remove": "Retirer des récents",
   "folderSelection.recent.openBadge": "Ouvert",
-  "folderSelection.recent.alreadyOpenTitle": "Projet déjà ouvert",
-  "folderSelection.recent.alreadyOpenMessage": "Choisissez comment ouvrir ce dossier.",
   "folderSelection.recent.switchToOpenProject": "Basculer vers le projet ouvert",
-  "folderSelection.recent.openAnotherInstance": "Ouvrir une autre instance",
 
   "folderSelection.browse.title": "Parcourir un dossier",
   "folderSelection.browse.subtitle": "Sélectionnez n'importe quel dossier sur votre ordinateur",

--- a/packages/ui/src/lib/i18n/messages/he/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/he/folderSelection.ts
@@ -17,10 +17,7 @@ export const folderSelectionMessages = {
   "folderSelection.recent.rename": "שנה שם סביבת עבודה",
   "folderSelection.recent.remove": "הסר מהרשימה האחרונה",
   "folderSelection.recent.openBadge": "פתוח",
-  "folderSelection.recent.alreadyOpenTitle": "הפרויקט כבר פתוח",
-  "folderSelection.recent.alreadyOpenMessage": "בחר כיצד לפתוח את התיקייה הזו.",
   "folderSelection.recent.switchToOpenProject": "עבור לפרויקט הפתוח",
-  "folderSelection.recent.openAnotherInstance": "פתח מופע נוסף",
 
   "folderSelection.browse.title": "עיון בתיקייה",
   "folderSelection.browse.subtitle": "בחר כל תיקייה במחשב שלך",

--- a/packages/ui/src/lib/i18n/messages/ja/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/ja/folderSelection.ts
@@ -17,10 +17,7 @@ export const folderSelectionMessages = {
   "folderSelection.recent.rename": "ワークスペース名を変更",
   "folderSelection.recent.remove": "履歴から削除",
   "folderSelection.recent.openBadge": "開いています",
-  "folderSelection.recent.alreadyOpenTitle": "プロジェクトはすでに開いています",
-  "folderSelection.recent.alreadyOpenMessage": "このフォルダの開き方を選択してください。",
   "folderSelection.recent.switchToOpenProject": "開いているプロジェクトに切り替え",
-  "folderSelection.recent.openAnotherInstance": "別のインスタンスを開く",
 
   "folderSelection.browse.title": "フォルダを参照",
   "folderSelection.browse.subtitle": "コンピュータ上の任意のフォルダを選択",

--- a/packages/ui/src/lib/i18n/messages/ne/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/ne/folderSelection.ts
@@ -17,10 +17,7 @@ export const folderSelectionMessages = {
   "folderSelection.recent.rename": "कार्यस्थान पुन: नामकरण गर्नुहोस्",
   "folderSelection.recent.remove": "भर्खरको सूचीबाट हटाउनुहोस्",
   "folderSelection.recent.openBadge": "खोल्नुहोस्",
-  "folderSelection.recent.alreadyOpenTitle": "परियोजना पहिले नै खुला छ",
-  "folderSelection.recent.alreadyOpenMessage": "यो फोल्डर कसरी खोल्ने छनौट गर्नुहोस्।",
   "folderSelection.recent.switchToOpenProject": "खुला परियोजनामा जानुहोस्",
-  "folderSelection.recent.openAnotherInstance": "अर्को उदाहरण खोल्नुहोस्",
 
   "folderSelection.browse.title": "फोल्डरको लागि ब्राउज गर्नुहोस्",
   "folderSelection.browse.subtitle": "तपाईंको कम्प्युटरमा कुनै पनि फोल्डर चयन गर्नुहोस्",

--- a/packages/ui/src/lib/i18n/messages/ru/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/ru/folderSelection.ts
@@ -17,10 +17,7 @@ export const folderSelectionMessages = {
   "folderSelection.recent.rename": "Переименовать рабочее пространство",
   "folderSelection.recent.remove": "Убрать из недавних",
   "folderSelection.recent.openBadge": "Открыта",
-  "folderSelection.recent.alreadyOpenTitle": "Проект уже открыт",
-  "folderSelection.recent.alreadyOpenMessage": "Выберите, как открыть эту папку.",
   "folderSelection.recent.switchToOpenProject": "Перейти к открытому проекту",
-  "folderSelection.recent.openAnotherInstance": "Открыть еще одну инстанцию",
 
   "folderSelection.browse.title": "Выбрать папку",
   "folderSelection.browse.subtitle": "Выберите любую папку на компьютере",

--- a/packages/ui/src/lib/i18n/messages/zh-Hans/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-Hans/folderSelection.ts
@@ -17,10 +17,7 @@ export const folderSelectionMessages = {
   "folderSelection.recent.rename": "重命名工作区",
   "folderSelection.recent.remove": "从最近列表移除",
   "folderSelection.recent.openBadge": "已打开",
-  "folderSelection.recent.alreadyOpenTitle": "项目已打开",
-  "folderSelection.recent.alreadyOpenMessage": "选择如何打开此文件夹。",
   "folderSelection.recent.switchToOpenProject": "切换到已打开的项目",
-  "folderSelection.recent.openAnotherInstance": "打开另一个实例",
 
   "folderSelection.browse.title": "浏览文件夹",
   "folderSelection.browse.subtitle": "选择你电脑上的任意文件夹",

--- a/packages/ui/src/styles/components/folder-home.css
+++ b/packages/ui/src/styles/components/folder-home.css
@@ -52,21 +52,23 @@
   align-items: center;
   gap: 0.125rem;
   padding: 0.375rem 0.625rem;
-  border: 1px solid var(--button-primary-bg);
-  border-radius: 0;
-  background-color: var(--button-primary-bg);
-  color: var(--button-primary-text);
+  border: 1px solid var(--border-base);
+  border-radius: 9999px;
+  background-color: var(--surface-base);
+  color: var(--text-secondary);
   font-size: 0.625rem;
   font-weight: 700;
   letter-spacing: 0.05em;
   line-height: 1;
   text-transform: uppercase;
-  transition: background-color 150ms ease, color 150ms ease, box-shadow 150ms ease;
+  transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease, box-shadow 150ms ease;
 }
 
 .folder-home-open-instance-button:hover:not(:disabled),
 .folder-home-open-instance-button:focus-visible {
-  background-color: var(--button-primary-hover-bg);
+  border-color: var(--accent-hover);
+  background-color: var(--accent-hover);
+  color: var(--text-on-accent);
 }
 
 .folder-home-open-instance-button:focus-visible {
@@ -77,6 +79,16 @@
 .folder-home-open-instance-button:disabled {
   cursor: not-allowed;
   opacity: 0.5;
+}
+
+.folder-home-row-action:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--focus-ring-offset), 0 0 0 4px var(--focus-ring-color);
+}
+
+.folder-home-recent-item.folder-home-recent-item-action-active {
+  background-color: transparent !important;
+  box-shadow: none !important;
 }
 
 @media (min-width: 1024px) {

--- a/packages/ui/src/styles/components/folder-home.css
+++ b/packages/ui/src/styles/components/folder-home.css
@@ -46,6 +46,39 @@
   max-height: var(--folder-home-actions-height, none);
 }
 
+.folder-home-open-instance-button {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 0.125rem;
+  padding: 0.375rem 0.625rem;
+  border: 1px solid var(--button-primary-bg);
+  border-radius: 0;
+  background-color: var(--button-primary-bg);
+  color: var(--button-primary-text);
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  line-height: 1;
+  text-transform: uppercase;
+  transition: background-color 150ms ease, color 150ms ease, box-shadow 150ms ease;
+}
+
+.folder-home-open-instance-button:hover:not(:disabled),
+.folder-home-open-instance-button:focus-visible {
+  background-color: var(--button-primary-hover-bg);
+}
+
+.folder-home-open-instance-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--focus-ring-offset), 0 0 0 4px var(--focus-ring-color);
+}
+
+.folder-home-open-instance-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 @media (min-width: 1024px) {
   .folder-home-main {
     display: grid;

--- a/packages/ui/src/styles/components/folder-home.css
+++ b/packages/ui/src/styles/components/folder-home.css
@@ -50,14 +50,13 @@
   display: inline-flex;
   flex-shrink: 0;
   align-items: center;
-  gap: 0.125rem;
-  padding: 0.375rem 0.625rem;
+  padding: 0.125rem 0.5rem;
   border: 1px solid var(--border-base);
   border-radius: 9999px;
   background-color: var(--surface-base);
   color: var(--text-secondary);
   font-size: 0.625rem;
-  font-weight: 700;
+  font-weight: 500;
   letter-spacing: 0.05em;
   line-height: 1;
   text-transform: uppercase;
@@ -79,6 +78,28 @@
 .folder-home-open-instance-button:disabled {
   cursor: not-allowed;
   opacity: 0.5;
+}
+
+.folder-home-recent-primary-action {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.folder-home-recent-primary-action:focus {
+  outline: none;
+}
+
+.folder-home-recent-primary-action:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--focus-ring-color);
+}
+
+.folder-home-recent-primary-action:disabled {
+  cursor: not-allowed;
 }
 
 .folder-home-row-action:focus-visible {


### PR DESCRIPTION
## Summary

- turn the existing `Open` badge into a prominent action that returns directly to the running workspace
- make the rest of every recent-folder row consistently start a new instance
- remove the repeated already-open choice dialog and its unused translations

## Why

Choosing between the existing workspace and another instance on every activation adds avoidable cognitive load. The two intentions are now represented directly by separate, stable targets: `Open` resumes existing work, while the folder row starts fresh.

## Details

- force recent-row activations to request a new instance even during hydration or workspace-creation races
- keep Browse, drag/drop, and clone fallback reuse behavior, but switch directly without a dialog
- preserve the exact recent-folder alias when returning to an existing instance
- keep native Enter/Space behavior on focused controls while preserving list and browse shortcuts
- use project-specific accessible names and semantic button/focus tokens

## Validation

- `npm run typecheck --workspace @codenomad/ui`
- `npm run build --workspace @codenomad/ui`
- `bun test --conditions=browser packages/ui/src/stores/session-tree.test.ts packages/ui/src/stores/session-pagination-model.test.ts`
- `git diff --check upstream/dev...HEAD`
- independent gatekeeper review: PASS