### PR TITLE
refactor(server): route background-process prompt through the instance client factory

### DIFF
--- a/packages/server/src/background-processes/manager.test.ts
+++ b/packages/server/src/background-processes/manager.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { promises as fs } from "node:fs"
+import path from "node:path"
+import os from "node:os"
+
+import { BackgroundProcessManager } from "./manager"
+import type { WorkspaceManager } from "../workspaces/manager"
+import type { EventBus } from "../events/bus"
+import type { Logger } from "../logger"
+
+const WORKSPACE_ID = "ws-test"
+const SESSION_ID = "sess-1"
+const INSTANCE_PORT = 9999
+const AUTH_HEADER = "Basic test-auth"
+const TERMINAL_TIMEOUT_MS = 3000
+
+interface CapturedRequest {
+  method: string
+  url: string
+  headers: Headers
+  body: string
+}
+
+/**
+ * Drives the real {@link BackgroundProcessManager} lifecycle (spawn a
+ * fast-exiting command with notify enabled) against a mocked transport, so the
+ * migrated `sendCompletionPrompt` path — factory + SDK client + `fetch` — is
+ * exercised end to end without touching production wiring.
+ *
+ * The workspace temp directory is intentionally left in place (under
+ * `os.tmpdir()`, OS-reaped): removing it from the test races the manager's
+ * asynchronous finalization writes, which intermittently fail with ENOENT.
+ */
+async function runCompletionPrompt(
+  fetchImpl: (input: Request, init: RequestInit | undefined) => Promise<Response>,
+): Promise<{ requests: CapturedRequest[]; warned: boolean; directory: string }> {
+  const requests: CapturedRequest[] = []
+  const originalFetch = globalThis.fetch
+  // Captured now but swapped in only inside the try below, so a failure during
+  // setup (mkdtemp, manager construction) can't leak the mocked fetch.
+  const fetchMock = (async (input: any, init: any) => {
+    const req = input instanceof Request ? input : new Request(String(input), init)
+    requests.push({
+      method: req.method,
+      url: req.url,
+      headers: req.headers,
+      body: await req.text(),
+    })
+    return fetchImpl(input instanceof Request ? input : req, init)
+  }) as typeof fetch
+
+  let warned = false
+  const logger = {
+    warn: () => { warned = true },
+    debug: () => {},
+    trace: () => {},
+    info: () => {},
+    error: () => {},
+    fatal: () => {},
+    isLevelEnabled: () => false,
+    level: "info",
+    child: () => logger,
+  } as unknown as Logger
+
+  const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "bp-test-"))
+  // Distinct from the workspace root so the directory-override assertion is
+  // discriminating: if `sendCompletionPrompt` stops passing `notify.directory`,
+  // the factory would fall back to `workspacePath` and the header check fails.
+  const sessionDir = path.join(workspacePath, "session-worktree")
+
+  // Resolve once the manager publishes a terminal (non-running) status update.
+  let resolveTerminal: () => void = () => {}
+  const terminal = new Promise<void>((resolve) => { resolveTerminal = resolve })
+  const eventBus = {
+    on: () => {},
+    publish: (event: any) => {
+      if (event?.type === "instance.event") {
+        const type = event?.event?.type
+        const status = event?.event?.properties?.process?.status
+        if (type === "background.process.removed" || (status && status !== "running")) resolveTerminal()
+      }
+      return true
+    },
+  } as unknown as EventBus
+
+  const workspaceManager = {
+    get: () => ({ path: workspacePath }),
+    getInstancePort: () => INSTANCE_PORT,
+    getInstanceAuthorizationHeader: () => AUTH_HEADER,
+  } as unknown as WorkspaceManager
+
+  const manager = new BackgroundProcessManager({ workspaceManager, eventBus, logger })
+
+  try {
+    globalThis.fetch = fetchMock
+    await manager.start(WORKSPACE_ID, "test-proc", "true", {
+      notify: true,
+      notification: { sessionID: SESSION_ID, directory: sessionDir },
+    })
+    // The terminal status update is published at the very end of finalize, so
+    // resolving on it is a deterministic completion signal. Fail loudly rather
+    // than racing a silent timeout that could mask a hang.
+    let timeoutHandle: NodeJS.Timeout | undefined
+    const reachedTerminal = await Promise.race([
+      terminal.then(() => true),
+      new Promise<boolean>((resolve) => {
+        timeoutHandle = setTimeout(() => resolve(false), TERMINAL_TIMEOUT_MS)
+      }),
+    ])
+    if (timeoutHandle) clearTimeout(timeoutHandle)
+    if (!reachedTerminal) {
+      throw new Error("background process did not reach a terminal state in time")
+    }
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+
+  return { requests, warned, directory: sessionDir }
+}
+
+describe("BackgroundProcessManager.sendCompletionPrompt", () => {
+  it("posts the synthetic completion prompt to the instance via the SDK route", async () => {
+    const { requests, directory } = await runCompletionPrompt(async () =>
+      new Response("{}", { status: 200, headers: { "content-type": "application/json" } }),
+    )
+
+    const promptCall = requests.find((r) => r.url.includes("/prompt_async"))
+    assert.ok(promptCall, "expected a prompt_async request")
+    assert.equal(promptCall.method, "POST")
+    assert.equal(
+      promptCall.url,
+      `http://127.0.0.1:${INSTANCE_PORT}/session/${SESSION_ID}/prompt_async`,
+    )
+    assert.equal(promptCall.headers.get("authorization"), AUTH_HEADER)
+    // The prompt is scoped to the session's directory (a POST keeps the
+    // directory as a header — the SDK only rewrites header→query for GET/HEAD).
+    assert.equal(promptCall.headers.get("x-opencode-directory"), encodeURIComponent(directory))
+
+    const body = JSON.parse(promptCall.body)
+    assert.equal(body.parts.length, 1)
+    assert.equal(body.parts[0].type, "text")
+    assert.equal(body.parts[0].synthetic, true)
+    assert.match(body.parts[0].text, /test-proc/)
+  })
+
+  it("swallows a failed prompt and logs it without aborting finalization", async () => {
+    const { warned } = await runCompletionPrompt(async () =>
+      new Response("boom", { status: 500 }),
+    )
+    assert.equal(warned, true)
+  })
+})

