### PR TITLE
fix(ui): keep relevant file path segments visible

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -105,6 +105,7 @@ jobs:
         run: >-
           node --import tsx --test
           packages/ui/src/components/session-list-visibility.test.ts
+          packages/ui/src/components/unified-picker-path.test.ts
           packages/ui/src/lib/hooks/use-app-session-capture.test.ts
           packages/ui/src/lib/message-selection-position.test.ts
           packages/ui/src/lib/trailing-resync.test.ts

--- a/packages/ui/src/components/unified-picker-path.test.ts
+++ b/packages/ui/src/components/unified-picker-path.test.ts
@@ -2,23 +2,20 @@ import assert from "node:assert/strict"
 import test from "node:test"
 import { splitDisplayPath } from "./unified-picker-path"
 
-test("splits paths into file and abbreviated directory context", () => {
+test("splits paths into file and directory context", () => {
   assert.deepEqual(splitDisplayPath("packages/ui/src/components/unified-picker.tsx"), {
     name: "unified-picker.tsx",
-    start: "packages",
     parent: "components",
-    hasMiddle: true,
+    directory: "packages/ui/src/components",
   })
   assert.deepEqual(splitDisplayPath("src/components/"), {
     name: "components/",
-    start: "src",
-    parent: "",
-    hasMiddle: false,
+    parent: "src",
+    directory: "src",
   })
   assert.deepEqual(splitDisplayPath("README.md"), {
     name: "README.md",
-    start: "",
     parent: "",
-    hasMiddle: false,
+    directory: "",
   })
 })

--- a/packages/ui/src/components/unified-picker-path.test.ts
+++ b/packages/ui/src/components/unified-picker-path.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { splitDisplayPath } from "./unified-picker-path"
+
+test("splits paths into file and abbreviated directory context", () => {
+  assert.deepEqual(splitDisplayPath("packages/ui/src/components/unified-picker.tsx"), {
+    name: "unified-picker.tsx",
+    start: "packages",
+    parent: "components",
+    hasMiddle: true,
+  })
+  assert.deepEqual(splitDisplayPath("src/components/"), {
+    name: "components/",
+    start: "src",
+    parent: "",
+    hasMiddle: false,
+  })
+  assert.deepEqual(splitDisplayPath("README.md"), {
+    name: "README.md",
+    start: "",
+    parent: "",
+    hasMiddle: false,
+  })
+})

--- a/packages/ui/src/components/unified-picker-path.ts
+++ b/packages/ui/src/components/unified-picker-path.ts
@@ -3,9 +3,8 @@ export function splitDisplayPath(path: string) {
   const parts = path.split("/").filter(Boolean)
   const folders = parts.slice(0, -1)
   return {
-    name: parts.length > 0 ? `${parts.at(-1)}${isDirectory ? "/" : ""}` : path,
-    start: folders[0] ?? "",
-    parent: folders.length > 1 ? folders.at(-1) ?? "" : "",
-    hasMiddle: folders.length > 2,
+    name: parts.length > 0 ? `${parts[parts.length - 1]}${isDirectory ? "/" : ""}` : path,
+    parent: folders[folders.length - 1] ?? "",
+    directory: folders.join("/"),
   }
 }

--- a/packages/ui/src/components/unified-picker-path.ts
+++ b/packages/ui/src/components/unified-picker-path.ts
@@ -1,0 +1,11 @@
+export function splitDisplayPath(path: string) {
+  const isDirectory = path.endsWith("/")
+  const parts = path.split("/").filter(Boolean)
+  const folders = parts.slice(0, -1)
+  return {
+    name: parts.length > 0 ? `${parts.at(-1)}${isDirectory ? "/" : ""}` : path,
+    start: folders[0] ?? "",
+    parent: folders.length > 1 ? folders.at(-1) ?? "" : "",
+    hasMiddle: folders.length > 2,
+  }
+}

--- a/packages/ui/src/components/unified-picker.tsx
+++ b/packages/ui/src/components/unified-picker.tsx
@@ -115,6 +115,7 @@ const UnifiedPicker: Component<UnifiedPickerProps> = (props) => {
     setTimeout(() => {
       if (scrollContainerRef) {
         scrollContainerRef.scrollTop = 0
+        scrollContainerRef.scrollLeft = 0
       }
     }, 0)
   }
@@ -595,7 +596,7 @@ const UnifiedPicker: Component<UnifiedPickerProps> = (props) => {
                     data-picker-selected={itemIndex === selectedIndex()}
                     onClick={() => props.onSelect({ type: "file", file }, "click")}
                   >
-                    <div class="flex min-w-0 items-center gap-2 text-sm">
+                    <div class="flex min-w-full w-max items-center gap-2 text-sm">
                       <Show
                         when={isFolder}
                         fallback={
@@ -621,17 +622,14 @@ const UnifiedPicker: Component<UnifiedPickerProps> = (props) => {
                       <span class="min-w-0 flex-1" title={file.path}>
                         <span class="sr-only">{file.path}</span>
                         <span aria-hidden="true">
-                          <span class="block break-all">{displayPath.name}</span>
-                          <Show when={displayPath.start}>
-                            <span class="flex min-w-0 items-center text-[11px]" style="color: var(--text-muted)">
-                              <span class="min-w-0 shrink truncate">{displayPath.start}</span>
-                              <Show when={displayPath.hasMiddle}>
-                                <span class="shrink-0">/…</span>
-                              </Show>
-                              <Show when={displayPath.parent}>
-                                <span class="min-w-0 shrink truncate">/{displayPath.parent}</span>
-                              </Show>
-                            </span>
+                          <span class="block whitespace-nowrap">
+                            {displayPath.name}
+                          </span>
+                          <Show when={displayPath.parent}>
+                            <span class="block whitespace-nowrap text-[11px]" style="color: var(--text-muted)">{displayPath.parent}/</span>
+                          </Show>
+                          <Show when={displayPath.directory && displayPath.directory !== displayPath.parent}>
+                            <span class="block whitespace-nowrap text-[10px]" style="color: var(--text-muted)">{displayPath.directory}</span>
                           </Show>
                         </span>
                       </span>

--- a/packages/ui/src/components/unified-picker.tsx
+++ b/packages/ui/src/components/unified-picker.tsx
@@ -5,6 +5,7 @@ import type { OpencodeClient } from "@opencode-ai/sdk/v2/client"
 import { serverApi } from "../lib/api-client"
 import { useI18n } from "../lib/i18n"
 import { getLogger } from "../lib/logger"
+import { splitDisplayPath } from "./unified-picker-path"
 const log = getLogger("actions")
 
 
@@ -585,6 +586,7 @@ const UnifiedPicker: Component<UnifiedPickerProps> = (props) => {
                   (item) => item.type === "file" && item.file.relativePath === file.relativePath,
                 )
                 const isFolder = file.isDirectory
+                const displayPath = splitDisplayPath(file.path)
                 return (
                   <div
                     class={`dropdown-item py-1.5 ${
@@ -593,7 +595,7 @@ const UnifiedPicker: Component<UnifiedPickerProps> = (props) => {
                     data-picker-selected={itemIndex === selectedIndex()}
                     onClick={() => props.onSelect({ type: "file", file }, "click")}
                   >
-                    <div class="flex min-w-full w-max items-center gap-2 text-sm">
+                    <div class="flex min-w-0 items-center gap-2 text-sm">
                       <Show
                         when={isFolder}
                         fallback={
@@ -616,7 +618,23 @@ const UnifiedPicker: Component<UnifiedPickerProps> = (props) => {
                           />
                         </svg>
                       </Show>
-                      <span class="whitespace-nowrap">{file.path}</span>
+                      <span class="min-w-0 flex-1" title={file.path}>
+                        <span class="sr-only">{file.path}</span>
+                        <span aria-hidden="true">
+                          <span class="block break-all">{displayPath.name}</span>
+                          <Show when={displayPath.start}>
+                            <span class="flex min-w-0 items-center text-[11px]" style="color: var(--text-muted)">
+                              <span class="min-w-0 shrink truncate">{displayPath.start}</span>
+                              <Show when={displayPath.hasMiddle}>
+                                <span class="shrink-0">/…</span>
+                              </Show>
+                              <Show when={displayPath.parent}>
+                                <span class="min-w-0 shrink truncate">/{displayPath.parent}</span>
+                              </Show>
+                            </span>
+                          </Show>
+                        </span>
+                      </span>
                     </div>
                   </div>
                 )


### PR DESCRIPTION
## Summary
- show the file or directory name first in each @ picker result
- show the immediate parent and complete root-aligned directory on separate lines
- preserve horizontal inspection for long directories and reset it when results change
- retain the complete path for assistive technology without changing selection values
- run the focused path-splitting regression test in PR CI

## Context
PR #623 replaced end truncation with horizontal scrolling. This follow-up keeps that behavior while moving the relevant filename and parent to the start of each result, matching the CLI-style expectation from the report.

## Validation
- workspace typecheck passes
- UI production build passes
- focused path test passes
- git diff check passes
- Gatekeeper round 3: zero findings

Closes #603