### PR TITLE
fix(ui): label new local instance action

### DIFF
--- a/packages/ui/src/components/folder-selection-view.tsx
+++ b/packages/ui/src/components/folder-selection-view.tsx
@@ -974,6 +974,7 @@ const FolderSelectionView: Component<FolderSelectionViewProps> = (props) => {
                                     class="folder-home-recent-primary-action"
                                     disabled={isLoading()}
                                     aria-labelledby={projectLabelId()}
+                                    title={t("folderSelection.recent.openNewInstance")}
                                     onClick={() => handleFolderSelect(folder.path, true)}
                                     onFocus={() => {
                                       setFocusMode("recent")

--- a/packages/ui/src/lib/i18n/messages/de/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/de/folderSelection.ts
@@ -17,6 +17,7 @@ export const folderSelectionMessages = {
   "folderSelection.recent.rename": "Arbeitsbereich umbenennen",
   "folderSelection.recent.remove": "Aus Liste entfernen",
   "folderSelection.recent.openBadge": "Offen",
+  "folderSelection.recent.openNewInstance": "Neue Instanz öffnen",
   "folderSelection.recent.switchToOpenProject": "Zum offenen Projekt wechseln",
 
   "folderSelection.browse.title": "Nach Ordner suchen",

--- a/packages/ui/src/lib/i18n/messages/en/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/en/folderSelection.ts
@@ -17,6 +17,7 @@ export const folderSelectionMessages = {
   "folderSelection.recent.rename": "Rename workspace",
   "folderSelection.recent.remove": "Remove from recent",
   "folderSelection.recent.openBadge": "Open",
+  "folderSelection.recent.openNewInstance": "Open new instance",
   "folderSelection.recent.switchToOpenProject": "Switch to open project",
 
   "folderSelection.browse.title": "Browse for Folder",

--- a/packages/ui/src/lib/i18n/messages/es/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/es/folderSelection.ts
@@ -17,6 +17,7 @@ export const folderSelectionMessages = {
   "folderSelection.recent.rename": "Renombrar workspace",
   "folderSelection.recent.remove": "Eliminar de recientes",
   "folderSelection.recent.openBadge": "Abierta",
+  "folderSelection.recent.openNewInstance": "Abrir una nueva instancia",
   "folderSelection.recent.switchToOpenProject": "Cambiar al proyecto abierto",
 
   "folderSelection.browse.title": "Buscar carpeta",

--- a/packages/ui/src/lib/i18n/messages/fr/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/fr/folderSelection.ts
@@ -17,6 +17,7 @@ export const folderSelectionMessages = {
   "folderSelection.recent.rename": "Renommer l'espace de travail",
   "folderSelection.recent.remove": "Retirer des récents",
   "folderSelection.recent.openBadge": "Ouvert",
+  "folderSelection.recent.openNewInstance": "Ouvrir une nouvelle instance",
   "folderSelection.recent.switchToOpenProject": "Basculer vers le projet ouvert",
 
   "folderSelection.browse.title": "Parcourir un dossier",

--- a/packages/ui/src/lib/i18n/messages/he/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/he/folderSelection.ts
@@ -17,6 +17,7 @@ export const folderSelectionMessages = {
   "folderSelection.recent.rename": "שנה שם סביבת עבודה",
   "folderSelection.recent.remove": "הסר מהרשימה האחרונה",
   "folderSelection.recent.openBadge": "פתוח",
+  "folderSelection.recent.openNewInstance": "פתיחת מופע חדש",
   "folderSelection.recent.switchToOpenProject": "עבור לפרויקט הפתוח",
 
   "folderSelection.browse.title": "עיון בתיקייה",

--- a/packages/ui/src/lib/i18n/messages/ja/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/ja/folderSelection.ts
@@ -17,6 +17,7 @@ export const folderSelectionMessages = {
   "folderSelection.recent.rename": "ワークスペース名を変更",
   "folderSelection.recent.remove": "履歴から削除",
   "folderSelection.recent.openBadge": "開いています",
+  "folderSelection.recent.openNewInstance": "新しいインスタンスを開く",
   "folderSelection.recent.switchToOpenProject": "開いているプロジェクトに切り替え",
 
   "folderSelection.browse.title": "フォルダを参照",

--- a/packages/ui/src/lib/i18n/messages/ne/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/ne/folderSelection.ts
@@ -17,6 +17,7 @@ export const folderSelectionMessages = {
   "folderSelection.recent.rename": "कार्यस्थान पुन: नामकरण गर्नुहोस्",
   "folderSelection.recent.remove": "भर्खरको सूचीबाट हटाउनुहोस्",
   "folderSelection.recent.openBadge": "खोल्नुहोस्",
+  "folderSelection.recent.openNewInstance": "नयाँ इन्स्ट्यान्स खोल्नुहोस्",
   "folderSelection.recent.switchToOpenProject": "खुला परियोजनामा जानुहोस्",
 
   "folderSelection.browse.title": "फोल्डरको लागि ब्राउज गर्नुहोस्",

--- a/packages/ui/src/lib/i18n/messages/ru/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/ru/folderSelection.ts
@@ -17,6 +17,7 @@ export const folderSelectionMessages = {
   "folderSelection.recent.rename": "Переименовать рабочее пространство",
   "folderSelection.recent.remove": "Убрать из недавних",
   "folderSelection.recent.openBadge": "Открыта",
+  "folderSelection.recent.openNewInstance": "Открыть новый экземпляр",
   "folderSelection.recent.switchToOpenProject": "Перейти к открытому проекту",
 
   "folderSelection.browse.title": "Выбрать папку",

--- a/packages/ui/src/lib/i18n/messages/zh-Hans/folderSelection.ts
+++ b/packages/ui/src/lib/i18n/messages/zh-Hans/folderSelection.ts
@@ -17,6 +17,7 @@ export const folderSelectionMessages = {
   "folderSelection.recent.rename": "重命名工作区",
   "folderSelection.recent.remove": "从最近列表移除",
   "folderSelection.recent.openBadge": "已打开",
+  "folderSelection.recent.openNewInstance": "打开新实例",
   "folderSelection.recent.switchToOpenProject": "切换到已打开的项目",
 
   "folderSelection.browse.title": "浏览文件夹",


### PR DESCRIPTION
## Summary
- add an Open new instance hover tooltip to local workspace rows
- translate the tooltip across all supported locales
- reuse the existing native title pattern without new styling or dependencies

## Validation
- npm run typecheck --workspace @codenomad/ui
- npm run build --workspace @codenomad/ui
- git diff --check

Closes #608