### PR TITLE
fix(tauri): restore macOS quit shortcut

### DIFF
--- a/packages/tauri-app/src-tauri/src/main.rs
+++ b/packages/tauri-app/src-tauri/src/main.rs
@@ -861,13 +861,9 @@ fn build_menu(app: &AppHandle) -> tauri::Result<()> {
             cfg!(target_os = "linux"),
         )),
     )?;
-    let get_updates_item = MenuItem::with_id(
-        app,
-        "get_updates",
-        "Get Updates...",
-        true,
-        None::<&str>,
-    )?;
+    let get_updates_item =
+        MenuItem::with_id(app, "get_updates", "Get Updates...", true, None::<&str>)?;
+    let quit_item = MenuItem::with_id(app, "quit", "Quit CodeNomad", true, Some("CmdOrCtrl+Q"))?;
 
     // App menu (macOS only)
     if is_mac {
@@ -879,7 +875,7 @@ fn build_menu(app: &AppHandle) -> tauri::Result<()> {
             .text("hide_others", "Hide Others")
             .text("show_all", "Show All")
             .separator()
-            .text("quit", "Quit CodeNomad")
+            .item(&quit_item)
             .build()?;
         submenus.push(app_menu);
     }


### PR DESCRIPTION
## Summary
- add the standard Cmd+Q accelerator to the Tauri macOS Quit menu item
- keep the existing custom quit event so shutdown still flushes renderer state and stops the managed CLI
- leave Windows Ctrl+W tab closing and Alt+F4 app closing unchanged

## Why
The macOS menu used a plain text item with no accelerator. Tauri's predefined native Quit item would restore Cmd+Q, but it bypasses the custom menu event and could skip CodeNomad's coordinated shutdown. A regular menu item with CmdOrCtrl+Q restores the shortcut while preserving cleanup.

## Validation
- 84 Tauri tests pass
- cargo check --locked passes
- ustfmt check passes for main.rs
- git diff --check passes
- Gatekeeper review: zero findings
- macOS runtime unavailable; accelerator and shutdown routing verified against the pinned Tauri/muda behavior

Closes #590