--- a/packages/server/src/background-processes/manager.ts
+++ b/packages/server/src/background-processes/manager.ts
@@ -4,6 +4,7 @@ import path from "path"
 import { randomBytes } from "crypto"
 import type { EventBus } from "../events/bus"
 import type { WorkspaceManager } from "../workspaces/manager"
+import { createInstanceClient } from "../workspaces/instance-client"
 import type { Logger } from "../logger"
 import type { BackgroundProcess, BackgroundProcessStatus, BackgroundProcessTerminalReason } from "../api-types"
 
@@ -625,29 +626,16 @@ export class BackgroundProcessManager {
     const notify = record.notify
     if (!notify || !record.terminalReason) return
 
-    if (!this.deps.workspaceManager.get(workspaceId)) {
-      throw new Error("Workspace not found")
-    }
-
-    const port = this.deps.workspaceManager.getInstancePort(workspaceId)
-    if (!port) {
+    const client = createInstanceClient(this.deps.workspaceManager, workspaceId, {
+      directory: notify.directory,
+    })
+    if (!client) {
       throw new Error("Workspace instance is not ready")
     }
 
-    const targetUrl = `http://127.0.0.1:${port}/session/${encodeURIComponent(notify.sessionID)}/prompt_async`
-    const headers: Record<string, string> = {
-      "content-type": "application/json",
-    }
-
-    const authorization = this.deps.workspaceManager.getInstanceAuthorizationHeader(workspaceId)
-    if (authorization) {
-      headers.authorization = authorization
-    }
-
-    const response = await fetch(targetUrl, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
+    await client.session.promptAsync(
+      {
+        sessionID: notify.sessionID,
         parts: [
           {
             type: "text",
@@ -655,13 +643,9 @@ export class BackgroundProcessManager {
             synthetic: true,
           },
         ],
-      }),
-    })
-
-    if (!response.ok) {
-      const message = await response.text().catch(() => "")
-      throw new Error(message || `Prompt request failed with ${response.status}`)
-    }
+      },
+      { throwOnError: true },
+    )
   }
 
   private buildCompletionPrompt(record: PersistedBackgroundProcess): string {

--- a/packages/server/src/workspaces/instance-client.test.ts
+++ b/packages/server/src/workspaces/instance-client.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { createInstanceClient } from "./instance-client"
+import type { WorkspaceManager } from "./manager"
+
+/**
+ * Minimal stand-in for the parts of {@link WorkspaceManager} the factory reads.
+ * The factory only touches three members, so a structural stub is enough and
+ * keeps the test free of the full manager's heavy dependencies.
+ */
+interface StubWorkspaceManager {
+  getInstancePort: (id: string) => number | undefined
+  getInstanceAuthorizationHeader: (id: string) => string | undefined
+  get: (id: string) => { path: string } | undefined
+}
+
+function makeManager(overrides: Partial<StubWorkspaceManager> = {}): StubWorkspaceManager {
+  return {
+    getInstancePort: overrides.getInstancePort ?? (() => undefined),
+    getInstanceAuthorizationHeader: overrides.getInstanceAuthorizationHeader ?? (() => undefined),
+    get: overrides.get ?? (() => undefined),
+  }
+}
+
+interface CapturedRequest {
+  url: string
+  headers: Headers
+}
+
+/**
+ * Installs a global `fetch` stub that records every outgoing request and
+ * answers a minimal healthy JSON body. Returns the capture buffer and a
+ * restore function. The stub tolerates both `fetch(url, init)` and
+ * `fetch(Request)` invocation styles so it is independent of the SDK's
+ * internal call convention.
+ */
+function installRecordingFetch(): { requests: CapturedRequest[]; restore: () => void } {
+  const requests: CapturedRequest[] = []
+  const original = globalThis.fetch
+
+  globalThis.fetch = (async (input: any, init: any) => {
+    if (input instanceof Request) {
+      requests.push({ url: input.url, headers: new Headers(init?.headers ?? input.headers) })
+    } else {
+      requests.push({ url: String(input), headers: new Headers(init?.headers) })
+    }
+    return new Response(JSON.stringify({ healthy: true }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })
+  }) as typeof fetch
+
+  return { requests, restore: () => { globalThis.fetch = original } }
+}
+
+describe("createInstanceClient", () => {
+  it("returns null when the instance has no open port", () => {
+    const manager = makeManager({ getInstancePort: () => undefined })
+    assert.equal(createInstanceClient(manager as unknown as WorkspaceManager, "ws-1"), null)
+  })
+
+  it("targets the loopback host and port on outgoing requests", async () => {
+    const { requests, restore } = installRecordingFetch()
+    try {
+      const manager = makeManager({ getInstancePort: () => 4321, get: () => ({ path: "/repo" }) })
+      const client = createInstanceClient(manager as unknown as WorkspaceManager, "ws-1")
+      assert.ok(client, "expected a client when the instance has a port")
+
+      await client!.global.health()
+      const parsed = new URL(requests[0].url)
+      assert.equal(parsed.hostname, "127.0.0.1")
+      assert.equal(parsed.port, "4321")
+    } finally {
+      restore()
+    }
+  })
+
+  it("attaches the authorization header when one is configured", async () => {
+    const { requests, restore } = installRecordingFetch()
+    try {
+      const manager = makeManager({
+        getInstancePort: () => 4321,
+        getInstanceAuthorizationHeader: () => "Basic abc",
+        get: () => ({ path: "/repo" }),
+      })
+      const client = createInstanceClient(manager as unknown as WorkspaceManager, "ws-1")
+
+      await client!.global.health()
+      assert.equal(requests[0].headers.get("authorization"), "Basic abc")
+    } finally {
+      restore()
+    }
+  })
+
+  it("omits the authorization header when none is configured", async () => {
+    const { requests, restore } = installRecordingFetch()
+    try {
+      const manager = makeManager({ getInstancePort: () => 4321, get: () => ({ path: "/repo" }) })
+      const client = createInstanceClient(manager as unknown as WorkspaceManager, "ws-1")
+
+      await client!.global.health()
+      assert.equal(requests[0].headers.get("authorization"), null)
+    } finally {
+      restore()
+    }
+  })
+
+  it("scopes requests to the workspace directory", async () => {
+    const { requests, restore } = installRecordingFetch()
+    try {
+      const manager = makeManager({ getInstancePort: () => 4321, get: () => ({ path: "/repo" }) })
+      const client = createInstanceClient(manager as unknown as WorkspaceManager, "ws-1")
+
+      await client!.global.health()
+      // GET requests carry directory as a query parameter (see SDK rewrite).
+      assert.equal(new URL(requests[0].url).searchParams.get("directory"), "/repo")
+    } finally {
+      restore()
+    }
+  })
+
+  it("does not scope requests when the workspace has no path", async () => {
+    const { requests, restore } = installRecordingFetch()
+    try {
+      const manager = makeManager({ getInstancePort: () => 4321, get: () => undefined })
+      const client = createInstanceClient(manager as unknown as WorkspaceManager, "ws-1")
+
+      await client!.global.health()
+      assert.equal(new URL(requests[0].url).searchParams.get("directory"), null)
+    } finally {
+      restore()
+    }
+  })
+
+  it("honours an explicit directory override over the workspace root", async () => {
+    const { requests, restore } = installRecordingFetch()
+    try {
+      const manager = makeManager({ getInstancePort: () => 4321, get: () => ({ path: "/workspace-root" }) })
+      const client = createInstanceClient(manager as unknown as WorkspaceManager, "ws-1", {
+        directory: "/explicit/session-dir",
+      })
+
+      await client!.global.health()
+      assert.equal(new URL(requests[0].url).searchParams.get("directory"), "/explicit/session-dir")
+    } finally {
+      restore()
+    }
+  })
+
+  it("applies the loopback timeout and aborts a stuck instance", async () => {
+    const original = globalThis.fetch
+    // Never resolves on its own; only settles when the passed signal aborts,
+    // mirroring how a real fetch honours an AbortSignal. Without the factory
+    // timeout this call would hang forever and time the test out.
+    globalThis.fetch = (async (_input: any, init: any) => {
+      return new Promise((_resolve, reject) => {
+        const signal = (init as RequestInit | undefined)?.signal
+        if (!signal) return
+        if (signal.aborted) reject((signal as AbortSignal).reason ?? new Error("aborted"))
+        else signal.addEventListener("abort", () => reject((signal as AbortSignal).reason ?? new Error("aborted")))
+      })
+    }) as typeof fetch
+    try {
+      const manager = makeManager({ getInstancePort: () => 4321, get: () => ({ path: "/repo" }) })
+      const client = createInstanceClient(manager as unknown as WorkspaceManager, "ws-1", { timeoutMs: 10 })
+
+      // SDK methods resolve with { error } rather than throwing by default.
+      const result = await client!.global.health()
+      assert.ok(result.error, "expected the stuck-instance call to surface an error")
+    } finally {
+      globalThis.fetch = original
+    }
+  })
+})

--- a/packages/server/src/workspaces/instance-client.ts
+++ b/packages/server/src/workspaces/instance-client.ts
@@ -1,11 +1,18 @@
 import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk/v2/client"
 import type { WorkspaceManager } from "./manager"
+import { LOOPBACK_HOST } from "./loopback"
 
-const INSTANCE_HOST = "127.0.0.1"
 const LOOPBACK_TIMEOUT_MS = 10_000
 
 interface InstanceClientOptions {
   timeoutMs?: number
+  /**
+   * Directory the instance should scope the call to. Defaults to the
+   * workspace root; pass an explicit path when targeting a session that
+   * lives elsewhere (e.g. a worktree) so OpenCode resolves the right
+   * project context.
+   */
+  directory?: string
 }
 
 /**
@@ -18,8 +25,8 @@ interface InstanceClientOptions {
  * OpenCode instance directly should use this factory rather than building
  * `http://127.0.0.1:{port}/...` URLs by hand.
  *
- * All requests carry a 10-second timeout — loopback calls should be
- * near-instant; a hang indicates a stuck instance.
+ * Requests carry a 10-second timeout (configurable via `timeoutMs`) —
+ * loopback calls should be near-instant; a hang indicates a stuck instance.
  *
  * The client is cheap to create (object only, no connection); create one per
  * call or cache per instance as needed. Returns `null` when the instance has
@@ -41,15 +48,16 @@ export function createInstanceClient(
 
   const workspace = workspaceManager.get(instanceId)
   const timeoutMs = options.timeoutMs ?? LOOPBACK_TIMEOUT_MS
+  const directory = options.directory ?? workspace?.path
 
   return createOpencodeClient({
-    baseUrl: `http://${INSTANCE_HOST}:${port}/`,
+    baseUrl: `http://${LOOPBACK_HOST}:${port}/`,
     headers,
     fetch: (url, init) =>
       fetch(url, {
         ...(init as RequestInit),
         signal: (init as RequestInit)?.signal ?? AbortSignal.timeout(timeoutMs),
       }),
-    ...(workspace?.path ? { directory: workspace.path } : {}),
+    ...(directory ? { directory } : {}),
   })
 }

--- a/packages/server/src/workspaces/instance-events.ts
+++ b/packages/server/src/workspaces/instance-events.ts
@@ -3,9 +3,9 @@ import { Agent as UndiciAgent } from "undici"
 import { EventBus } from "../events/bus"
 import { Logger } from "../logger"
 import { WorkspaceManager } from "./manager"
+import { LOOPBACK_HOST } from "./loopback"
 import { InstanceStreamEvent, InstanceStreamStatus } from "../api-types"
 
-const INSTANCE_HOST = "127.0.0.1"
 const STREAM_AGENT = new UndiciAgent({ bodyTimeout: 0, headersTimeout: 0 })
 const RECONNECT_DELAY_MS = 1000
 
@@ -95,7 +95,7 @@ export class InstanceEventBridge {
   }
 
   private async consumeStream(workspaceId: string, port: number, signal: AbortSignal) {
-    const url = `http://${INSTANCE_HOST}:${port}/global/event`
+    const url = `http://${LOOPBACK_HOST}:${port}/global/event`
 
     const headers: Record<string, string> = { Accept: "text/event-stream" }
     const authHeader = this.options.workspaceManager.getInstanceAuthorizationHeader(workspaceId)

--- a/packages/server/src/workspaces/loopback.ts
+++ b/packages/server/src/workspaces/loopback.ts
@@ -1,0 +1,8 @@
+/**
+ * Loopback host used for direct in-process communication with a running
+ * OpenCode workspace instance (the server and the instance share a machine).
+ *
+ * Shared by the workspace-instance loopback callers so they agree on the host
+ * instead of each hardcoding their own `127.0.0.1` literal.
+ */
+export const LOOPBACK_HOST = "127.0.0.1"

--- a/packages/server/src/workspaces/manager.ts
+++ b/packages/server/src/workspaces/manager.ts
@@ -26,6 +26,7 @@ import {
 } from "./opencode-auth"
 import { resolveWorkspaceIdentity } from "./workspace-identity"
 import { parseWslUncPath } from "./spawn"
+import { LOOPBACK_HOST } from "./loopback"
 
 const STARTUP_STABILITY_DELAY_MS = 1500
 const DEFAULT_LAUNCH_TIMEOUT_MS = 30_000
@@ -749,7 +750,7 @@ export class WorkspaceManager {
     port: number,
     signal?: AbortSignal,
   ): Promise<{ ok: boolean; reason?: string; version?: string }> {
-    const url = `http://127.0.0.1:${port}/global/health`
+    const url = `http://${LOOPBACK_HOST}:${port}/global/health`
 
     try {
       const headers: Record<string, string> = {}
@@ -811,7 +812,7 @@ export class WorkspaceManager {
 
       const tryConnect = () => {
         if (settled) return
-        const socket = connect({ port, host: "127.0.0.1", signal }, () => {
+        const socket = connect({ port, host: LOOPBACK_HOST, signal }, () => {
           cleanup()
           socket.end()
           resolve()


### PR DESCRIPTION
## Summary

PR #561 introduced `createInstanceClient` so server modules would stop hand-assembling the OpenCode loopback URL and use the generated SDK client. Three call sites adopted it; the background-process completion prompt was the remaining holdout — it still hand-built `http://127.0.0.1:{port}/session/{id}/prompt_async` with manual auth/content-type wiring. This PR routes it through the factory + `client.session.promptAsync`, and consolidates the loopback host constant.

## Why

- **Consistency** — the last hand-built OpenCode-instance loopback URL (explicitly flagged in #561 as a future adoption target) now uses the same version-correct SDK path as the permission replier, yolo metadata, and the opencode updater.
- **Correctness** — the old call sent no directory at all; `notify.directory` was stored but never used (dead data). The factory now scopes the prompt to the session's own directory, which for a worktree/subdirectory session is the correct project context (a normal session coincides with the workspace root, so no change there).

## What changed

**Migration** — `background-processes/manager.ts`: `sendCompletionPrompt` → `createInstanceClient(...)` + `client.session.promptAsync({sessionID, parts:[{type:"text", text, synthetic:true}]}, {throwOnError:true})`. Synthetic `<system-message>` text + `synthetic:true` preserved. Side effect: the call now carries the factory's 10s loopback timeout (the old fetch had none; the failure is swallowed + warn-logged, so finalization is unaffected).

**Factory** — `workspaces/instance-client.ts`: new optional `directory` override in `InstanceClientOptions` (defaults to workspace root); adopts shared `LOOPBACK_HOST`. Fetch wrapper unchanged from `dev`.

**Consolidation** — new `workspaces/loopback.ts` exporting `LOOPBACK_HOST = "127.0.0.1"`, adopted by `instance-client.ts`, `instance-events.ts`, and the workspace manager's health + TCP probes (`manager.ts`). (Other `127.0.0.1` uses — remote-access proxy, sidecars — are different concerns, left alone.)

**Tests**
- `workspaces/instance-client.test.ts` (8 cases): null-when-no-port, loopback host/port targeting, auth header attach/omit, directory scoping present/absent, explicit directory override, timeout aborts stuck call.
- `background-processes/manager.test.ts` (2 cases, first test for this manager): drives the real lifecycle (spawn + exit) against a mocked transport; asserts the `prompt_async` POST URL/body/authorization/`x-opencode-directory` (= session dir, distinct from workspace root), and that a failed prompt is swallowed + warn-logged without aborting finalization.

## Behavior parity

| Aspect | Before | After |
|---|---|---|
| Route / body | `/session/{id}/prompt_async`, `{parts:[{type,text,synthetic}]}` | **same** (via SDK) |
| Auth header | manual | via factory |
| Directory scoping | none | session's `notify.directory` |
| Loopback timeout | none | 10s (factory default) |
| Error handling | throw on non-2xx → caught + warn-logged | `throwOnError` → caught + warn-logged (**same**) |

## Testing

10 new tests pass. The background-process integration test is stable 12/12 under `--test-concurrency=4` and is mutation-killed if the `directory` override or `throwOnError` is removed. Full server suite: 255 pass / 1 fail — the single failure is pre-existing (`git-clone.test.ts` Chinese-locale git message, confirmed failing identically on `dev`). Server typecheck clean.

## Risk / rollback

Additive refactor; the factory is production-proven by #561's consumers. Rollback = revert the single commit.

## Notes

- Per the file-length guideline: `packages/server/src/background-processes/manager.ts` is ~684 lines (above the 500 warn threshold, under the 800 limit); this PR shrank it by ~16 lines net.
