### PR TITLE
fix(ui): preserve failed prompts in input history

### DIFF
--- a/packages/ui/src/components/prompt-input.tsx
+++ b/packages/ui/src/components/prompt-input.tsx
@@ -510,10 +510,8 @@ export default function PromptInput(props: PromptInputProps) {
 
     clearHistoryDraft()
 
-    if (isKnownSlashCommand) {
-      // Record attempted slash commands even if execution fails.
-      void refreshHistory()
-    }
+    // Keep attempted prompts recoverable even when execution fails.
+    void refreshHistory()
 
     if (!isTouchOnlyPointer()) {
       focusConversationStream(wrapperRef?.closest(".session-view"))
@@ -534,9 +532,6 @@ export default function PromptInput(props: PromptInputProps) {
         }
       } else {
         await props.onSend(submitPrompt, currentAttachments)
-      }
-      if (!isKnownSlashCommand) {
-        void refreshHistory()
       }
     } catch (error) {
       log.error("Failed to send message:", error)


### PR DESCRIPTION
## Summary
- record normal messages and shell commands in composer history before dispatch
- keep failed prompts recoverable with the existing history navigation
- avoid duplicate history writes after successful sends

## Validation
- pm run typecheck --workspace @codenomad/ui
- pm run build --workspace @codenomad/ui
- px tsx --test packages/ui/src/components/prompt-input/submitPrompt.test.ts packages/ui/src/stores/app-session-prompt-hydration.test.ts
- two independent zero-finding reviews of the final diff

Closes #507