### PR TITLE
fix(auth): submit the displayed default username

### DIFF
--- a/packages/server/src/server/routes/auth-pages/login.html
+++ b/packages/server/src/server/routes/auth-pages/login.html
@@ -95,7 +95,7 @@
 
       async function submit() {
         hideError()
-        const username = $("username").value.trim()
+        const username = $("username").value
         const password = $("password").value
         if (!username || !password) {
           showError("Username and password are required.")

--- a/packages/server/src/server/routes/auth-pages/login.html
+++ b/packages/server/src/server/routes/auth-pages/login.html
@@ -72,10 +72,10 @@
       <p>This CodeNomad server is protected. Enter your credentials to continue.</p>
 
       <label for="username">Username</label>
-      <input id="username" autocomplete="username" placeholder="{{DEFAULT_USERNAME}}" value="" />
+      <input id="username" autocomplete="username" autocapitalize="none" autocorrect="off" spellcheck="false" placeholder="{{DEFAULT_USERNAME}}" value="{{DEFAULT_USERNAME}}" />
 
       <label for="password">Password</label>
-      <input id="password" type="password" autocomplete="current-password" value="" />
+      <input id="password" type="password" autocomplete="current-password" autocapitalize="none" autocorrect="off" spellcheck="false" value="" />
 
       <button id="submit" type="button">Continue</button>
       <div id="error" class="error" style="display: none"></div>

--- a/packages/server/src/server/routes/auth.test.ts
+++ b/packages/server/src/server/routes/auth.test.ts
@@ -4,18 +4,20 @@ import Fastify from "fastify"
 import type { AuthManager } from "../../auth/manager"
 import { registerAuthRoutes } from "./auth"
 
-it("renders the default username as the login field value", async () => {
+it("renders the escaped default username literally as the login field value", async () => {
   const app = Fastify({ logger: false })
+  const username = " code$&\"nomad "
   const authManager = {
     getSessionFromRequest: () => null,
-    getStatus: () => ({ username: "codenomad" }),
+    getStatus: () => ({ username }),
   } as unknown as AuthManager
   registerAuthRoutes(app, { authManager })
 
   const response = await app.inject({ method: "GET", url: "/login" })
 
   assert.equal(response.statusCode, 200)
-  assert.match(response.body, /id="username"[^>]*value="codenomad"/)
+  assert.ok(response.body.includes('value=" code$&amp;&quot;nomad "'))
+  assert.match(response.body, /const username = \$\("username"\)\.value\s*\n/)
   assert.equal(response.body.match(/autocapitalize="none"/g)?.length, 2)
   assert.equal(response.body.match(/autocorrect="off"/g)?.length, 2)
   assert.equal(response.body.match(/spellcheck="false"/g)?.length, 2)

--- a/packages/server/src/server/routes/auth.test.ts
+++ b/packages/server/src/server/routes/auth.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict"
+import { it } from "node:test"
+import Fastify from "fastify"
+import type { AuthManager } from "../../auth/manager"
+import { registerAuthRoutes } from "./auth"
+
+it("renders the default username as the login field value", async () => {
+  const app = Fastify({ logger: false })
+  const authManager = {
+    getSessionFromRequest: () => null,
+    getStatus: () => ({ username: "codenomad" }),
+  } as unknown as AuthManager
+  registerAuthRoutes(app, { authManager })
+
+  const response = await app.inject({ method: "GET", url: "/login" })
+
+  assert.equal(response.statusCode, 200)
+  assert.match(response.body, /id="username"[^>]*value="codenomad"/)
+  assert.equal(response.body.match(/autocapitalize="none"/g)?.length, 2)
+  assert.equal(response.body.match(/autocorrect="off"/g)?.length, 2)
+  assert.equal(response.body.match(/spellcheck="false"/g)?.length, 2)
+  await app.close()
+})

--- a/packages/server/src/server/routes/auth.ts
+++ b/packages/server/src/server/routes/auth.ts
@@ -39,7 +39,7 @@ function getLoginHtml(defaultUsername: string): string {
   }
 
   const escapedUsername = escapeHtml(defaultUsername)
-  return cachedLoginTemplate.replace(/\{\{DEFAULT_USERNAME\}\}/g, escapedUsername)
+  return cachedLoginTemplate.replace(/\{\{DEFAULT_USERNAME\}\}/g, () => escapedUsername)
 }
 
 function getTokenHtml(): string {


### PR DESCRIPTION
## Summary
- Populate the remote login username input with the configured default value instead of displaying it only as a placeholder.
- Disable mobile capitalization, autocorrection, and spellchecking for username and password inputs.
- Add a route-level regression test for the rendered username value and mobile credential attributes.

## Validation
- node --import tsx --test packages/server/src/server/routes/auth.test.ts
- npm run typecheck --workspace @neuralnomads/codenomad
- node packages/server/scripts/copy-auth-pages.mjs

Closes #616