### PR TITLE
fix(ui): temporarily raise project session list ceiling

### DIFF
--- a/packages/ui/src/stores/session-list-options.ts
+++ b/packages/ui/src/stores/session-list-options.ts
@@ -1,4 +1,4 @@
-export const PROJECT_SESSION_LIST_LIMIT = 1000
+export const PROJECT_SESSION_LIST_LIMIT = 10000
 
 type ProjectSessionListInput = {
   directory?: string


### PR DESCRIPTION
## Summary

- raise PROJECT_SESSION_LIST_LIMIT from 1,000 to 10,000
- keep sessions visible for projects whose subagent activity exceeds the current 1,000-session cap
- leave the existing one-shot project-scoped request behavior unchanged

## Context

This is an urgent temporary mitigation for the regression described in https://github.com/NeuralNomadsAI/CodeNomad/pull/565#issuecomment-4990950140.

PR #565 replaced paginated loading with a single request capped at 1,000 sessions. Projects that exceed that cap can still have all sessions in OpenCode's database, but older sessions disappear from the CodeNomad UI.

This PR deliberately does not solve the underlying scalability problem. The follow-up fix should restore proper paginated loading and remove reliance on a fixed high ceiling.

## Validation

- npm run typecheck --workspace @codenomad/ui
- node --test packages/ui/src/stores/session-pagination.test.ts (5 passed)