### PR TITLE
fix(permissions): ignore stale permission updates

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -127,6 +127,7 @@ jobs:
         run: >-
           node --conditions=browser --import tsx --test --test-force-exit
           packages/ui/src/stores/instances-restore-ownership.test.ts
+          packages/ui/src/stores/permission-lifecycle.test.ts
 
       - name: Test server
         run: node --import tsx --test "packages/server/src/**/*.test.ts"

--- a/packages/ui/src/stores/instances.ts
+++ b/packages/ui/src/stores/instances.ts
@@ -1391,12 +1391,12 @@ function recomputeActiveInterruption(instanceId: string): void {
   setActiveInterruptionForInstance(instanceId, computeActiveInterruption(instanceId))
 }
 
-function addPermissionToQueue(instanceId: string, permission: PermissionRequest, source: PermissionSource = "v2"): PermissionRequest | undefined {
+function addPermissionToQueue(instanceId: string, permission: PermissionRequest, source?: PermissionSource): PermissionRequest | undefined {
   let inserted = false
   let updated = false
   let previousPermission: PermissionRequest | undefined
   let queuedPermission = permission
-  permissionRegistry.setSource(instanceId, permission.id, source)
+  if (source) permissionRegistry.setSource(instanceId, permission.id, source)
 
   setPermissionQueues((prev) => {
     const next = new Map(prev)

--- a/packages/ui/src/stores/permission-lifecycle.test.ts
+++ b/packages/ui/src/stores/permission-lifecycle.test.ts
@@ -63,16 +63,34 @@ test("permission.updated preserves the V2 reply route", async () => {
 
   assert.equal(v2Replies, 1)
   assert.equal(legacyReplies, 0)
-})
-
-test("orphan permission.updated does not create a pending permission", () => {
-  const client = {} as OpencodeClient
-  addTestInstance("permission-orphan-update", client)
-
-  handlePermissionUpdated("permission-orphan-update", {
+  handlePermissionUpdated("permission-v2-source", {
     type: "permission.updated",
     properties: { id: "permission", sessionID: "session", patterns: ["C:/work"] },
   })
+  assert.deepEqual(getPermissionQueue("permission-v2-source"), [])
+})
 
-  assert.deepEqual(getPermissionQueue("permission-orphan-update"), [])
+test("standalone permission.updated remains a legacy permission request", async () => {
+  let legacyReplies = 0
+  let v2Replies = 0
+  const client = {
+    permission: {
+      reply: async () => { legacyReplies += 1; return { data: true } },
+    },
+    v2: { session: { permission: {
+      reply: async () => { v2Replies += 1; return { data: true } },
+    } } },
+  } as unknown as OpencodeClient
+  sdkManager.createClient = (() => client) as typeof sdkManager.createClient
+  addTestInstance("permission-legacy-update", client)
+
+  handlePermissionUpdated("permission-legacy-update", {
+    type: "permission.updated",
+    properties: { id: "permission", sessionID: "session", patterns: ["C:/work"] },
+  })
+  assert.equal(getPermissionQueue("permission-legacy-update").length, 1)
+  await sendPermissionResponse("permission-legacy-update", "session", "permission", "always")
+
+  assert.equal(legacyReplies, 1)
+  assert.equal(v2Replies, 0)
 })

--- a/packages/ui/src/stores/permission-lifecycle.test.ts
+++ b/packages/ui/src/stores/permission-lifecycle.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict"
+import { afterEach, test } from "node:test"
+import type { OpencodeClient } from "@opencode-ai/sdk/v2/client"
+import { sdkManager } from "../lib/sdk-manager"
+import type { Instance } from "../types/instance"
+import {
+  addInstance,
+  clearPermissionQueue,
+  getPermissionQueue,
+  sendPermissionResponse,
+} from "./instances"
+import { messageStoreBus } from "./message-v2/bus"
+import { handlePermissionUpdated } from "./session-events"
+
+const instanceIds: string[] = []
+const originalCreateClient = sdkManager.createClient
+
+function addTestInstance(id: string, client: OpencodeClient): void {
+  instanceIds.push(id)
+  addInstance({
+    id,
+    folder: "/workspace",
+    port: 1,
+    pid: 1,
+    proxyPath: `/workspaces/${id}/instance`,
+    status: "ready",
+    client,
+  } satisfies Instance)
+}
+
+afterEach(() => {
+  for (const instanceId of instanceIds.splice(0)) {
+    clearPermissionQueue(instanceId)
+    messageStoreBus.unregisterInstance(instanceId)
+    sdkManager.destroyClientsForInstance(instanceId)
+  }
+  sdkManager.createClient = originalCreateClient
+})
+
+test("permission.updated preserves the V2 reply route", async () => {
+  let legacyReplies = 0
+  let v2Replies = 0
+  const client = {
+    permission: {
+      reply: async () => { legacyReplies += 1; return { data: true } },
+    },
+    v2: { session: { permission: {
+      reply: async () => { v2Replies += 1; return { data: true } },
+    } } },
+  } as unknown as OpencodeClient
+  sdkManager.createClient = (() => client) as typeof sdkManager.createClient
+  addTestInstance("permission-v2-source", client)
+
+  handlePermissionUpdated("permission-v2-source", {
+    type: "permission.v2.asked",
+    properties: { id: "permission", sessionID: "session", action: "external_directory", resources: ["C:/work"] },
+  } as never)
+  handlePermissionUpdated("permission-v2-source", {
+    type: "permission.updated",
+    properties: { id: "permission", sessionID: "session", patterns: ["C:/work"] },
+  })
+  await sendPermissionResponse("permission-v2-source", "session", "permission", "always")
+
+  assert.equal(v2Replies, 1)
+  assert.equal(legacyReplies, 0)
+})
+
+test("orphan permission.updated does not create a pending permission", () => {
+  const client = {} as OpencodeClient
+  addTestInstance("permission-orphan-update", client)
+
+  handlePermissionUpdated("permission-orphan-update", {
+    type: "permission.updated",
+    properties: { id: "permission", sessionID: "session", patterns: ["C:/work"] },
+  })
+
+  assert.deepEqual(getPermissionQueue("permission-orphan-update"), [])
+})

--- a/packages/ui/src/stores/session-events.ts
+++ b/packages/ui/src/stores/session-events.ts
@@ -682,12 +682,10 @@ function handlePermissionUpdated(instanceId: string, event: EventPermissionV2Ask
     log.info(`[SSE] Ignoring stale permission request after local reply: ${permissionId}`)
     return
   }
-  const isUpdate = event.type === "permission.updated"
-  if (isUpdate && !getPermissionQueue(instanceId).some((pending) => pending.id === permissionId)) {
-    log.info(`[SSE] Ignoring permission update without a pending request: ${permissionId}`)
-    return
-  }
-  const source = isUpdate ? undefined : event.type === "permission.v2.asked" ? "v2" : "legacy"
+  const isPending = getPermissionQueue(instanceId).some((pending) => pending.id === permissionId)
+  const source = event.type === "permission.v2.asked"
+    ? "v2"
+    : event.type === "permission.updated" && isPending ? undefined : "legacy"
 
   log.info(`[SSE] Permission request: ${permissionId} (${getPermissionKind(permission)})`)
   const queuedPermission = addPermissionToQueue(instanceId, permission, source) ?? permission

--- a/packages/ui/src/stores/session-events.ts
+++ b/packages/ui/src/stores/session-events.ts
@@ -46,6 +46,7 @@ import { preferences } from "./preferences"
 import {
   instances,
   addPermissionToQueue,
+  getPermissionQueue,
   removePermissionFromQueue,
   markPermissionReplied,
   hasRepliedPermission,
@@ -675,12 +676,18 @@ function handleTuiToast(_instanceId: string, event: TuiToastEvent): void {
 function handlePermissionUpdated(instanceId: string, event: EventPermissionV2Asked | LegacyPermissionAskedEvent): void {
   const permission = event?.properties as PermissionRequest | undefined
   if (!permission) return
-  const source = event.type === "permission.v2.asked" ? "v2" : "legacy"
   const permissionId = getPermissionId(permission)
-  if (permissionId && hasRepliedPermission(instanceId, permissionId)) {
+  if (!permissionId) return
+  if (hasRepliedPermission(instanceId, permissionId)) {
     log.info(`[SSE] Ignoring stale permission request after local reply: ${permissionId}`)
     return
   }
+  const isUpdate = event.type === "permission.updated"
+  if (isUpdate && !getPermissionQueue(instanceId).some((pending) => pending.id === permissionId)) {
+    log.info(`[SSE] Ignoring permission update without a pending request: ${permissionId}`)
+    return
+  }
+  const source = isUpdate ? undefined : event.type === "permission.v2.asked" ? "v2" : "legacy"
 
   log.info(`[SSE] Permission request: ${permissionId} (${getPermissionKind(permission)})`)
   const queuedPermission = addPermissionToQueue(instanceId, permission, source) ?? permission


### PR DESCRIPTION
## Summary
- Preserve the original V2 source when permission.updated changes an already-pending request, so approval continues through the V2 reply API instead of the legacy endpoint.
- Keep standalone permission.updated events as valid legacy requests for older supported OpenCode binaries.
- Continue suppressing delayed post-reply updates through the existing replied-request tombstone, preventing an approved request from reappearing.

## Reproduced failure
The regression test fails on dev before the fix: permission.v2.asked followed by permission.updated changes the request source to legacy, so approval calls the legacy endpoint and never reaches the V2 reply API.

## Compatibility coverage
- V2 request plus permission.updated replies through V2
- delayed permission.updated after a successful local reply does not re-enter the queue
- standalone legacy permission.updated remains visible and replies through legacy

## Scope
This PR intentionally does not add speculative timeout, reconnect, or modal-rendering changes. It only fixes the reproduced source-routing bug and preserves verified legacy behavior.

## Validation
- npm run typecheck
- npm run build --workspace @codenomad/ui
- 144 existing runnable UI tests passed
- browser integration tests passed, including all permission lifecycle regressions

Closes #566