### PR TITLE
feat(restore): persist Yolo and session expansion state

### DIFF
--- a/packages/server/src/api-types.ts
+++ b/packages/server/src/api-types.ts
@@ -415,6 +415,10 @@ export interface YoloStateResponse {
   enabled: boolean
 }
 
+export interface SessionMetadataResponse {
+  metadata: Record<string, unknown>
+}
+
 export interface RemoteServerProfile {
   id: string
   name: string

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -33,6 +33,9 @@ import { PluginChannelManager } from "./plugins/channel"
 import { VoiceModeManager } from "./plugins/voice-mode"
 import { runCliUpgrade } from "./cli-upgrade"
 import { createServerShutdownHandler, orchestrateServerShutdown, type ServerShutdownTrigger } from "./shutdown"
+import { AutoAcceptManager } from "./permissions/auto-accept-manager"
+import { createOpencodePermissionReplier } from "./permissions/opencode-replier"
+import { createOpencodeYoloPersistence } from "./permissions/opencode-yolo-metadata"
 
 const require = createRequire(import.meta.url)
 
@@ -384,6 +387,15 @@ async function main() {
     logger: logger.child({ component: "sidecars" }),
   })
   const previewManager = new PreviewManager()
+  const yoloLogger = logger.child({ component: "yolo" })
+  const sessionMetadataPersistence = createOpencodeYoloPersistence(workspaceManager)
+  const yoloManager = new AutoAcceptManager({
+    eventBus,
+    logger: yoloLogger,
+    replier: createOpencodePermissionReplier({ workspaceManager, logger: yoloLogger }),
+    persistence: sessionMetadataPersistence,
+  })
+  yoloManager.start()
   const instanceEventBridge = new InstanceEventBridge({
     workspaceManager,
     eventBus,
@@ -485,6 +497,8 @@ async function main() {
         pluginChannel,
         voiceModeManager,
         remoteProxySessionManager,
+        yoloManager,
+        sessionMetadataPersistence,
         uiStaticDir: uiResolution.uiStaticDir ?? DEFAULT_UI_STATIC_DIR,
         uiDevServerUrl: uiResolution.uiDevServerUrl,
         logger,
@@ -512,6 +526,8 @@ async function main() {
         pluginChannel,
         voiceModeManager,
         remoteProxySessionManager,
+        yoloManager,
+        sessionMetadataPersistence,
         uiStaticDir: uiResolution.uiStaticDir ?? DEFAULT_UI_STATIC_DIR,
         uiDevServerUrl: undefined,
         logger,
@@ -612,6 +628,7 @@ async function main() {
           stopRemoteProxySessions: () => remoteProxySessionManager.shutdown(),
           stopWorkspaces: () => workspaceManager.shutdown(),
           stopHttpServers: async () => {
+            yoloManager.stop()
             const results = await Promise.allSettled(servers.map((srv) => srv.stop()))
             const failures = results.flatMap((result) => (result.status === "rejected" ? [result.reason] : []))
             if (failures.length > 0) {

--- a/packages/server/src/permissions/auto-accept-manager.test.ts
+++ b/packages/server/src/permissions/auto-accept-manager.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 
 import { EventBus } from "../events/bus"
-import { AutoAcceptManager, type PermissionReplier, type AutoAcceptReply } from "./auto-accept-manager"
+import { AutoAcceptManager, type AutoAcceptPersistence, type PermissionReplier, type AutoAcceptReply } from "./auto-accept-manager"
 import type { InstanceStreamEvent } from "../api-types"
 import type { Logger } from "../logger"
 
@@ -84,6 +84,219 @@ describe("AutoAcceptManager session tree", () => {
     assert.equal(manager.isEnabled("inst", "master"), true)
 
     manager.stop()
+  })
+})
+
+describe("AutoAcceptManager persistence", () => {
+  it("hydrates a persisted family root before processing queued permissions", async () => {
+    const bus = new EventBus(noopLogger)
+    const replier = makeRecordingReplier()
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => { release = resolve })
+    const persistence: AutoAcceptPersistence = {
+      async loadSessions() {
+        await gate
+        return [
+          { id: "root", parentId: null, yoloEnabled: true },
+          { id: "child", parentId: "root", yoloEnabled: false },
+        ]
+      },
+      async persist() {},
+    }
+    const manager = new AutoAcceptManager({ eventBus: bus, logger: noopLogger, replier, persistence })
+    manager.start()
+    publishSession(bus, "inst", "session.updated", { id: "child", parentID: "root" })
+    publishInstanceEvent(bus, "inst", {
+      type: "permission.v2.asked",
+      properties: { id: "permission", sessionID: "child" },
+    })
+    await flushMicrotasks()
+    assert.equal(replier.calls.length, 0)
+    release()
+    await manager.hydrateInstance("inst")
+    await flushMicrotasks()
+    assert.equal(manager.isEnabled("inst", "child"), true)
+    assert.equal(replier.calls.length, 1)
+    manager.stop()
+  })
+
+  it("persists before enabling memory and emitting feedback", async () => {
+    const bus = new EventBus(noopLogger)
+    const changes: Record<string, unknown>[] = []
+    bus.on("yolo.stateChanged", (event) => changes.push(event))
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => { release = resolve })
+    const writes: unknown[][] = []
+    const persistence: AutoAcceptPersistence = {
+      async loadSessions() { return [{ id: "root", parentId: null, yoloEnabled: false }] },
+      async persist(...args) { writes.push(args); await gate },
+    }
+    const manager = new AutoAcceptManager({ eventBus: bus, logger: noopLogger, replier: makeRecordingReplier(), persistence })
+    const toggle = manager.toggle("inst", "root")
+    await flushMicrotasks()
+    assert.deepEqual(writes, [["inst", "root", true, undefined]])
+    assert.equal(manager.isEnabled("inst", "root"), false)
+    assert.equal(changes.length, 0)
+    release()
+    assert.equal(await toggle, true)
+    assert.equal(manager.isEnabled("inst", "root"), true)
+    assert.equal(changes.length, 1)
+  })
+
+  it("serializes concurrent toggles", async () => {
+    const bus = new EventBus(noopLogger)
+    const writes: boolean[] = []
+    const persistence: AutoAcceptPersistence = {
+      async loadSessions() { return [{ id: "root", parentId: null, yoloEnabled: false }] },
+      async persist(_instanceId, _rootSessionId, enabled) { writes.push(enabled) },
+    }
+    const manager = new AutoAcceptManager({ eventBus: bus, logger: noopLogger, replier: makeRecordingReplier(), persistence })
+    assert.deepEqual(await Promise.all([manager.toggle("inst", "root"), manager.toggle("inst", "root")]), [true, false])
+    assert.deepEqual(writes, [true, false])
+    assert.equal(manager.isEnabled("inst", "root"), false)
+  })
+
+  it("keeps queued permissions until a failed hydration can retry", async () => {
+    const bus = new EventBus(noopLogger)
+    const replier = makeRecordingReplier()
+    let attempts = 0
+    const persistence: AutoAcceptPersistence = {
+      async loadSessions() {
+        if (++attempts === 1) throw new Error("temporary failure")
+        return [{ id: "root", parentId: null, yoloEnabled: true }]
+      },
+      async persist() {},
+    }
+    const manager = new AutoAcceptManager({ eventBus: bus, logger: noopLogger, replier, persistence })
+    manager.start()
+    publishInstanceEvent(bus, "inst", {
+      type: "permission.v2.asked",
+      properties: { id: "permission", sessionID: "root" },
+    })
+    await flushMicrotasks()
+    assert.equal(replier.calls.length, 0)
+    await manager.hydrateInstance("inst")
+    await flushMicrotasks()
+    assert.equal(replier.calls.length, 1)
+    manager.stop()
+  })
+
+  it("does not re-enable memory when a persisted toggle finishes after cleanup", async () => {
+    const bus = new EventBus(noopLogger)
+    const changes: Record<string, unknown>[] = []
+    bus.on("yolo.stateChanged", (event) => changes.push(event))
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => { release = resolve })
+    let writes = 0
+    const persistence: AutoAcceptPersistence = {
+      async loadSessions() { return [{ id: "root", parentId: null, yoloEnabled: false }] },
+      async persist() { writes += 1; await gate },
+    }
+    const manager = new AutoAcceptManager({ eventBus: bus, logger: noopLogger, replier: makeRecordingReplier(), persistence })
+    const toggle = manager.toggle("inst", "root")
+    const queued = manager.toggle("inst", "root")
+    await flushMicrotasks()
+    manager.clearInstance("inst")
+    release()
+    assert.equal(await toggle, false)
+    assert.equal(await queued, false)
+    assert.equal(writes, 1)
+    assert.equal(manager.isEnabled("inst", "root"), false)
+    assert.equal(changes.length, 0)
+  })
+
+  it("moves persisted Yolo state when late ancestry changes the family root", async () => {
+    const bus = new EventBus(noopLogger)
+    const writes: unknown[][] = []
+    const persistence: AutoAcceptPersistence = {
+      async loadSessions() {
+        return [
+          { id: "parent", parentId: null, workspaceId: "workspace", yoloEnabled: false },
+          { id: "child", parentId: null, workspaceId: "workspace", yoloEnabled: true },
+        ]
+      },
+      async persist(...args) { writes.push(args) },
+    }
+    const manager = new AutoAcceptManager({ eventBus: bus, logger: noopLogger, replier: makeRecordingReplier(), persistence })
+    manager.start()
+    await manager.hydrateInstance("inst")
+    publishSession(bus, "inst", "session.updated", { id: "child", parentID: "parent", workspaceID: "workspace" })
+    await flushMicrotasks()
+    assert.equal(manager.isEnabled("inst", "parent"), true)
+    assert.deepEqual(writes, [
+      ["inst", "parent", true, "workspace"],
+      ["inst", "child", false, "workspace"],
+    ])
+    manager.stop()
+  })
+
+  it("does not re-enable a family when ancestry repeatedly changes during a disable", async () => {
+    const bus = new EventBus(noopLogger)
+    let releaseFirst!: () => void
+    let releaseSecond!: () => void
+    const firstGate = new Promise<void>((resolve) => { releaseFirst = resolve })
+    const secondGate = new Promise<void>((resolve) => { releaseSecond = resolve })
+    const writes: unknown[][] = []
+    const persistence: AutoAcceptPersistence = {
+      async loadSessions() {
+        return [
+          { id: "grandparent", parentId: null, workspaceId: "workspace", yoloEnabled: false },
+          { id: "parent", parentId: null, workspaceId: "workspace", yoloEnabled: false },
+          { id: "child", parentId: null, workspaceId: "workspace", yoloEnabled: true },
+        ]
+      },
+      async persist(...args) {
+        writes.push(args)
+        if (writes.length === 1) await firstGate
+        if (writes.length === 2) await secondGate
+      },
+    }
+    const manager = new AutoAcceptManager({ eventBus: bus, logger: noopLogger, replier: makeRecordingReplier(), persistence })
+    manager.start()
+    await manager.hydrateInstance("inst")
+    const toggle = manager.toggle("inst", "child")
+    await flushMicrotasks()
+    publishSession(bus, "inst", "session.updated", { id: "child", parentID: "parent", workspaceID: "workspace" })
+    releaseFirst()
+    await flushMicrotasks()
+    publishSession(bus, "inst", "session.updated", { id: "child", parentID: "grandparent", workspaceID: "workspace" })
+    releaseSecond()
+    assert.equal(await toggle, false)
+    await flushMicrotasks()
+    assert.equal(manager.isEnabled("inst", "grandparent"), false)
+    assert.equal(writes.some(([, , enabled]) => enabled === true), false, JSON.stringify(writes))
+    manager.stop()
+  })
+
+  it("allows a queued toggle to continue after an earlier persistence failure", async () => {
+    const bus = new EventBus(noopLogger)
+    let attempts = 0
+    const persistence: AutoAcceptPersistence = {
+      async loadSessions() { return [{ id: "root", parentId: null, yoloEnabled: false }] },
+      async persist() { if (++attempts === 1) throw new Error("write failed") },
+    }
+    const manager = new AutoAcceptManager({ eventBus: bus, logger: noopLogger, replier: makeRecordingReplier(), persistence })
+    const first = manager.toggle("inst", "root")
+    const second = manager.toggle("inst", "root")
+    await assert.rejects(Promise.resolve(first), /write failed/)
+    assert.equal(await second, true)
+    assert.equal(manager.isEnabled("inst", "root"), true)
+  })
+
+  it("does not restore a late hydration after workspace cleanup", async () => {
+    const bus = new EventBus(noopLogger)
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => { release = resolve })
+    const persistence: AutoAcceptPersistence = {
+      async loadSessions() { await gate; return [{ id: "root", parentId: null, yoloEnabled: true }] },
+      async persist() {},
+    }
+    const manager = new AutoAcceptManager({ eventBus: bus, logger: noopLogger, replier: makeRecordingReplier(), persistence })
+    const hydration = manager.hydrateInstance("inst")
+    manager.clearInstance("inst")
+    release()
+    await hydration
+    assert.equal(manager.isEnabled("inst", "root"), false)
   })
 })
 

--- a/packages/server/src/permissions/auto-accept-manager.ts
+++ b/packages/server/src/permissions/auto-accept-manager.ts
@@ -1,6 +1,6 @@
 import type { EventBus } from "../events/bus"
 import type { Logger } from "../logger"
-import { AutoAcceptStore } from "./auto-accept-store"
+import { AutoAcceptStore, type AutoAcceptSessionInfo } from "./auto-accept-store"
 
 /**
  * Server-side owner of Yolo (permission auto-accept).
@@ -39,6 +39,17 @@ interface AutoAcceptManagerDeps {
   eventBus: EventBus
   logger: Logger
   replier: PermissionReplier
+  persistence?: AutoAcceptPersistence
+}
+
+export interface PersistedAutoAcceptSession extends AutoAcceptSessionInfo {
+  yoloEnabled: boolean
+  workspaceId?: string
+}
+
+export interface AutoAcceptPersistence {
+  loadSessions(instanceId: string): Promise<PersistedAutoAcceptSession[]>
+  persist(instanceId: string, rootSessionId: string, enabled: boolean, workspaceId?: string): Promise<void>
 }
 
 const PERMISSION_ASK_TYPES = new Set(["permission.v2.asked", "permission.asked", "permission.updated"])
@@ -55,6 +66,12 @@ export class AutoAcceptManager {
   private readonly pending = new Map<string, Map<string, PendingPermission>>()
   /** instanceId:permissionId -> failure count, to stop retrying stuck permissions */
   private readonly replyAttempts = new Map<string, number>()
+  private readonly hydratedInstances = new Set<string>()
+  private readonly hydration = new Map<string, Promise<void>>()
+  private readonly queuedEvents = new Map<string, InstanceStreamPayload[]>()
+  private readonly instanceGeneration = new Map<string, number>()
+  private readonly sessionWorkspaces = new Map<string, Map<string, string>>()
+  private readonly mutations = new Map<string, Promise<boolean>>()
   private unsubscribe?: () => void
 
   constructor(private readonly deps: AutoAcceptManagerDeps) {}
@@ -63,7 +80,23 @@ export class AutoAcceptManager {
     if (this.unsubscribe) return
     const handler = (payload: { instanceId?: string; event?: InstanceStreamPayload }) => {
       if (!payload || !payload.instanceId || !payload.event) return
+      if (this.deps.persistence && !this.hydratedInstances.has(payload.instanceId)) {
+        const queued = this.queuedEvents.get(payload.instanceId) ?? []
+        queued.push(payload.event)
+        this.queuedEvents.set(payload.instanceId, queued)
+        void this.hydrateInstance(payload.instanceId).catch((error) => {
+          this.deps.logger.warn({ instanceId: payload.instanceId, err: error }, "Failed to hydrate persisted Yolo state")
+        })
+        return
+      }
       this.handleInstanceEvent(payload.instanceId, payload.event)
+    }
+    const onStarted = (event: { workspace?: { id?: string } }) => {
+      const instanceId = event.workspace?.id
+      if (!instanceId) return
+      void this.hydrateInstance(instanceId).catch((error) => {
+        this.deps.logger.warn({ instanceId, err: error }, "Failed to hydrate persisted Yolo state")
+      })
     }
     const onStopped = (event: { workspaceId?: string }) => {
       if (event?.workspaceId) this.clearInstance(event.workspaceId)
@@ -72,10 +105,12 @@ export class AutoAcceptManager {
       if (event?.workspace?.id) this.clearInstance(event.workspace.id)
     }
     this.deps.eventBus.on("instance.event", handler)
+    this.deps.eventBus.on("workspace.started", onStarted)
     this.deps.eventBus.on("workspace.stopped", onStopped)
     this.deps.eventBus.on("workspace.error", onError)
     this.unsubscribe = () => {
       this.deps.eventBus.off("instance.event", handler)
+      this.deps.eventBus.off("workspace.started", onStarted)
       this.deps.eventBus.off("workspace.stopped", onStopped)
       this.deps.eventBus.off("workspace.error", onError)
     }
@@ -90,7 +125,43 @@ export class AutoAcceptManager {
     return this.store.isEnabled(instanceId, sessionId)
   }
 
-  toggle(instanceId: string, sessionId: string): boolean {
+  hydrateInstance(instanceId: string): Promise<void> {
+    if (!this.deps.persistence || this.hydratedInstances.has(instanceId)) return Promise.resolve()
+    const existing = this.hydration.get(instanceId)
+    if (existing) return existing
+    const generation = this.instanceGeneration.get(instanceId) ?? 0
+    let hydrated = false
+    const pending = this.deps.persistence.loadSessions(instanceId).then((sessions) => {
+      if ((this.instanceGeneration.get(instanceId) ?? 0) !== generation) return
+      this.store.clearInstance(instanceId)
+      const workspaces = new Map<string, string>()
+      for (const session of sessions) {
+        this.store.upsertSession(instanceId, session)
+        if (session.workspaceId) workspaces.set(session.id, session.workspaceId)
+      }
+      this.sessionWorkspaces.set(instanceId, workspaces)
+      for (const session of sessions) {
+        if (!session.yoloEnabled || this.store.familyRoot(instanceId, session.id) !== session.id) continue
+        this.store.setEnabled(instanceId, session.id, true)
+        this.deps.eventBus.publish({ type: "yolo.stateChanged", instanceId, sessionId: session.id, enabled: true })
+        this.drainPending(instanceId, session.id)
+      }
+      this.hydratedInstances.add(instanceId)
+      hydrated = true
+    }).finally(() => {
+      if ((this.instanceGeneration.get(instanceId) ?? 0) !== generation) return
+      this.hydration.delete(instanceId)
+      if (!hydrated) return
+      const queued = this.queuedEvents.get(instanceId) ?? []
+      this.queuedEvents.delete(instanceId)
+      for (const event of queued) this.handleInstanceEvent(instanceId, event)
+    })
+    this.hydration.set(instanceId, pending)
+    return pending
+  }
+
+  toggle(instanceId: string, sessionId: string): boolean | Promise<boolean> {
+    if (this.deps.persistence) return this.togglePersisted(instanceId, sessionId)
     const enabled = this.store.toggle(instanceId, sessionId)
     this.deps.eventBus.publish({ type: "yolo.stateChanged", instanceId, sessionId, enabled })
     if (enabled) {
@@ -99,7 +170,74 @@ export class AutoAcceptManager {
     return enabled
   }
 
+  private async togglePersisted(instanceId: string, sessionId: string): Promise<boolean> {
+    await this.hydrateInstance(instanceId)
+    const generation = this.instanceGeneration.get(instanceId) ?? 0
+    const mutation = (this.mutations.get(instanceId) ?? Promise.resolve(false)).catch(() => false).then(async () => {
+      if ((this.instanceGeneration.get(instanceId) ?? 0) !== generation) {
+        return this.store.isEnabled(instanceId, sessionId)
+      }
+      const rootSessionId = this.store.familyRoot(instanceId, sessionId)
+      const traversedRootSessionIds = new Set([rootSessionId])
+      const enabled = !this.store.isEnabled(instanceId, rootSessionId)
+      await this.deps.persistence!.persist(
+        instanceId,
+        rootSessionId,
+        enabled,
+        this.sessionWorkspaces.get(instanceId)?.get(rootSessionId),
+      )
+      if ((this.instanceGeneration.get(instanceId) ?? 0) !== generation) {
+        return this.store.isEnabled(instanceId, rootSessionId)
+      }
+      let persistedRootSessionId = rootSessionId
+      let currentRootSessionId = this.store.familyRoot(instanceId, sessionId)
+      while (currentRootSessionId !== persistedRootSessionId) {
+        traversedRootSessionIds.add(currentRootSessionId)
+        await this.deps.persistence!.persist(
+          instanceId,
+          currentRootSessionId,
+          enabled,
+          this.sessionWorkspaces.get(instanceId)?.get(currentRootSessionId),
+        )
+        if (enabled) {
+          await this.deps.persistence!.persist(
+            instanceId,
+            persistedRootSessionId,
+            false,
+            this.sessionWorkspaces.get(instanceId)?.get(persistedRootSessionId),
+          )
+        }
+        persistedRootSessionId = currentRootSessionId
+        currentRootSessionId = this.store.familyRoot(instanceId, sessionId)
+      }
+      if ((this.instanceGeneration.get(instanceId) ?? 0) !== generation) {
+        return this.store.isEnabled(instanceId, currentRootSessionId)
+      }
+      if (enabled) {
+        this.store.setEnabled(instanceId, currentRootSessionId, true)
+      } else {
+        for (const traversedRootSessionId of traversedRootSessionIds) {
+          this.store.setEnabled(instanceId, traversedRootSessionId, false)
+        }
+      }
+      this.deps.eventBus.publish({ type: "yolo.stateChanged", instanceId, sessionId: currentRootSessionId, enabled })
+      if (enabled) this.drainPending(instanceId, currentRootSessionId)
+      return enabled
+    })
+    const settled = mutation.finally(() => {
+      if (this.mutations.get(instanceId) === settled) this.mutations.delete(instanceId)
+    })
+    this.mutations.set(instanceId, settled)
+    return settled
+  }
+
   clearInstance(instanceId: string): void {
+    this.instanceGeneration.set(instanceId, (this.instanceGeneration.get(instanceId) ?? 0) + 1)
+    this.hydratedInstances.delete(instanceId)
+    this.hydration.delete(instanceId)
+    this.queuedEvents.delete(instanceId)
+    this.sessionWorkspaces.delete(instanceId)
+    this.mutations.delete(instanceId)
     this.store.clearInstance(instanceId)
     this.pending.delete(instanceId)
     const prefix = `${instanceId}:`
@@ -147,12 +285,52 @@ export class AutoAcceptManager {
     if (!session || typeof session.id !== "string") return
     const parentId = session.parentID ?? session.parentId ?? null
     const revert = session.revert ?? undefined
+    const enabledBefore = this.store.enabledRoots(instanceId)
     this.store.upsertSession(instanceId, { id: session.id, parentId, revert })
+    if (typeof session.workspaceID === "string" && session.workspaceID) {
+      const workspaces = this.sessionWorkspaces.get(instanceId) ?? new Map<string, string>()
+      workspaces.set(session.id, session.workspaceID)
+      this.sessionWorkspaces.set(instanceId, workspaces)
+    }
+    this.persistRootMigration(instanceId, enabledBefore, this.store.enabledRoots(instanceId))
     // Session ancestry may have changed (parent discovered, revert toggled).
     // Re-drain pending permissions whose family root may have migrated into
     // an enabled family — mirrors the old UI's drainAutoAcceptPermissions-
     // ForInstance trigger on session.updated (#497).
     this.drainPending(instanceId, session.id)
+  }
+
+  private persistRootMigration(instanceId: string, before: readonly string[], after: readonly string[]): void {
+    if (!this.deps.persistence) return
+    const removed = before.filter((id) => !after.includes(id))
+    const added = after.filter((id) => !before.includes(id))
+    if (removed.length === 0 && added.length === 0) return
+    const generation = this.instanceGeneration.get(instanceId) ?? 0
+    const mutation = (this.mutations.get(instanceId) ?? Promise.resolve(false)).catch(() => false).then(async () => {
+      if ((this.instanceGeneration.get(instanceId) ?? 0) !== generation) return false
+      const enabledRoots = new Set(this.store.enabledRoots(instanceId))
+      for (const rootSessionId of added) {
+        if (!enabledRoots.has(rootSessionId)) continue
+        await this.deps.persistence!.persist(
+          instanceId, rootSessionId, true, this.sessionWorkspaces.get(instanceId)?.get(rootSessionId),
+        )
+      }
+      for (const rootSessionId of removed) {
+        if (enabledRoots.has(rootSessionId)) continue
+        if ((this.instanceGeneration.get(instanceId) ?? 0) !== generation) return false
+        await this.deps.persistence!.persist(
+          instanceId, rootSessionId, false, this.sessionWorkspaces.get(instanceId)?.get(rootSessionId),
+        )
+      }
+      return false
+    })
+    const settled = mutation.finally(() => {
+      if (this.mutations.get(instanceId) === settled) this.mutations.delete(instanceId)
+    })
+    this.mutations.set(instanceId, settled)
+    void settled.catch((error) => {
+      this.deps.logger.warn({ instanceId, err: error }, "Failed to migrate persisted Yolo family root")
+    })
   }
 
   private handlePermissionRequest(instanceId: string, eventType: string, permission: unknown): void {
@@ -275,6 +453,7 @@ interface SessionProperties {
   parentID?: string | null
   parentId?: string | null
   revert?: unknown
+  workspaceID?: string
 }
 
 interface PermissionProperties {

--- a/packages/server/src/permissions/auto-accept-store.ts
+++ b/packages/server/src/permissions/auto-accept-store.ts
@@ -8,8 +8,8 @@
  *   - a session with a `revert` snapshot is treated as its own root (fork)
  *   - enabling any session enables its whole family root and vice-versa
  *
- * No persistence: state is lost on server restart, matching the "no
- * persistence for now" milestone.
+ * This store remains in-memory; AutoAcceptManager hydrates and persists it
+ * through OpenCode session metadata.
  */
 
 export interface AutoAcceptSessionInfo {
@@ -106,6 +106,10 @@ export class AutoAcceptStore {
   familyRoot(instanceId: string, sessionId: string): string {
     const tree = this.sessions.get(instanceId)
     return resolveFamilyRoot(sessionId, (id) => tree?.get(id))
+  }
+
+  enabledRoots(instanceId: string): string[] {
+    return [...(this.enabled.get(instanceId) ?? [])]
   }
 
   /**

--- a/packages/server/src/permissions/opencode-yolo-metadata.test.ts
+++ b/packages/server/src/permissions/opencode-yolo-metadata.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { createOpencodeYoloPersistence, hasPersistedYolo, mergePersistedYolo } from "./opencode-yolo-metadata"
+
+describe("OpenCode Yolo metadata", () => {
+  it("preserves unrelated metadata while replacing Yolo state", () => {
+    assert.deepEqual(
+      mergePersistedYolo({ thirdParty: { keep: true }, codenomad: { version: 1, worktreeSlug: "feature" } }, "root", true),
+      {
+        thirdParty: { keep: true },
+        codenomad: { version: 1, worktreeSlug: "feature", yolo: { enabled: true, rootSessionId: "root" } },
+      },
+    )
+  })
+
+  it("accepts only a marker owned by its session", () => {
+    const metadata = mergePersistedYolo({}, "root", true)
+    assert.equal(hasPersistedYolo("root", metadata), true)
+    assert.equal(hasPersistedYolo("fork", metadata), false)
+    assert.equal(hasPersistedYolo("root", mergePersistedYolo({}, "root", false)), false)
+  })
+
+  it("uses the session workspace for metadata updates", async () => {
+    const calls: Array<Record<string, unknown>> = []
+    const client = {
+      session: {
+        async list() { return { data: [{ id: "root", parentID: null, workspaceID: "workspace", metadata: {} }] } },
+        async get(parameters: Record<string, unknown>) { calls.push(parameters); return { data: { metadata: {} } } },
+        async update(parameters: Record<string, unknown>) { calls.push(parameters); return { data: {} } },
+      },
+    }
+    const persistence = createOpencodeYoloPersistence({} as never, () => client as never)
+    const [session] = await persistence.loadSessions("instance")
+    await persistence.persist("instance", "root", true, session?.workspaceId)
+    assert.equal(session?.workspaceId, "workspace")
+    assert.equal(calls[0]?.workspace, "workspace")
+    assert.equal(calls[1]?.workspace, "workspace")
+  })
+
+  it("serializes Yolo and worktree metadata writes across instances", async () => {
+    let metadata: Record<string, unknown> = { thirdParty: true }
+    const client = {
+      session: {
+        async get() { return { data: { metadata } } },
+        async update(parameters: Record<string, unknown>) {
+          metadata = parameters.metadata as Record<string, unknown>
+          return { data: { metadata } }
+        },
+      },
+    }
+    const persistence = createOpencodeYoloPersistence({} as never, () => client as never)
+    await Promise.all([
+      persistence.persist("instance-a", "root", true),
+      persistence.setWorktreeSlug("instance-b", "root", "feature"),
+    ])
+    assert.deepEqual(metadata, {
+      thirdParty: true,
+      codenomad: { version: 1, yolo: { enabled: true, rootSessionId: "root" }, worktreeSlug: "feature" },
+    })
+  })
+})

--- a/packages/server/src/permissions/opencode-yolo-metadata.ts
+++ b/packages/server/src/permissions/opencode-yolo-metadata.ts
@@ -1,0 +1,111 @@
+import type { OpencodeClient } from "@opencode-ai/sdk/v2/client"
+import type { WorkspaceManager } from "../workspaces/manager"
+import { createInstanceClient } from "../workspaces/instance-client"
+import type { AutoAcceptPersistence, PersistedAutoAcceptSession } from "./auto-accept-manager"
+
+const CODENOMAD_METADATA_VERSION = 1
+const SESSION_LIST_LIMIT = 10_000
+
+type Metadata = Record<string, unknown>
+
+export interface OpencodeYoloPersistence extends AutoAcceptPersistence {
+  hasProjectSession(instanceId: string, sessionId: string): Promise<boolean>
+  setWorktreeSlug(instanceId: string, sessionId: string, worktreeSlug: string): Promise<Metadata>
+}
+
+function record(value: unknown): Metadata {
+  return value && typeof value === "object" && !Array.isArray(value) ? { ...(value as Metadata) } : {}
+}
+
+export function hasPersistedYolo(sessionId: string, metadata: unknown): boolean {
+  const codenomad = record(record(metadata).codenomad)
+  const yolo = record(codenomad.yolo)
+  return codenomad.version === CODENOMAD_METADATA_VERSION
+    && yolo.enabled === true
+    && yolo.rootSessionId === sessionId
+}
+
+export function mergePersistedYolo(metadata: unknown, rootSessionId: string, enabled: boolean): Metadata {
+  const current = record(metadata)
+  const codenomad = record(current.codenomad)
+  return {
+    ...current,
+    codenomad: {
+      ...codenomad,
+      version: CODENOMAD_METADATA_VERSION,
+      yolo: { enabled, rootSessionId },
+    },
+  }
+}
+
+export function mergePersistedWorktreeSlug(metadata: unknown, worktreeSlug: string): Metadata {
+  const current = record(metadata)
+  const codenomad = record(current.codenomad)
+  return {
+    ...current,
+    codenomad: { ...codenomad, version: CODENOMAD_METADATA_VERSION, worktreeSlug },
+  }
+}
+
+export function createOpencodeYoloPersistence(
+  workspaceManager: WorkspaceManager,
+  createClient: (manager: WorkspaceManager, instanceId: string) => OpencodeClient | null = createInstanceClient,
+): OpencodeYoloPersistence {
+  const writes = new Map<string, Promise<unknown>>()
+  const clientFor = (instanceId: string) => {
+    const client = createClient(workspaceManager, instanceId)
+    if (!client) throw new Error(`Yolo: instance ${instanceId} has no open port`)
+    return client
+  }
+  const updateMetadata = (
+    instanceId: string,
+    sessionId: string,
+    workspaceId: string | undefined,
+    update: (metadata: unknown) => Metadata,
+  ): Promise<Metadata> => {
+    const writeKey = sessionId
+    const write = (writes.get(writeKey) ?? Promise.resolve()).catch(() => undefined).then(async () => {
+      const client = clientFor(instanceId)
+      const scope = { sessionID: sessionId, ...(workspaceId ? { workspace: workspaceId } : {}) }
+      const { data: session } = await client.session.get(scope, { throwOnError: true })
+      const metadata = update(session.metadata)
+      const { data } = await client.session.update({ ...scope, metadata }, { throwOnError: true })
+      return record(data?.metadata ?? metadata)
+    })
+    const settled = write.finally(() => {
+      if (writes.get(writeKey) === settled) writes.delete(writeKey)
+    })
+    writes.set(writeKey, settled)
+    return settled
+  }
+  return {
+    async loadSessions(instanceId): Promise<PersistedAutoAcceptSession[]> {
+      const { data } = await clientFor(instanceId).session.list(
+        { scope: "project", limit: SESSION_LIST_LIMIT },
+        { throwOnError: true },
+      )
+      return (data ?? []).map((session) => ({
+        id: session.id,
+        parentId: session.parentID ?? null,
+        revert: session.revert,
+        workspaceId: session.workspaceID,
+        yoloEnabled: hasPersistedYolo(session.id, session.metadata),
+      }))
+    },
+    persist(instanceId, rootSessionId, enabled, workspaceId): Promise<void> {
+      return updateMetadata(instanceId, rootSessionId, workspaceId,
+        (metadata) => mergePersistedYolo(metadata, rootSessionId, enabled)).then(() => undefined)
+    },
+    async hasProjectSession(instanceId, sessionId): Promise<boolean> {
+      const { data } = await clientFor(instanceId).session.list(
+        { scope: "project", limit: SESSION_LIST_LIMIT },
+        { throwOnError: true },
+      )
+      return (data ?? []).some((session) => session.id === sessionId)
+    },
+    setWorktreeSlug(instanceId, sessionId, worktreeSlug): Promise<Metadata> {
+      return updateMetadata(instanceId, sessionId, undefined,
+        (metadata) => mergePersistedWorktreeSlug(metadata, worktreeSlug))
+    },
+  }
+}

--- a/packages/server/src/server/http-server.ts
+++ b/packages/server/src/server/http-server.ts
@@ -34,8 +34,8 @@ import { registerUsageRoutes } from "./routes/usage"
 import { ServerMeta } from "../api-types"
 import { InstanceStore } from "../storage/instance-store"
 import { BackgroundProcessManager } from "../background-processes/manager"
-import { AutoAcceptManager } from "../permissions/auto-accept-manager"
-import { createOpencodePermissionReplier } from "../permissions/opencode-replier"
+import type { AutoAcceptManager } from "../permissions/auto-accept-manager"
+import type { OpencodeYoloPersistence } from "../permissions/opencode-yolo-metadata"
 import type { AuthManager } from "../auth/manager"
 import { registerAuthRoutes } from "./routes/auth"
 import { sendUnauthorized, wantsHtml } from "../auth/http-auth"
@@ -69,6 +69,8 @@ interface HttpServerDeps {
   pluginChannel: PluginChannelManager
   voiceModeManager: VoiceModeManager
   remoteProxySessionManager: RemoteProxySessionManager
+  yoloManager: AutoAcceptManager
+  sessionMetadataPersistence: OpencodeYoloPersistence
   uiStaticDir: string
   uiDevServerUrl?: string
   logger: Logger
@@ -198,16 +200,6 @@ export function createHttpServer(deps: HttpServerDeps) {
     logger: deps.logger.child({ component: "background-processes" }),
   })
 
-  const yoloManager = new AutoAcceptManager({
-    eventBus: deps.eventBus,
-    logger: deps.logger.child({ component: "yolo" }),
-    replier: createOpencodePermissionReplier({
-      workspaceManager: deps.workspaceManager,
-      logger: deps.logger.child({ component: "yolo" }),
-    }),
-  })
-  yoloManager.start()
-
   registerAuthRoutes(app, { authManager: deps.authManager })
 
   app.addHook("preHandler", (request, reply, done) => {
@@ -298,7 +290,10 @@ export function createHttpServer(deps: HttpServerDeps) {
     logger: sseLogger,
     connectionManager: deps.clientConnectionManager,
   })
-  registerWorktreeRoutes(app, { workspaceManager: deps.workspaceManager })
+  registerWorktreeRoutes(app, {
+    workspaceManager: deps.workspaceManager,
+    sessionMetadataPersistence: deps.sessionMetadataPersistence,
+  })
   registerStorageRoutes(app, {
     instanceStore: deps.instanceStore,
     eventBus: deps.eventBus,
@@ -330,7 +325,7 @@ export function createHttpServer(deps: HttpServerDeps) {
     voiceModeManager: deps.voiceModeManager,
   })
   registerBackgroundProcessRoutes(app, { backgroundProcessManager })
-  registerYoloRoutes(app, { yoloManager })
+  registerYoloRoutes(app, { yoloManager: deps.yoloManager })
   registerInstanceProxyRoutes(app, { workspaceManager: deps.workspaceManager, logger: proxyLogger })
 
 
@@ -393,7 +388,6 @@ export function createHttpServer(deps: HttpServerDeps) {
       return { port: actualPort, url: serverUrl, displayHost }
     },
     stop: () => {
-      yoloManager.stop()
       closeSseClients()
       return app.close()
     },

--- a/packages/server/src/server/routes/worktrees.ts
+++ b/packages/server/src/server/routes/worktrees.ts
@@ -9,10 +9,12 @@ import {
   removeWorktree,
 } from "../../workspaces/git-worktrees"
 import type { WorktreeListResponse, WorktreeMap } from "../../api-types"
+import type { OpencodeYoloPersistence } from "../../permissions/opencode-yolo-metadata"
 import { ensureCodenomadGitExclude, readWorktreeMap, writeWorktreeMap } from "../../workspaces/worktree-map"
 
 interface RouteDeps {
   workspaceManager: WorkspaceManager
+  sessionMetadataPersistence: OpencodeYoloPersistence
 }
 
 const WorktreeMapSchema = z.object({
@@ -26,7 +28,34 @@ const WorktreeCreateSchema = z.object({
   branch: z.string().trim().min(1).optional(),
 })
 
+const WorktreeSessionSchema = z.object({ worktreeSlug: z.string().trim().refine(isValidWorktreeSlug) })
+
 export function registerWorktreeRoutes(app: FastifyInstance, deps: RouteDeps) {
+  app.put<{ Params: { id: string; sessionId: string }; Body: unknown }>(
+    "/api/workspaces/:id/worktrees/sessions/:sessionId",
+    async (request, reply) => {
+      if (!deps.workspaceManager.get(request.params.id)) {
+        reply.code(404)
+        return { error: "Workspace not found" }
+      }
+      try {
+        const body = WorktreeSessionSchema.parse(request.body)
+        if (!await deps.sessionMetadataPersistence.hasProjectSession(request.params.id, request.params.sessionId)) {
+          reply.code(404)
+          return { error: "Session not found" }
+        }
+        const metadata = await deps.sessionMetadataPersistence.setWorktreeSlug(
+          request.params.id,
+          request.params.sessionId,
+          body.worktreeSlug,
+        )
+        return { metadata }
+      } catch (error) {
+        return handleError(error, reply)
+      }
+    },
+  )
+
   app.get<{ Params: { id: string } }>("/api/workspaces/:id/worktrees", async (request, reply) => {
     const workspace = deps.workspaceManager.get(request.params.id)
     if (!workspace) {

--- a/packages/server/src/server/routes/yolo.ts
+++ b/packages/server/src/server/routes/yolo.ts
@@ -10,6 +10,7 @@ export function registerYoloRoutes(app: FastifyInstance, deps: RouteDeps) {
     "/workspaces/:id/yolo/sessions/:sessionId",
     async (request) => {
       const { id, sessionId } = request.params
+      await deps.yoloManager.hydrateInstance(id)
       return { enabled: deps.yoloManager.isEnabled(id, sessionId) }
     },
   )
@@ -18,7 +19,7 @@ export function registerYoloRoutes(app: FastifyInstance, deps: RouteDeps) {
     "/workspaces/:id/yolo/sessions/:sessionId/toggle",
     async (request, reply) => {
       const { id, sessionId } = request.params
-      const enabled = deps.yoloManager.toggle(id, sessionId)
+      const enabled = await deps.yoloManager.toggle(id, sessionId)
       reply.code(200)
       return { enabled }
     },

--- a/packages/ui/src/components/session-list.tsx
+++ b/packages/ui/src/components/session-list.tsx
@@ -746,14 +746,6 @@ const SessionList: Component<SessionListProps> = (props) => {
     )
   }
 
-  createEffect(() => {
-    const activeId = props.activeSessionId
-    if (!activeId || activeId === "info") return
-    const activeSession = sessionStateSessions().get(props.instanceId)?.get(activeId)
-    if (!activeSession?.parentId) return
-    ensureSessionAncestorsExpanded(props.instanceId, activeId)
-  })
- 
   createEffect(on(
     () => [props.activeSessionId, virtualizerHandle()] as const,
     ([activeId, handle]) => {

--- a/packages/ui/src/lib/api-client.ts
+++ b/packages/ui/src/lib/api-client.ts
@@ -20,6 +20,7 @@ import type {
   PreviewSession,
   ProviderUsageResponse,
   ServerMeta,
+  SessionMetadataResponse,
   RemoteProxySessionCreateRequest,
   RemoteProxySessionCreateResponse,
   RemoteServerProbeRequest,
@@ -560,6 +561,12 @@ export const serverApi = {
     return request<YoloStateResponse>(
       `/workspaces/${encodeURIComponent(instanceId)}/yolo/sessions/${encodeURIComponent(sessionId)}/toggle`,
       { method: "POST" },
+    )
+  },
+  setSessionWorktreeSlug(instanceId: string, sessionId: string, worktreeSlug: string): Promise<SessionMetadataResponse> {
+    return request<SessionMetadataResponse>(
+      `/api/workspaces/${encodeURIComponent(instanceId)}/worktrees/sessions/${encodeURIComponent(sessionId)}`,
+      { method: "PUT", body: JSON.stringify({ worktreeSlug }) },
     )
   },
   sendClientConnectionPong(payload: { clientId: string; connectionId: string; pingTs?: number }, signal?: AbortSignal): Promise<void> {

--- a/packages/ui/src/lib/hooks/use-app-session-capture.ts
+++ b/packages/ui/src/lib/hooks/use-app-session-capture.ts
@@ -20,8 +20,9 @@ import { activeAppTabId, appTabs, getInstanceAppTabId } from "../../stores/app-t
 import { showFolderSelection } from "../../stores/ui"
 import { instances, waitForInstanceInitialSessionHydration } from "../../stores/instances"
 import {
-  activeParentSessionId, activeSessionId, getAuthoritativeDraftSessionIdsForInstance,
-  getAuthoritativelyDeletedSessionIdsForInstance, getSessionDraftPromptsForInstance, getSessions,
+  activeParentSessionId, activeSessionId, expandedSessions, getAuthoritativeDraftSessionIdsForInstance,
+  getAuthoritativeSessionExpansionIdsForInstance, getAuthoritativelyDeletedSessionIdsForInstance,
+  getSessionDraftPromptsForInstance, getSessions,
   hasAuthoritativeSessionSelection,
 } from "../../stores/sessions"
 import { messageStoreBus } from "../../stores/message-v2/bus"
@@ -75,6 +76,8 @@ function captureState(scrollAuthority: ReadonlyMap<string, ReadonlySet<string>>)
     const id = tab.instance.id
     const parentId = activeParentSessionId().get(id)
     const sessionId = activeSessionId().get(id)
+    const expansionAuthority = getAuthoritativeSessionExpansionIdsForInstance(id)
+    const expanded = [...(expandedSessions().get(id) ?? [])]
     const prioritySessionIds = [sessionId, "__no_session_draft__"].filter((value): value is string => Boolean(value))
     const result: RestorableWorkspaceTabState = {
       kind: "workspace", folder: tab.instance.folder, occurrence: occurrenceByInstance.get(id) ?? 0,
@@ -82,6 +85,10 @@ function captureState(scrollAuthority: ReadonlyMap<string, ReadonlySet<string>>)
         getSessionDraftPromptsForInstance(id), getSessionAttachmentsForInstance(id), prioritySessionIds,
       ),
       ...captureRuntimeState(id), scrollSnapshots: captureScrollSnapshots(id),
+      expandedSessionIds: [
+        ...expanded.filter((sessionId) => expansionAuthority.has(sessionId)),
+        ...expanded.filter((sessionId) => !expansionAuthority.has(sessionId)),
+      ],
     }
     if (tab.instance.projectName) result.projectName = tab.instance.projectName
     if (tab.instance.binaryPath) result.binaryPath = tab.instance.binaryPath
@@ -97,6 +104,7 @@ function captureState(scrollAuthority: ReadonlyMap<string, ReadonlySet<string>>)
       drafts: getAuthoritativeDraftSessionIdsForInstance(id),
       attachments: getAuthoritativeAttachmentSessionIdsForInstance(id),
       scrollSnapshots: scrollAuthority.get(id), idleMarkers: sessionIds, generationRecovery: sessionIds,
+      sessionExpansion: getAuthoritativeSessionExpansionIdsForInstance(id),
       deletedSessions: getAuthoritativelyDeletedSessionIdsForInstance(id),
       sessionSelection: hasAuthoritativeSessionSelection(id),
     }
@@ -237,7 +245,7 @@ export function useAppSessionCapture() {
   createEffect(() => {
     if (!enabled()) return
     const tabs = appTabs()
-    activeAppTabId(); activeParentSessionId(); activeSessionId(); showFolderSelection()
+    activeAppTabId(); activeParentSessionId(); activeSessionId(); expandedSessions(); showFolderSelection()
     for (const tab of tabs) if (tab.kind === "instance") {
       getSessions(tab.instance.id)
       getSessionDraftPromptsForInstance(tab.instance.id)

--- a/packages/ui/src/stores/app-session-reconciliation.test.ts
+++ b/packages/ui/src/stores/app-session-reconciliation.test.ts
@@ -57,6 +57,7 @@ describe("app session reconciliation", () => {
     assert.deepEqual(unavailable({ activeParentSessionId: "loaded", activeSessionId: "info", draftSessionIds: ["loaded", "__no_session_draft__"], attachmentSessionIds: ["loaded"], scrollSessionIds: ["loaded"] }, ["__no_session_draft__"]), [])
     assert.notEqual(unavailable({ activeParentSessionId: "missing-parent", activeSessionId: "missing-active", draftSessionIds: ["missing-draft"], attachmentSessionIds: ["missing-attachment"], scrollSessionIds: ["missing-scroll"] }).length, 0)
     assert.deepEqual(unavailable({ activeSessionId: "missing-active", draftSessionIds: ["missing-draft"], attachmentSessionIds: ["missing-attachment"], scrollSessionIds: ["loaded"] }), ["missing-active", "missing-draft", "missing-attachment"])
+    assert.deepEqual(unavailable({ draftSessionIds: [], scrollSessionIds: [], expandedSessionIds: ["loaded", "later"] }), ["later"])
   })
 
   it("falls back to the first restored tab when the active SideCar failed", () => {

--- a/packages/ui/src/stores/app-session-reconciliation.ts
+++ b/packages/ui/src/stores/app-session-reconciliation.ts
@@ -9,6 +9,7 @@ export interface RestoredSessionReferences {
   scrollSessionIds: readonly string[]
   idleMarkerSessionIds?: readonly string[]
   generationRecoverySessionIds?: readonly string[]
+  expandedSessionIds?: readonly string[]
 }
 export function normalizeWorkspacePath(folderPath: string): string {
   const windowsLike = /^(?:[A-Za-z]:[/\\]|[/\\]{2})/.test(folderPath)
@@ -90,6 +91,7 @@ export function getUnavailableRestoredSessionIds(
     ...references.scrollSessionIds,
     ...(references.idleMarkerSessionIds ?? []),
     ...(references.generationRecoverySessionIds ?? []),
+    ...(references.expandedSessionIds ?? []),
   ]
   return new Set(referenced.filter((id): id is string => Boolean(id) && !available.has(id!) && !allowed.has(id!)))
 }

--- a/packages/ui/src/stores/app-session-snapshot-merge.test.ts
+++ b/packages/ui/src/stores/app-session-snapshot-merge.test.ts
@@ -223,6 +223,19 @@ describe("app session snapshot merge", () => {
     assert.equal(tab.generationRecovery.id, "interrupted")
   })
 
+  it("keeps later expansion while loaded collapse and deletion remain authoritative", () => {
+    const saved = session([workspace("/work", 0, { expandedSessionIds: ["loaded", "later", "deleted"] })])
+    const merged = mergeRestorableSessionState(
+      session([workspace("/work", 0, { expandedSessionIds: ["current", "deleted"] })]),
+      restored(saved, [{ source: 0, runtime: "instance:work", unavailable: ["later", "deleted"] }]),
+      {
+        currentTabIds: ["instance:work"],
+        currentTabAuthorities: [{ sessionExpansion: new Set(["loaded"]), deletedSessions: new Set(["deleted"]) }],
+      },
+    )
+    assert.deepEqual(workspaceAt(merged).expandedSessionIds, ["current", "later"])
+  })
+
   for (const testCase of [
     { label: "later parent/child selection", current: { activeParentSessionId: "current-parent", activeSessionId: "current-child" },
       expected: ["current-parent", "current-child"] },

--- a/packages/ui/src/stores/app-session-snapshot-merge.ts
+++ b/packages/ui/src/stores/app-session-snapshot-merge.ts
@@ -21,6 +21,7 @@ export interface RestorableWorkspaceRuntimeAuthority {
   scrollSnapshots?: ReadonlySet<string>
   idleMarkers?: ReadonlySet<string>
   generationRecovery?: ReadonlySet<string>
+  sessionExpansion?: ReadonlySet<string>
   deletedSessions?: ReadonlySet<string>
   sessionSelection?: boolean
 }
@@ -155,6 +156,7 @@ function getPreservedTab(source: RestorableTabState, result: RestoreTabResult): 
     scrollSnapshots: keep(source.scrollSnapshots),
     unseenIdleSince: keep(source.unseenIdleSince),
     generationRecovery: keep(source.generationRecovery),
+    expandedSessionIds: (source.expandedSessionIds ?? []).filter((id) => unavailable.has(id)),
   }
   if (source.occurrence !== undefined) tab.occurrence = source.occurrence
   if (source.activeParentSessionId && unavailable.has(source.activeParentSessionId)) {
@@ -180,6 +182,11 @@ function mergeWorkspaceState(
     scrollSnapshots: mergeRecords(current.scrollSnapshots, preserved.scrollSnapshots, authority.scrollSnapshots),
     unseenIdleSince: mergeRecords(current.unseenIdleSince, preserved.unseenIdleSince, authority.idleMarkers),
     generationRecovery: mergeRecords(current.generationRecovery, preserved.generationRecovery, authority.generationRecovery),
+    expandedSessionIds: [
+      ...(current.expandedSessionIds ?? []).filter((id) => !authority.deletedSessions?.has(id)),
+      ...(preserved.expandedSessionIds ?? []).filter((id) =>
+        !authority.sessionExpansion?.has(id) && !authority.deletedSessions?.has(id)),
+    ].filter((id, index, values) => values.indexOf(id) === index),
   }
   const restoreSelection = !authority.sessionSelection && !current.activeParentSessionId && !current.activeSessionId
   if (restoreSelection && preserved.activeParentSessionId && !authority.deletedSessions?.has(preserved.activeParentSessionId)) {

--- a/packages/ui/src/stores/app-session-workspace-hydration.ts
+++ b/packages/ui/src/stores/app-session-workspace-hydration.ts
@@ -3,9 +3,10 @@ import { getUnavailableRestoredSessionIds, resolveRestoredSessionSelection } fro
 import { getAbortReason } from "./app-session-restore-timeout"
 import { hydrateWorkspacePromptState } from "./app-session-prompt-hydration"
 import { messageStoreBus, type MessageScrollSnapshotSeed } from "./message-v2/bus"
+import { getSessionAncestorIdsFromMap } from "./session-tree"
 import {
   getSessions, hasAuthoritativeSessionSelection, hydrateActiveSessionSelection,
-  hydrateRestoredSessionChain, hydrateSessionGenerationRecovery, hydrateSessionIdleMarkers,
+  hydrateRestoredSessionChain, hydrateSessionExpansion, hydrateSessionGenerationRecovery, hydrateSessionIdleMarkers,
 } from "./sessions"
 
 const MESSAGE_SCROLL_SCOPE = "message-stream"
@@ -22,20 +23,25 @@ export async function hydrateRestoredWorkspaceState(
   if (!isCurrentBinding()) return null
   const sessions = getSessions(instanceId)
   const validIds = new Set(sessions.map(({ id }) => id))
+  const selection = resolveRestoredSessionSelection(sessions, snapshot.activeParentSessionId, snapshot.activeSessionId)
   const unavailable = getUnavailableRestoredSessionIds(sessions, {
     activeParentSessionId: snapshot.activeParentSessionId, activeSessionId: snapshot.activeSessionId,
     draftSessionIds: Object.keys(snapshot.drafts), attachmentSessionIds: Object.keys(snapshot.attachments),
     scrollSessionIds: Object.keys(snapshot.scrollSnapshots), idleMarkerSessionIds: Object.keys(snapshot.unseenIdleSince),
     generationRecoverySessionIds: Object.keys(snapshot.generationRecovery),
+    expandedSessionIds: snapshot.expandedSessionIds ?? [],
   }, [NO_SESSION_DRAFT_SESSION_ID])
   hydrateWorkspacePromptState(instanceId, snapshot, validIds, NO_SESSION_DRAFT_SESSION_ID)
   hydrateSessionIdleMarkers(instanceId, snapshot.unseenIdleSince)
   hydrateSessionGenerationRecovery(instanceId, snapshot.generationRecovery)
+  const expandedSessionIds = snapshot.expandedSessionIds ?? (!hasAuthoritativeSessionSelection(instanceId) && selection?.activeSessionId
+    ? getSessionAncestorIdsFromMap(new Map(sessions.map((session) => [session.id, session])), selection.activeSessionId)
+    : [])
+  hydrateSessionExpansion(instanceId, expandedSessionIds)
   const scrollSeeds: MessageScrollSnapshotSeed[] = Object.entries(snapshot.scrollSnapshots)
     .map(([sessionId, scrollSnapshot]) => ({ sessionId, scope: MESSAGE_SCROLL_SCOPE, snapshot: scrollSnapshot }))
   messageStoreBus.seedScrollSnapshots(instanceId, scrollSeeds)
   if (!hasAuthoritativeSessionSelection(instanceId)) {
-    const selection = resolveRestoredSessionSelection(sessions, snapshot.activeParentSessionId, snapshot.activeSessionId)
     hydrateActiveSessionSelection(instanceId, selection?.parentSessionId ?? null, selection?.activeSessionId ?? null)
   }
   return unavailable

--- a/packages/ui/src/stores/client-state-codec.test.ts
+++ b/packages/ui/src/stores/client-state-codec.test.ts
@@ -50,6 +50,7 @@ describe("client state codec", () => {
           scrollSnapshots: { session1: { scrollTop: 120, scrollRatio: 0.5, atBottom: false, updatedAt: 1200 } },
           unseenIdleSince: { session1: 1100, malformed: -1 },
           generationRecovery: { session1: "working", session2: "interrupted", malformed: "idle" },
+          expandedSessionIds: ["session1", "session1", 42],
         }), { kind: "sidecar", sidecarId: "docs" }],
       },
     }))
@@ -63,6 +64,7 @@ describe("client state codec", () => {
     assert.deepEqual({ ...tab.drafts }, { session1: "unfinished prompt" })
     assert.deepEqual({ ...tab.unseenIdleSince }, { session1: 1100 })
     assert.deepEqual({ ...tab.generationRecovery }, { session1: "working", session2: "interrupted" })
+    assert.deepEqual(tab.expandedSessionIds, ["session1"])
     assert.deepEqual(tab.scrollSnapshots.session1, { scrollTop: 120, scrollRatio: 0.5, atBottom: false, updatedAt: 1200 })
     assert.deepEqual(decoded?.session?.tabs[1], { kind: "sidecar", sidecarId: "docs" })
   })
@@ -77,6 +79,7 @@ describe("client state codec", () => {
     assert.equal(isFutureClientSnapshot({ version: 2 }), true, "future envelope")
     assert.equal(isFutureClientSnapshot({ version: 1 }), false, "current envelope")
     assert.equal(normalizeRestorableSession({ tabs: [{ kind: "workspace" }], activeTabIndex: 0 }), null)
+    assert.equal(normalizeWorkspace({}).expandedSessionIds, undefined)
   })
 
   it("caps records and drops unsafe or malformed entries", () => {

--- a/packages/ui/src/stores/client-state-codec.ts
+++ b/packages/ui/src/stores/client-state-codec.ts
@@ -9,6 +9,7 @@ export interface RestorableWorkspaceTabState {
   drafts: Record<string, string>; attachments: Record<string, RestorableAttachment[]>
   scrollSnapshots: Record<string, ScrollSnapshot>; unseenIdleSince: Record<string, number>
   generationRecovery: Record<string, PersistedGenerationRecovery>
+  expandedSessionIds?: string[]
 }
 
 export interface RestorableSidecarTabState { kind: "sidecar"; sidecarId: string }
@@ -20,7 +21,7 @@ export interface ClientSnapshotV1 {
 }
 
 const MAX_TABS = 32, MAX_LAYOUT_ENTRIES = 64, MAX_DRAFTS = 24, MAX_SCROLLS_PER_TAB = 96
-const MAX_IDLE_MARKERS = 256, MAX_RECOVERY = 256, MAX_KEY = 256, MAX_PATH = 4096, MAX_ID = 512
+const MAX_IDLE_MARKERS = 256, MAX_RECOVERY = 256, MAX_EXPANDED = 256, MAX_KEY = 256, MAX_PATH = 4096, MAX_ID = 512
 const MAX_LAYOUT_VALUE = 4096, MAX_DRAFT = 32 * 1024, MAX_ANCHOR_KEY = 1024
 const MAX_STRINGS = 96 * 1024, MAX_SCROLLS = 256
 const NO_SESSION_DRAFT_SESSION_ID = "__no_session_draft__"
@@ -103,6 +104,20 @@ function normalizeScrollSnapshot(value: unknown, budget: StringBudget): ScrollSn
   return result
 }
 
+function normalizeExpandedSessionIds(value: unknown, budget: StringBudget): string[] | null {
+  if (!Array.isArray(value)) return null
+  const result: string[] = []
+  const seen = new Set<string>()
+  for (const entry of value.slice(0, MAX_EXPANDED)) {
+    if (typeof entry !== "string" || seen.has(entry)) continue
+    const id = takeString(entry, MAX_ID, budget)
+    if (id === undefined) continue
+    seen.add(id)
+    result.push(id)
+  }
+  return result
+}
+
 function normalizeWorkspaceTab(
   value: Record<string, unknown>,
   identity: WorkspaceIdentity,
@@ -129,7 +144,10 @@ function normalizeWorkspaceTab(
     value.generationRecovery ?? {}, MAX_RECOVERY, budget,
     (entry) => entry as PersistedGenerationRecovery,
     (entry) => entry === "working" || entry === "interrupted")
-  if (!drafts || !scrollSnapshots || !unseenIdleSince || !generationRecovery) return null
+  const expandedSessionIds = value.expandedSessionIds === undefined
+    ? undefined
+    : normalizeExpandedSessionIds(value.expandedSessionIds, budget)
+  if (!drafts || !scrollSnapshots || !unseenIdleSince || !generationRecovery || expandedSessionIds === null) return null
   const remainingAttachments = Object.fromEntries(Object.entries(value.attachments ?? {})
     .filter(([id]) => !identity.prioritySessionIds.includes(id)))
   const attachmentResult = normalizeRestorableAttachmentRecord(
@@ -143,6 +161,7 @@ function normalizeWorkspaceTab(
     attachments: { ...identity.priorityAttachments, ...attachmentResult.attachments },
     scrollSnapshots, unseenIdleSince, generationRecovery,
   }
+  if (expandedSessionIds !== undefined) result.expandedSessionIds = expandedSessionIds
   if (Number.isInteger(value.occurrence) && Number(value.occurrence) >= 0 && Number(value.occurrence) < MAX_TABS) {
     result.occurrence = Number(value.occurrence)
   }

--- a/packages/ui/src/stores/instances.ts
+++ b/packages/ui/src/stores/instances.ts
@@ -19,6 +19,7 @@ import {
   clearInstanceDraftPrompts,
   clearSessionListRequestState,
   clearInstanceDeletedSessionAuthority,
+  clearInstanceSessionExpansionState,
   clearInstanceSessionSelection,
   resetSessionPagination,
 } from "./sessions"
@@ -995,6 +996,7 @@ function removeInstance(id: string, options: { authoritative?: boolean } = {}) {
   clearSessionListRequestState(id)
   clearInstanceAttachments(id)
   clearInstanceDeletedSessionAuthority(id)
+  clearInstanceSessionExpansionState(id)
   clearInstanceSessionSelection(id)
   if (removedInstance && removedOccurrence >= 0 && options.authoritative !== false) {
     publishInstanceLifecycleAuthority({

--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -51,6 +51,7 @@ import {
   isLatestSessionSearch,
   setSessionSearchResults,
   setSessionListError,
+  setSessionExpanded,
 } from "./session-state"
 import { deleteSessionAttachments } from "./attachments"
 import { DEFAULT_MODEL_OUTPUT_LIMIT, getDefaultModel, isModelValid } from "./session-models"
@@ -909,6 +910,7 @@ function removeSessionRuntimeState(instanceId: string, sessionId: string): void 
   markSessionDeletedAuthoritative(instanceId, sessionId)
   deleteSessionAttachments(instanceId, sessionId)
   clearSessionDraftPrompt(instanceId, sessionId)
+  setSessionExpanded(instanceId, sessionId, false)
 
   setSessions((prev) => {
     const next = new Map(prev)

--- a/packages/ui/src/stores/session-metadata.ts
+++ b/packages/ui/src/stores/session-metadata.ts
@@ -1,4 +1,5 @@
 import type { OpencodeClient } from "@opencode-ai/sdk/v2/client"
+import { serverApi } from "../lib/api-client"
 import { requestData } from "../lib/opencode-api"
 import { sessions, withSession } from "./session-state"
 import { shouldReplaceSessionMetadata } from "./session-metadata-completeness"
@@ -30,57 +31,12 @@ function normalizeCodeNomadMetadata(value: unknown): CodeNomadSessionMetadata {
   return metadata
 }
 
-function mergeCodeNomadMetadata(
-  metadata: MetadataRecord,
-  updater: (current: CodeNomadSessionMetadata) => CodeNomadSessionMetadata,
-): MetadataRecord {
-  const currentCodeNomad = isRecord(metadata[CODENOMAD_METADATA_KEY])
-    ? { ...(metadata[CODENOMAD_METADATA_KEY] as MetadataRecord) }
-    : {}
-  const nextCodeNomad = updater(normalizeCodeNomadMetadata(currentCodeNomad))
-  const mergedCodeNomad: MetadataRecord = {
-    ...currentCodeNomad,
-    ...nextCodeNomad,
-    version: CODENOMAD_METADATA_VERSION,
-  }
-
-  if (!nextCodeNomad.worktreeSlug) {
-    delete mergedCodeNomad.worktreeSlug
-  }
-
-  return {
-    ...metadata,
-    [CODENOMAD_METADATA_KEY]: mergedCodeNomad,
-  }
-}
-
 export function getSessionMetadata(instanceId: string, sessionId: string): MetadataRecord {
   return normalizeMetadata(sessions().get(instanceId)?.get(sessionId)?.metadata)
 }
 
 export function getCodeNomadSessionMetadata(instanceId: string, sessionId: string): CodeNomadSessionMetadata {
   return normalizeCodeNomadMetadata(getSessionMetadata(instanceId, sessionId)[CODENOMAD_METADATA_KEY])
-}
-
-export async function updateSessionMetadataWithClient(
-  client: OpencodeClient,
-  instanceId: string,
-  sessionId: string,
-  updater: (metadata: MetadataRecord) => MetadataRecord,
-): Promise<MetadataRecord> {
-  const latest = await requestData<any>(client.session.get({ sessionID: sessionId }), "session.get")
-  const nextMetadata = updater(normalizeMetadata(latest?.metadata))
-  const updated = await requestData<any>(
-    client.session.update({ sessionID: sessionId, metadata: nextMetadata } as any),
-    "session.update",
-  )
-  const persistedMetadata = normalizeMetadata(updated?.metadata ?? nextMetadata)
-
-  withSession(instanceId, sessionId, (session) => {
-    session.metadata = persistedMetadata
-  })
-
-  return persistedMetadata
 }
 
 export async function hydrateSessionMetadataWithClient(
@@ -101,26 +57,13 @@ export async function hydrateSessionMetadataWithClient(
   return metadata
 }
 
-export async function updateCodeNomadSessionMetadataWithClient(
-  client: OpencodeClient,
-  instanceId: string,
-  sessionId: string,
-  updater: (metadata: CodeNomadSessionMetadata) => CodeNomadSessionMetadata,
-): Promise<CodeNomadSessionMetadata> {
-  const persisted = await updateSessionMetadataWithClient(client, instanceId, sessionId, (metadata) =>
-    mergeCodeNomadMetadata(metadata, updater),
-  )
-  return normalizeCodeNomadMetadata(persisted[CODENOMAD_METADATA_KEY])
-}
-
-export async function setSessionWorktreeSlugWithClient(
-  client: OpencodeClient,
+export async function setSessionWorktreeSlug(
   instanceId: string,
   sessionId: string,
   worktreeSlug: string,
 ): Promise<void> {
-  await updateCodeNomadSessionMetadataWithClient(client, instanceId, sessionId, (metadata) => ({
-    ...metadata,
-    worktreeSlug,
-  }))
+  const { metadata } = await serverApi.setSessionWorktreeSlug(instanceId, sessionId, worktreeSlug)
+  withSession(instanceId, sessionId, (session) => {
+    session.metadata = normalizeMetadata(metadata)
+  })
 }

--- a/packages/ui/src/stores/session-state.ts
+++ b/packages/ui/src/stores/session-state.ts
@@ -65,6 +65,7 @@ const [sessionDraftPrompts, setSessionDraftPrompts] = createSignal<Map<string, s
 const [authoritativeDraftKeys, setAuthoritativeDraftKeys] = createSignal<Set<string>>(new Set())
 const [authoritativeSessionSelectionInstanceIds, setAuthoritativeSessionSelectionInstanceIds] = createSignal<Set<string>>(new Set())
 const [authoritativelyDeletedSessionKeys, setAuthoritativelyDeletedSessionKeys] = createSignal<Set<string>>(new Set())
+const [authoritativeSessionExpansionKeys, setAuthoritativeSessionExpansionKeys] = createSignal<Set<string>>(new Set())
 type SessionDraftHydratedListener = (instanceId: string, sessionId: string, draft: string) => void
 const sessionDraftHydratedListeners = new Set<SessionDraftHydratedListener>()
 
@@ -444,6 +445,10 @@ function getAuthoritativeDraftSessionIdsForInstance(instanceId: string): Readonl
 
 function getAuthoritativelyDeletedSessionIdsForInstance(instanceId: string): ReadonlySet<string> {
   return getAuthoritativeSessionIds(authoritativelyDeletedSessionKeys(), instanceId)
+}
+
+function getAuthoritativeSessionExpansionIdsForInstance(instanceId: string): ReadonlySet<string> {
+  return getAuthoritativeSessionIds(authoritativeSessionExpansionKeys(), instanceId)
 }
 
 function markSessionDeletedAuthoritative(instanceId: string, sessionId: string): void {
@@ -906,14 +911,13 @@ function isSessionExpanded(instanceId: string, sessionId: string): boolean {
 }
 
 function setSessionExpanded(instanceId: string, sessionId: string, expanded: boolean): void {
+  addAuthoritativeKey(setAuthoritativeSessionExpansionKeys, getDraftKey(instanceId, sessionId))
   setExpandedSessions((prev) => {
     const next = new Map(prev)
     const currentSet = next.get(instanceId) ?? new Set<string>()
-    const updated = new Set(currentSet)
+    const updated = expanded ? new Set([sessionId, ...currentSet]) : new Set(currentSet)
 
-    if (expanded) {
-      updated.add(sessionId)
-    } else {
+    if (!expanded) {
       updated.delete(sessionId)
     }
 
@@ -927,21 +931,43 @@ function setSessionExpanded(instanceId: string, sessionId: string, expanded: boo
   })
 }
 
-function toggleSessionExpanded(instanceId: string, sessionId: string): void {
+function clearInstanceSessionExpansionState(instanceId: string): void {
+  if (!instanceId) return
+  const prefix = `${instanceId}:`
   setExpandedSessions((prev) => {
+    if (!prev.has(instanceId)) return prev
     const next = new Map(prev)
-    const currentSet = next.get(instanceId) ?? new Set<string>()
-    const updated = new Set(currentSet)
-
-    if (updated.has(sessionId)) {
-      updated.delete(sessionId)
-    } else {
-      updated.add(sessionId)
-    }
-
-    next.set(instanceId, updated)
+    next.delete(instanceId)
     return next
   })
+  setAuthoritativeSessionExpansionKeys((prev) => {
+    const next = new Set([...prev].filter((key) => !key.startsWith(prefix)))
+    return next.size === prev.size ? prev : next
+  })
+}
+
+function hydrateSessionExpansion(instanceId: string, sessionIds: readonly string[]): void {
+  setExpandedSessions((prev) => {
+    const current = prev.get(instanceId)
+    const authoritative = getAuthoritativeSessionExpansionIdsForInstance(instanceId)
+    const deleted = getAuthoritativelyDeletedSessionIdsForInstance(instanceId)
+    const expanded = new Set(sessionIds.filter((id) => !authoritative.has(id) && !deleted.has(id)))
+    for (const id of current ?? []) if (authoritative.has(id) && !deleted.has(id)) expanded.add(id)
+    if (current?.size === expanded.size && [...expanded].every((id) => current.has(id))) return prev
+    const next = new Map(prev)
+    if (expanded.size) next.set(instanceId, expanded)
+    else next.delete(instanceId)
+    return next
+  })
+  setAuthoritativeSessionExpansionKeys((prev) => {
+    const next = new Set(prev)
+    for (const id of sessions().get(instanceId)?.keys() ?? []) next.add(getDraftKey(instanceId, id))
+    return next
+  })
+}
+
+function toggleSessionExpanded(instanceId: string, sessionId: string): void {
+  setSessionExpanded(instanceId, sessionId, !isSessionExpanded(instanceId, sessionId))
 }
 
 function ensureSessionExpanded(instanceId: string, sessionId: string): void {
@@ -957,16 +983,15 @@ function getSessionAncestorIds(instanceId: string, sessionId: string): string[] 
 function ensureSessionAncestorsExpanded(instanceId: string, sessionId: string): void {
   const ancestorIds = getSessionAncestorIds(instanceId, sessionId)
   if (ancestorIds.length === 0) return
+  for (const ancestorId of ancestorIds) {
+    addAuthoritativeKey(setAuthoritativeSessionExpansionKeys, getDraftKey(instanceId, ancestorId))
+  }
   setExpandedSessions((prev) => {
     const next = new Map(prev)
-    const expanded = new Set(next.get(instanceId))
-    let changed = false
-    for (const ancestorId of ancestorIds) {
-      if (expanded.has(ancestorId)) continue
-      expanded.add(ancestorId)
-      changed = true
-    }
-    if (!changed) return prev
+    const current = next.get(instanceId) ?? new Set<string>()
+    const missing = ancestorIds.filter((ancestorId) => !current.has(ancestorId))
+    if (missing.length === 0) return prev
+    const expanded = new Set([...missing, ...current])
     next.set(instanceId, expanded)
     return next
   })
@@ -985,6 +1010,7 @@ function setActiveSessionFromList(instanceId: string, sessionId: string): void {
   if (!session) return
   const root = getSessionRoot(instanceId, sessionId)
   if (!root) return
+  ensureSessionAncestorsExpanded(instanceId, sessionId)
 
   batch(() => {
     setActiveParentSession(instanceId, root.id)
@@ -1210,8 +1236,10 @@ export {
   getSessionDraftPromptsForInstance,
   getAuthoritativeDraftSessionIdsForInstance,
   getAuthoritativelyDeletedSessionIdsForInstance,
+  getAuthoritativeSessionExpansionIdsForInstance,
   markSessionDeletedAuthoritative,
   clearInstanceDeletedSessionAuthority,
+  clearInstanceSessionExpansionState,
   hydrateSessionDraftPrompt,
   onSessionDraftHydrated,
   setSessionDraftPrompt,
@@ -1248,8 +1276,10 @@ export {
   getSessionThreads,
   getSessionSearchThreads,
   getVisibleSessionIds,
+  expandedSessions,
   isSessionExpanded,
   setSessionExpanded,
+  hydrateSessionExpansion,
   toggleSessionExpanded,
   ensureSessionExpanded,
   getSessionAncestorIds,

--- a/packages/ui/src/stores/sessions.ts
+++ b/packages/ui/src/stores/sessions.ts
@@ -14,6 +14,7 @@ import {
   clearSessionDraftPrompt,
   ensureSessionAncestorsExpanded,
   ensureSessionExpanded,
+  expandedSessions,
   getActiveParentSession,
   getActiveSession,
   getChildSessions,
@@ -24,10 +25,12 @@ import {
   getSessionDraftPromptsForInstance,
   getAuthoritativeDraftSessionIdsForInstance,
   getAuthoritativelyDeletedSessionIdsForInstance,
+  getAuthoritativeSessionExpansionIdsForInstance,
   hasAuthoritativeSessionSelection,
   hydrateActiveSessionSelection,
   hydrateSessionIdleMarkers,
   hydrateSessionGenerationRecovery,
+  hydrateSessionExpansion,
   beginSessionGenerationAdmission,
   cancelSessionGenerationAdmissions,
   getSessionFamily,
@@ -63,6 +66,7 @@ import {
   onSessionDraftHydrated,
   resetSessionPagination,
   clearInstanceDeletedSessionAuthority,
+  clearInstanceSessionExpansionState,
 } from "./session-state"
 
 import { getDefaultModel } from "./session-models"
@@ -140,6 +144,7 @@ export {
   deleteSession,
   ensureSessionAncestorsExpanded,
   ensureSessionExpanded,
+  expandedSessions,
   executeCustomCommand,
   renameSession,
   runShellCommand,
@@ -161,10 +166,12 @@ export {
   getSessionDraftPromptsForInstance,
   getAuthoritativeDraftSessionIdsForInstance,
   getAuthoritativelyDeletedSessionIdsForInstance,
+  getAuthoritativeSessionExpansionIdsForInstance,
   hasAuthoritativeSessionSelection,
   hydrateActiveSessionSelection,
   hydrateSessionIdleMarkers,
   hydrateSessionGenerationRecovery,
+  hydrateSessionExpansion,
   beginSessionGenerationAdmission,
   cancelSessionGenerationAdmissions,
   getSessionFamily,
@@ -205,5 +212,6 @@ export {
   onSessionDraftHydrated,
   resetSessionPagination,
   clearInstanceDeletedSessionAuthority,
+  clearInstanceSessionExpansionState,
 }
 export type { SessionInfo }

--- a/packages/ui/src/stores/worktrees.ts
+++ b/packages/ui/src/stores/worktrees.ts
@@ -3,8 +3,7 @@ import type { WorktreeDescriptor, WorktreeMap } from "../../../server/src/api-ty
 import { serverApi } from "../lib/api-client"
 import { getSessionRoot, sessions } from "./session-state"
 import { getLogger } from "../lib/logger"
-import { getCodeNomadSessionMetadata, setSessionWorktreeSlugWithClient } from "./session-metadata"
-import { getRootClient } from "./opencode-client"
+import { getCodeNomadSessionMetadata, setSessionWorktreeSlug } from "./session-metadata"
 import type { WorktreeReadyEvent } from "../lib/sse-manager"
 
 const log = getLogger("api")
@@ -178,8 +177,7 @@ async function moveSessionsFromDeletedWorktree(instanceId: string, slug: string)
     .map((session) => session.id)
 
   for (const parentSessionId of parentSessionIds) {
-    const client = getRootClient(instanceId)
-    await setSessionWorktreeSlugWithClient(client, instanceId, parentSessionId, "root")
+    await setSessionWorktreeSlug(instanceId, parentSessionId, "root")
     await removeLegacyParentSessionMapping(instanceId, parentSessionId)
   }
 }
@@ -337,16 +335,14 @@ async function setWorktreeSlugForParentSession(
   await ensureWorktreeMapLoaded(instanceId)
   const current = getWorktreeMap(instanceId)
   const normalizedSlug = normalizeWorktreeSlug(instanceId, slug)
-  const client = getRootClient(instanceId)
-  await setSessionWorktreeSlugWithClient(client, instanceId, parentSessionId, normalizedSlug)
+  await setSessionWorktreeSlug(instanceId, parentSessionId, normalizedSlug)
   await removeLegacyParentSessionMapping(instanceId, parentSessionId, current)
 }
 
 async function removeParentSessionMapping(instanceId: string, parentSessionId: string): Promise<void> {
   await ensureWorktreeMapLoaded(instanceId)
   const current = getWorktreeMap(instanceId)
-  const client = getRootClient(instanceId)
-  await setSessionWorktreeSlugWithClient(client, instanceId, parentSessionId, "root")
+  await setSessionWorktreeSlug(instanceId, parentSessionId, "root")
   await removeLegacyParentSessionMapping(instanceId, parentSessionId, current)
 }
 
@@ -385,8 +381,7 @@ async function migrateLegacyWorktreeMapToSessionMetadata(instanceId: string): Pr
       }
 
       const normalizedSlug = normalizeWorktreeSlug(instanceId, legacySlug || "root")
-      const client = getRootClient(instanceId)
-      await setSessionWorktreeSlugWithClient(client, instanceId, parentSessionId, normalizedSlug)
+      await setSessionWorktreeSlug(instanceId, parentSessionId, normalizedSlug)
       await removeLegacyParentSessionMapping(instanceId, parentSessionId)
     }
   })().finally(() => {


### PR DESCRIPTION
## Summary

- Persist server-owned Yolo state through OpenCode session metadata so it survives workspace and CodeNomad restarts.
- Restore expanded and collapsed parent/subsession state from the desktop client snapshot.
- Serialize CodeNomad metadata mutations so Yolo and worktree metadata cannot overwrite each other.

## Yolo persistence

- Stores state under metadata.codenomad.yolo with enabled and rootSessionId fields.
- Accepts a persisted marker only when it is owned by that session, preventing copied fork metadata from enabling an unrelated family.
- Hydrates the project session tree before processing permission events and queues events while hydration is pending.
- Keeps the server authoritative for family inheritance, permission replies, toggles, and cleanup.
- Uses get/merge/update writes that preserve worktreeSlug and third-party metadata.
- Serializes writes by session across CodeNomad instances and routes worktree slug updates through the same server-owned path.
- Reconciles late ancestry and repeated root migrations without re-enabling a family after a concurrent disable.

## Expansion restoration

- Captures bounded, deduplicated expanded session IDs per workspace in the local desktop snapshot.
- Restores explicit expanded and collapsed state while preserving IDs that are temporarily unavailable during startup reconciliation.
- Gives live user changes, deletions, and loaded-session authority precedence over preserved state.
- Cleans expansion state when sessions or instances are removed.
- Keeps the active child visible when loading legacy snapshots that predate expansion persistence.

## Validation

- 39 focused server permission and metadata tests pass.
- 66 focused client snapshot and restoration tests pass.
- Server and UI TypeScript typechecks pass.
- git diff --check passes.

## Limits

- Project hydration follows the existing 10,000-session list ceiling.
- Snapshot expansion persistence is capped at 256 session IDs.

Closes #607

Depends on anomalyco/opencode#23068.