### PR TITLE
fix(ui): resolve stuck/duplicated messages after mobile background

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -120,7 +120,9 @@ jobs:
           packages/ui/src/stores/client-state-codec.test.ts
           packages/ui/src/stores/client-state.test.ts
           packages/ui/src/stores/instances-restore-cancellation.test.ts
+          packages/ui/src/stores/message-v2/instance-store.test.ts
           packages/ui/src/stores/message-v2/message-hydration-authority.test.ts
+          packages/ui/src/stores/message-v2/message-status.test.ts
           packages/ui/src/stores/session-generation-recovery.test.ts
           packages/ui/src/stores/session-metadata.test.ts
           packages/ui/src/stores/session-pagination.test.ts

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -107,6 +107,7 @@ jobs:
           packages/ui/src/components/session-list-visibility.test.ts
           packages/ui/src/components/unified-picker-path.test.ts
           packages/ui/src/lib/hooks/use-app-session-capture.test.ts
+          packages/ui/src/lib/hooks/use-foreground-refresh.test.ts
           packages/ui/src/lib/launch-errors.test.ts
           packages/ui/src/lib/message-selection-position.test.ts
           packages/ui/src/lib/trailing-resync.test.ts
@@ -133,6 +134,8 @@ jobs:
           node --conditions=browser --import tsx --test --test-force-exit
           packages/ui/src/stores/instances-restore-ownership.test.ts
           packages/ui/src/stores/permission-lifecycle.test.ts
+          packages/ui/src/stores/session-request-authority.test.ts
+          packages/ui/src/stores/session-send-lifecycle.test.ts
 
       - name: Test server
         run: node --import tsx --test "packages/server/src/**/*.test.ts"

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -272,13 +272,14 @@ const App: Component = () => {
       //     re-fetches lazily on next activation instead of returning stale
       //     content (a non-forced load short-circuits once "loaded").
       const instanceIds = Array.from(instances().keys())
-      await Promise.all(
-        instanceIds.map((id) =>
-          fetchSessions(id).catch((error) =>
-            log.error("Foreground refresh: fetchSessions failed", { instanceId: id, error }),
-          ),
-        ),
-      )
+      const sessionListResults = await Promise.allSettled(instanceIds.map((id) => fetchSessions(id)))
+      const failedInstanceIds: string[] = []
+      sessionListResults.forEach((result, i) => {
+        if (result.status === "rejected") {
+          failedInstanceIds.push(instanceIds[i])
+          log.error("Foreground refresh: fetchSessions failed", { instanceId: instanceIds[i], error: result.reason })
+        }
+      })
 
       const activeInst = activeInstance()
       const activeSession = activeSessionIdForInstance()
@@ -293,9 +294,19 @@ const App: Component = () => {
         }
       }
 
+      let activeReloadFailed = false
       if (hasActive) {
         const statusBefore = getSessionStatus(activeInst!.id, activeSession!)
-        await loadMessages(activeInst!.id, activeSession!, { force: true })
+        try {
+          await loadMessages(activeInst!.id, activeSession!, { force: true })
+        } catch (error) {
+          activeReloadFailed = true
+          log.error("Foreground refresh: active session reload failed", {
+            instanceId: activeInst!.id,
+            sessionId: activeSession,
+            error,
+          })
+        }
         const statusAfter = getSessionStatus(activeInst!.id, activeSession!)
         log.info("Foreground refresh: active session reloaded", {
           instanceId: activeInst!.id,
@@ -303,6 +314,15 @@ const App: Component = () => {
           statusBefore,
           statusAfter,
         })
+      }
+
+      // Report failure so the hook keeps its dirty latch and retries on the
+      // next reconnect instead of treating a partial recovery as success.
+      if (failedInstanceIds.length > 0 || activeReloadFailed) {
+        throw new Error(
+          `Foreground refresh incomplete: ${failedInstanceIds.length} session-list fetch(es) failed` +
+            (activeReloadFailed ? ", active session reload failed" : ""),
+        )
       }
     },
   })

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -55,6 +55,7 @@ import {
   updateSessionModel,
 } from "./stores/sessions"
 import { useForegroundRefresh } from "./lib/hooks/use-foreground-refresh"
+import { messagesLoaded, invalidateSessionMessageLoad } from "./stores/session-state"
 
 import { hasWakeLockEligibleWork, getSessionStatus } from "./stores/session-status"
 import { openSettings } from "./stores/settings-screen"
@@ -261,19 +262,48 @@ const App: Component = () => {
 
   useForegroundRefresh({
     onRefresh: async () => {
-      const instance = activeInstance()
-      const sessionId = activeSessionIdForInstance()
-      if (!instance || !sessionId || sessionId === "info") return
-      const statusBefore = getSessionStatus(instance.id, sessionId)
-      log.info("Foreground refresh: fetching session state after SSE reconnect", {
-        instanceId: instance.id,
-        sessionId,
-        statusBefore,
-      })
-      await fetchSessions(instance.id)
-      await loadMessages(instance.id, sessionId, { force: true })
-      const statusAfter = getSessionStatus(instance.id, sessionId)
-      log.info("Foreground refresh: done", { statusBefore, statusAfter })
+      // The SSE transport is global: a reconnect can mean missed events for
+      // EVERY loaded workspace/session, not just the one on screen. So we:
+      //  1. Re-fetch the session list for every instance (status/titles).
+      //  2. Force-reload whatever session is active AFTER the fetch settles
+      //     (so a session switch during the await still lands on the right
+      //     one), since it's the one the user is looking at.
+      //  3. Invalidate the loaded flag for every other loaded session so it
+      //     re-fetches lazily on next activation instead of returning stale
+      //     content (a non-forced load short-circuits once "loaded").
+      const instanceIds = Array.from(instances().keys())
+      await Promise.all(
+        instanceIds.map((id) =>
+          fetchSessions(id).catch((error) =>
+            log.error("Foreground refresh: fetchSessions failed", { instanceId: id, error }),
+          ),
+        ),
+      )
+
+      const activeInst = activeInstance()
+      const activeSession = activeSessionIdForInstance()
+      const hasActive = Boolean(activeInst && activeSession && activeSession !== "info")
+
+      // Invalidate every loaded session except the active one (force-reloaded
+      // below). Snapshot the map first; invalidate mutates it via setState.
+      for (const [instId, sessionSet] of messagesLoaded().entries()) {
+        for (const sId of sessionSet) {
+          if (hasActive && instId === activeInst!.id && sId === activeSession) continue
+          invalidateSessionMessageLoad(instId, sId)
+        }
+      }
+
+      if (hasActive) {
+        const statusBefore = getSessionStatus(activeInst!.id, activeSession!)
+        await loadMessages(activeInst!.id, activeSession!, { force: true })
+        const statusAfter = getSessionStatus(activeInst!.id, activeSession!)
+        log.info("Foreground refresh: active session reloaded", {
+          instanceId: activeInst!.id,
+          sessionId: activeSession,
+          statusBefore,
+          statusAfter,
+        })
+      }
     },
   })
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -41,6 +41,7 @@ import {
   stopInstance,
   disconnectedInstance,
   acknowledgeDisconnectedInstance,
+  syncPendingRequests,
 } from "./stores/instances"
 import {
   getSessions,
@@ -78,6 +79,28 @@ import {
   selectSidecarTab,
 } from "./stores/app-tabs"
 const log = getLogger("actions")
+const FOREGROUND_REFRESH_TIMEOUT_MS = 10_000
+
+async function withForegroundRefreshTimeout<T>(
+  promise: Promise<T>,
+  label: string,
+  onTimeout?: () => void,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          onTimeout?.()
+          reject(new Error(`${label} timed out`))
+        }, FOREGROUND_REFRESH_TIMEOUT_MS)
+      }),
+    ])
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}
 
 const App: Component = () => {
   useAppSessionRestore()
@@ -271,8 +294,29 @@ const App: Component = () => {
       //  3. Invalidate the loaded flag for every other loaded session so it
       //     re-fetches lazily on next activation instead of returning stale
       //     content (a non-forced load short-circuits once "loaded").
-      const instanceIds = Array.from(instances().keys())
-      const sessionListResults = await Promise.allSettled(instanceIds.map((id) => fetchSessions(id)))
+      const instanceIds = Array.from(instances().values())
+        .filter((instance) => instance.status === "ready" && Boolean(instance.client))
+        .map((instance) => instance.id)
+      const sessionListResults = await Promise.allSettled(
+        instanceIds.map((id) => {
+          let invalidateSessions = () => {}
+          let invalidatePendingRequests = () => {}
+          return withForegroundRefreshTimeout(
+            Promise.all([
+              fetchSessions(id, {
+                strictStatus: true,
+                registerInvalidation: (invalidate) => { invalidateSessions = invalidate },
+              }),
+              syncPendingRequests(id, (invalidate) => { invalidatePendingRequests = invalidate }),
+            ]),
+            `Foreground refresh for ${id}`,
+            () => {
+              invalidateSessions()
+              invalidatePendingRequests()
+            },
+          )
+        }),
+      )
       const failedInstanceIds: string[] = []
       sessionListResults.forEach((result, i) => {
         if (result.status === "rejected") {
@@ -283,22 +327,33 @@ const App: Component = () => {
 
       const activeInst = activeInstance()
       const activeSession = activeSessionIdForInstance()
-      const hasActive = Boolean(activeInst && activeSession && activeSession !== "info")
+      const hasActive = Boolean(
+        activeInst?.status === "ready" && activeInst.client && activeSession && activeSession !== "info",
+      )
+      const canReloadActive = hasActive && !failedInstanceIds.includes(activeInst!.id)
 
       // Invalidate every loaded session except the active one (force-reloaded
       // below). Snapshot the map first; invalidate mutates it via setState.
       for (const [instId, sessionSet] of messagesLoaded().entries()) {
         for (const sId of sessionSet) {
-          if (hasActive && instId === activeInst!.id && sId === activeSession) continue
+          if (canReloadActive && instId === activeInst!.id && sId === activeSession) continue
           invalidateSessionMessageLoad(instId, sId)
         }
       }
 
       let activeReloadFailed = false
-      if (hasActive) {
+      if (canReloadActive) {
         const statusBefore = getSessionStatus(activeInst!.id, activeSession!)
         try {
-          await loadMessages(activeInst!.id, activeSession!, { force: true })
+          let invalidateMessages = () => {}
+          await withForegroundRefreshTimeout(
+            loadMessages(activeInst!.id, activeSession!, {
+              force: true,
+              registerInvalidation: (invalidate) => { invalidateMessages = invalidate },
+            }),
+            `Active-session refresh for ${activeInst!.id}:${activeSession!}`,
+            () => invalidateMessages(),
+          )
         } catch (error) {
           activeReloadFailed = true
           log.error("Foreground refresh: active session reload failed", {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -50,11 +50,13 @@ import {
   clearActiveParentSession,
   createSession,
   fetchSessions,
+  loadMessages,
   updateSessionAgent,
   updateSessionModel,
 } from "./stores/sessions"
+import { useForegroundRefresh } from "./lib/hooks/use-foreground-refresh"
 
-import { hasWakeLockEligibleWork } from "./stores/session-status"
+import { hasWakeLockEligibleWork, getSessionStatus } from "./stores/session-status"
 import { openSettings } from "./stores/settings-screen"
 import {
   closeSidecarTab,
@@ -255,6 +257,24 @@ const App: Component = () => {
     const instance = activeInstance()
     if (!instance) return null
     return activeSessionId().get(instance.id) || null
+  })
+
+  useForegroundRefresh({
+    onRefresh: async () => {
+      const instance = activeInstance()
+      const sessionId = activeSessionIdForInstance()
+      if (!instance || !sessionId || sessionId === "info") return
+      const statusBefore = getSessionStatus(instance.id, sessionId)
+      log.info("Foreground refresh: fetching session state after SSE reconnect", {
+        instanceId: instance.id,
+        sessionId,
+        statusBefore,
+      })
+      await fetchSessions(instance.id)
+      await loadMessages(instance.id, sessionId, { force: true })
+      const statusAfter = getSessionStatus(instance.id, sessionId)
+      log.info("Foreground refresh: done", { statusBefore, statusAfter })
+    },
   })
 
   const launchErrorPath = () => {

--- a/packages/ui/src/lib/hooks/foreground-refresh-controller.ts
+++ b/packages/ui/src/lib/hooks/foreground-refresh-controller.ts
@@ -1,0 +1,82 @@
+import type { WorkspaceEventTransportStatus } from "../event-transport"
+
+interface ForegroundRefreshControllerOptions {
+  retryDelaysMs?: readonly number[]
+  onError?: (error: unknown) => void
+  setTimer?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>
+  clearTimer?: (timer: ReturnType<typeof setTimeout>) => void
+}
+
+export function createForegroundRefreshController(
+  onRefresh: () => void | Promise<void>,
+  options: ForegroundRefreshControllerOptions = {},
+) {
+  const retryDelaysMs = options.retryDelaysMs ?? [1_000, 3_000]
+  const setTimer = options.setTimer ?? ((callback, delayMs) => setTimeout(callback, delayMs))
+  const clearTimer = options.clearTimer ?? clearTimeout
+  let connected = false
+  let dirtyGeneration = 0
+  let recoveredGeneration = 0
+  let refreshInFlight = false
+  let retryAttempt = 0
+  let retryTimer: ReturnType<typeof setTimeout> | undefined
+  let disposed = false
+
+  const cancelRetry = () => {
+    if (retryTimer === undefined) return
+    clearTimer(retryTimer)
+    retryTimer = undefined
+  }
+
+  const runRefresh = async () => {
+    if (disposed || !connected || refreshInFlight || recoveredGeneration >= dirtyGeneration) return
+    const targetGeneration = dirtyGeneration
+    refreshInFlight = true
+    let succeeded = false
+    try {
+      await onRefresh()
+      recoveredGeneration = Math.max(recoveredGeneration, targetGeneration)
+      retryAttempt = 0
+      succeeded = true
+    } catch (error) {
+      options.onError?.(error)
+    } finally {
+      refreshInFlight = false
+    }
+
+    if (disposed || !connected || recoveredGeneration >= dirtyGeneration) return
+    if (succeeded) {
+      void runRefresh()
+      return
+    }
+
+    const delayMs = retryDelaysMs[retryAttempt]
+    if (delayMs === undefined || retryTimer !== undefined) return
+    retryAttempt += 1
+    retryTimer = setTimer(() => {
+      retryTimer = undefined
+      void runRefresh()
+    }, delayMs)
+  }
+
+  return {
+    handle(status: WorkspaceEventTransportStatus) {
+      if (status === "disconnected") {
+        connected = false
+        dirtyGeneration += 1
+        retryAttempt = 0
+        cancelRetry()
+        return
+      }
+      if (status !== "connected") return
+
+      connected = true
+      cancelRetry()
+      void runRefresh()
+    },
+    dispose() {
+      disposed = true
+      cancelRetry()
+    },
+  }
+}

--- a/packages/ui/src/lib/hooks/use-foreground-refresh.test.ts
+++ b/packages/ui/src/lib/hooks/use-foreground-refresh.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { createForegroundRefreshController } from "./foreground-refresh-controller.ts"
+
+const tick = () => new Promise<void>((resolve) => setImmediate(resolve))
+
+function deferred() {
+  let resolve!: () => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<void>((done, fail) => {
+    resolve = done
+    reject = fail
+  })
+  return { promise, resolve, reject }
+}
+
+describe("foreground refresh controller", () => {
+  it("refreshes only after a disconnect and reconnect", async () => {
+    let calls = 0
+    const controller = createForegroundRefreshController(() => {
+      calls += 1
+    })
+
+    controller.handle("connected")
+    await tick()
+    assert.equal(calls, 0)
+
+    controller.handle("disconnected")
+    controller.handle("connected")
+    await tick()
+    assert.equal(calls, 1)
+    controller.dispose()
+  })
+
+  it("runs a trailing refresh when another gap happens during recovery", async () => {
+    const first = deferred()
+    let calls = 0
+    const controller = createForegroundRefreshController(() => {
+      calls += 1
+      return calls === 1 ? first.promise : undefined
+    })
+
+    controller.handle("disconnected")
+    controller.handle("connected")
+    await tick()
+    controller.handle("disconnected")
+    controller.handle("connected")
+    first.resolve()
+    await tick()
+    await tick()
+
+    assert.equal(calls, 2)
+    controller.dispose()
+  })
+
+  it("retries a failed refresh while the transport stays connected", async () => {
+    const timers: Array<() => void> = []
+    let calls = 0
+    const controller = createForegroundRefreshController(
+      () => {
+        calls += 1
+        if (calls === 1) throw new Error("temporary")
+      },
+      {
+        retryDelaysMs: [1],
+        setTimer: (callback) => {
+          timers.push(callback)
+          return timers.length as unknown as ReturnType<typeof setTimeout>
+        },
+        clearTimer: () => {},
+      },
+    )
+
+    controller.handle("disconnected")
+    controller.handle("connected")
+    await tick()
+    assert.equal(calls, 1)
+    assert.equal(timers.length, 1)
+
+    timers[0]()
+    await tick()
+    assert.equal(calls, 2)
+    controller.dispose()
+  })
+
+})

--- a/packages/ui/src/lib/hooks/use-foreground-refresh.ts
+++ b/packages/ui/src/lib/hooks/use-foreground-refresh.ts
@@ -1,13 +1,9 @@
 import { onCleanup, onMount } from "solid-js"
 import { getLogger } from "../logger"
 import { serverEvents } from "../server-events"
+import { createForegroundRefreshController } from "./foreground-refresh-controller"
 
 const log = getLogger("foreground-refresh")
-
-// Module-level flags -- survive Solid reactive cycles, guaranteed not to reset
-// between renders the way a component-local signal could.
-let wasDisconnected = false
-let refreshInFlight = false
 
 interface ForegroundRefreshOptions {
   onRefresh: () => void | Promise<void>
@@ -29,45 +25,26 @@ interface ForegroundRefreshOptions {
 // disconnected.
 export function useForegroundRefresh(options: ForegroundRefreshOptions): void {
   onMount(() => {
+    const controller = createForegroundRefreshController(
+      async () => {
+        log.info("SSE transport reconnected — refreshing session state")
+        await options.onRefresh()
+        log.info("Foreground refresh complete")
+      },
+      {
+        onError: (error) => log.error("Foreground refresh failed — retrying while connected", error),
+      },
+    )
     const unsubscribe = serverEvents.onTransportStatus((status) => {
       if (status === "disconnected") {
-        wasDisconnected = true
         log.info("SSE transport disconnected — will refresh on reconnect")
-        return
       }
-
-      if (status === "connected") {
-        if (!wasDisconnected) {
-          log.info("SSE connected but wasDisconnected=false — skipping refresh")
-          return
-        }
-        // Do NOT clear the dirty latch yet: it must survive a failed refresh so
-        // a subsequent reconnect retries. Guard against overlapping runs if
-        // connected fires again while a refresh is still in flight.
-        if (refreshInFlight) {
-          log.info("Reconnect refresh already in flight — skipping duplicate")
-          return
-        }
-        refreshInFlight = true
-        log.info("SSE transport reconnected — refreshing session state")
-        void Promise.resolve(options.onRefresh())
-          .then(() => {
-            // Clear the latch ONLY after a fully successful recovery.
-            wasDisconnected = false
-            log.info("Foreground refresh complete")
-          })
-          .catch((error) => {
-            // Keep wasDisconnected=true so the next disconnected->connected
-            // transition performs a bounded retry instead of silently
-            // forgetting the missed events.
-            log.error("Foreground refresh failed — will retry on next reconnect", error)
-          })
-          .finally(() => {
-            refreshInFlight = false
-          })
-      }
+      controller.handle(status)
     })
 
-    onCleanup(() => unsubscribe())
+    onCleanup(() => {
+      controller.dispose()
+      unsubscribe()
+    })
   })
 }

--- a/packages/ui/src/lib/hooks/use-foreground-refresh.ts
+++ b/packages/ui/src/lib/hooks/use-foreground-refresh.ts
@@ -1,0 +1,57 @@
+import { onCleanup, onMount } from "solid-js"
+import { getLogger } from "../logger"
+import { serverEvents } from "../server-events"
+
+const log = getLogger("foreground-refresh")
+
+// Module-level flag -- survives Solid reactive cycles, guaranteed not to reset
+// between renders the way a component-local signal could.
+let wasDisconnected = false
+
+interface ForegroundRefreshOptions {
+  onRefresh: () => void | Promise<void>
+}
+
+// On mobile, backgrounding the app suspends JS execution and the SSE
+// connection eventually times out (commonly ~45s). Events that would have
+// arrived while suspended -- a tool call finishing, a message completing --
+// are lost, and the UI can appear stuck as "running" even though the work
+// actually finished on the server.
+//
+// The reliable signal that this happened is the SSE transport's
+// disconnected -> connected transition, not visibilitychange itself: a brief
+// tab switch where the connection stays alive should NOT force a reload
+// (that was tried first and it cleared in-flight "sending" state, making it
+// look like the AI never responded -- see git history on this hook).
+// Only once we know events were actually missed do we re-fetch session
+// status and force-reload messages to surface whatever completed while
+// disconnected.
+export function useForegroundRefresh(options: ForegroundRefreshOptions): void {
+  onMount(() => {
+    const unsubscribe = serverEvents.onTransportStatus((status) => {
+      if (status === "disconnected") {
+        wasDisconnected = true
+        log.info("SSE transport disconnected — will refresh on reconnect")
+        return
+      }
+
+      if (status === "connected") {
+        if (!wasDisconnected) {
+          log.info("SSE connected but wasDisconnected=false — skipping refresh")
+          return
+        }
+        wasDisconnected = false
+        log.info("SSE transport reconnected — refreshing session state")
+        void Promise.resolve(options.onRefresh())
+          .then(() => {
+            log.info("Foreground refresh complete")
+          })
+          .catch((error) => {
+            log.error("Foreground refresh failed", error)
+          })
+      }
+    })
+
+    onCleanup(() => unsubscribe())
+  })
+}

--- a/packages/ui/src/lib/hooks/use-foreground-refresh.ts
+++ b/packages/ui/src/lib/hooks/use-foreground-refresh.ts
@@ -4,9 +4,10 @@ import { serverEvents } from "../server-events"
 
 const log = getLogger("foreground-refresh")
 
-// Module-level flag -- survives Solid reactive cycles, guaranteed not to reset
+// Module-level flags -- survive Solid reactive cycles, guaranteed not to reset
 // between renders the way a component-local signal could.
 let wasDisconnected = false
+let refreshInFlight = false
 
 interface ForegroundRefreshOptions {
   onRefresh: () => void | Promise<void>
@@ -40,14 +41,29 @@ export function useForegroundRefresh(options: ForegroundRefreshOptions): void {
           log.info("SSE connected but wasDisconnected=false — skipping refresh")
           return
         }
-        wasDisconnected = false
+        // Do NOT clear the dirty latch yet: it must survive a failed refresh so
+        // a subsequent reconnect retries. Guard against overlapping runs if
+        // connected fires again while a refresh is still in flight.
+        if (refreshInFlight) {
+          log.info("Reconnect refresh already in flight — skipping duplicate")
+          return
+        }
+        refreshInFlight = true
         log.info("SSE transport reconnected — refreshing session state")
         void Promise.resolve(options.onRefresh())
           .then(() => {
+            // Clear the latch ONLY after a fully successful recovery.
+            wasDisconnected = false
             log.info("Foreground refresh complete")
           })
           .catch((error) => {
-            log.error("Foreground refresh failed", error)
+            // Keep wasDisconnected=true so the next disconnected->connected
+            // transition performs a bounded retry instead of silently
+            // forgetting the missed events.
+            log.error("Foreground refresh failed — will retry on next reconnect", error)
+          })
+          .finally(() => {
+            refreshInFlight = false
           })
       }
     })

--- a/packages/ui/src/lib/logger.ts
+++ b/packages/ui/src/lib/logger.ts
@@ -1,6 +1,6 @@
 import debug from "debug"
 
-export type LoggerNamespace = "sse" | "api" | "session" | "actions"
+export type LoggerNamespace = "sse" | "api" | "session" | "actions" | "foreground-refresh"
 
 interface Logger {
   log: (...args: unknown[]) => void
@@ -22,7 +22,7 @@ export interface LoggerControls {
   disableAllLoggers: () => void
 }
 
-const KNOWN_NAMESPACES: LoggerNamespace[] = ["sse", "api", "session", "actions"]
+const KNOWN_NAMESPACES: LoggerNamespace[] = ["sse", "api", "session", "actions", "foreground-refresh"]
 const STORAGE_KEY = "opencode:logger:namespaces"
 
 const namespaceLoggers = new Map<LoggerNamespace, Logger>()

--- a/packages/ui/src/lib/server-events.ts
+++ b/packages/ui/src/lib/server-events.ts
@@ -40,6 +40,7 @@ class ServerEvents {
     this.clearReconnectTimer()
 
     if (this.connection) {
+      this.emitTransportStatus("disconnected")
       this.connection.disconnect()
       this.connection = null
     }
@@ -48,7 +49,9 @@ class ServerEvents {
 
     try {
       const connection = await connectWorkspaceEvents({
-        onBatch: (events) => this.dispatchBatch(events),
+        onBatch: (events) => {
+          if (generation === this.connectGeneration) this.dispatchBatch(events)
+        },
         onError: () => {
           if (generation !== this.connectGeneration) {
             return
@@ -113,6 +116,8 @@ class ServerEvents {
     if (this.retryTimer) {
       return
     }
+
+    this.connectGeneration += 1
 
     if (this.connection) {
       this.connection.disconnect()
@@ -184,6 +189,7 @@ class ServerEvents {
     this.clearReconnectTimer()
 
     if (this.connection) {
+      this.emitTransportStatus("disconnected")
       this.connection.disconnect()
       this.connection = null
     }

--- a/packages/ui/src/lib/server-events.ts
+++ b/packages/ui/src/lib/server-events.ts
@@ -70,6 +70,9 @@ class ServerEvents {
           this.openHandlers.forEach((handler) => handler())
         },
         onPing: (payload) => {
+          if (generation !== this.connectGeneration) {
+            return
+          }
           const identity = getClientIdentity()
           const pongPayload = { ...identity, pingTs: payload.ts }
 

--- a/packages/ui/src/stores/instances.ts
+++ b/packages/ui/src/stores/instances.ts
@@ -202,7 +202,7 @@ async function getV2RequestLocations(instanceId: string): Promise<V2Location[]> 
   for (const worktree of worktrees) {
     if (!worktree.slug || worktree.slug === "root") continue
     const workspace = await getOpenCodeWorkspaceIdForWorktree(instanceId, worktree.slug)
-    if (!workspace) continue
+    if (!workspace) throw new Error(`Unable to resolve OpenCode workspace for worktree ${worktree.slug}`)
     workspaceBySlug.set(worktree.slug, workspace)
   }
 
@@ -230,6 +230,27 @@ const pendingRehydrations = new Map<string, Promise<void>>()
 const initialHydrations = new Map<string, Promise<void>>()
 const initialSessionHydrations = new Map<string, Promise<void>>()
 const initialWorkspaceMetadataHydrations = new Map<string, Promise<void>>()
+const pendingRequestSyncEpochs = new Map<string, number>()
+const pendingPermissionMutationEpochs = new Map<string, number>()
+const pendingQuestionMutationEpochs = new Map<string, number>()
+const pendingRequestSyncGenerations = new Map<string, number>()
+const pendingRequestSyncs = new Map<string, {
+  generation: number
+  token: { cancelled: boolean }
+  promise: Promise<void>
+}>()
+const pendingRequestSyncSuperseded = new Error("Pending request sync was superseded")
+let nextPendingRequestSyncGeneration = 0
+
+function bumpEpoch(epochs: Map<string, number>, instanceId: string): void {
+  epochs.set(instanceId, (epochs.get(instanceId) ?? 0) + 1)
+}
+
+function invalidatePendingRequestSync(instanceId: string): void {
+  bumpEpoch(pendingRequestSyncEpochs, instanceId)
+  bumpEpoch(pendingPermissionMutationEpochs, instanceId)
+  bumpEpoch(pendingQuestionMutationEpochs, instanceId)
+}
 type RestoreWorkspaceDescriptor = WorkspaceDescriptor & { reused?: boolean }
 const workspaceListReconciliationFence = new WorkspaceListReconciliationFence()
 
@@ -257,7 +278,10 @@ const connectionResyncs = new TrailingResyncCoordinator(
     await waitForSettledPrerequisite(initialHydrations.get(instanceId))
     const instance = instances().get(instanceId)
     if (!instance?.client || instance.status !== "ready") return
-    await fetchSessions(instanceId, { reset: false })
+    await Promise.all([
+      fetchSessions(instanceId, { reset: false }),
+      syncPendingRequests(instanceId),
+    ])
   },
   (instanceId, error) => {
     log.warn("Failed to resync sessions after instance connection", { instanceId, error })
@@ -466,22 +490,28 @@ function releaseInstanceResources(instanceId: string) {
   sseManager.seedStatus(instanceId, "disconnected")
 }
 
-async function syncPendingPermissions(instanceId: string): Promise<void> {
+async function syncPendingPermissions(
+  instanceId: string,
+  propagateErrors = false,
+  isCurrent: () => boolean = () => true,
+): Promise<void> {
   const instance = instances().get(instanceId)
   if (!instance?.client) return
+  const mutationEpoch = pendingPermissionMutationEpochs.get(instanceId) ?? 0
 
   try {
     const syncStartedAt = Date.now()
     const remote: Array<{ request: PermissionRequest; source: PermissionSource }> = []
+    let legacyKnown = true
     const legacyRemote = await requestData<PermissionRequest[]>(
       instance.client.permission.list(),
       "permission.list",
     ).catch((error) => {
       log.warn("Failed to list legacy pending permissions", { instanceId, error })
+      legacyKnown = false
       return []
     })
     for (const permission of legacyRemote) {
-      permissionRegistry.setSource(instanceId, permission.id, "legacy")
       remote.push({ request: permission, source: "legacy" })
     }
 
@@ -492,13 +522,16 @@ async function syncPendingPermissions(instanceId: string): Promise<void> {
       )
       log.info("v2.permission.request.list", { instanceId, location, resolvedLocation: response.location })
       for (const permission of response.data) {
-        permissionRegistry.setSource(instanceId, permission.id, "v2")
         remote.push({ request: permission, source: "v2" })
       }
     }
 
     const remotePendingIds = new Set(remote.map((item) => item.request.id))
-    pruneRepliedPermissions(instanceId, remotePendingIds, syncStartedAt)
+    if (!isCurrent() || (pendingPermissionMutationEpochs.get(instanceId) ?? 0) !== mutationEpoch) {
+      if (propagateErrors) throw pendingRequestSyncSuperseded
+      return
+    }
+    if (legacyKnown) pruneRepliedPermissions(instanceId, remotePendingIds, syncStartedAt)
 
     const pendingRemote = remote.filter((item) => !hasRepliedPermission(instanceId, item.request.id))
     const remoteIds = new Set(pendingRemote.map((item) => item.request.id))
@@ -506,6 +539,7 @@ async function syncPendingPermissions(instanceId: string): Promise<void> {
 
     // Remove any stale local permissions missing from server.
     for (const entry of local) {
+      if (!legacyKnown && permissionRegistry.getSource(instanceId, entry.id) === "legacy") continue
       if (!remoteIds.has(entry.id)) {
         removePermissionFromQueue(instanceId, entry.id)
         removePermissionV2(instanceId, entry.id)
@@ -520,24 +554,31 @@ async function syncPendingPermissions(instanceId: string): Promise<void> {
     reconcilePendingSessionIndicators(instanceId)
   } catch (error) {
     log.warn("Failed to sync pending permissions", { instanceId, error })
+    if (propagateErrors) throw error
   }
 }
 
-async function syncPendingQuestions(instanceId: string): Promise<void> {
+async function syncPendingQuestions(
+  instanceId: string,
+  propagateErrors = false,
+  isCurrent: () => boolean = () => true,
+): Promise<void> {
   const instance = instances().get(instanceId)
   if (!instance?.client) return
+  const mutationEpoch = pendingQuestionMutationEpochs.get(instanceId) ?? 0
 
   try {
     const remote: Array<{ request: QuestionRequest; source: QuestionSource }> = []
+    let legacyKnown = true
     const legacyRemote = await requestData<QuestionRequest[]>(
       instance.client.question.list(),
       "question.list",
     ).catch((error) => {
       log.warn("Failed to list legacy pending questions", { instanceId, error })
+      legacyKnown = false
       return []
     })
     for (const request of legacyRemote) {
-      questionRegistry.setSource(instanceId, request.id, "legacy")
       remote.push({ request, source: "legacy" })
     }
 
@@ -548,16 +589,20 @@ async function syncPendingQuestions(instanceId: string): Promise<void> {
       )
       log.info("v2.question.request.list", { instanceId, location, resolvedLocation: response.location })
       for (const request of response.data) {
-        questionRegistry.setSource(instanceId, request.id, "v2")
         remote.push({ request, source: "v2" })
       }
     }
 
     const remoteIds = new Set(remote.map((item) => item.request.id))
+    if (!isCurrent() || (pendingQuestionMutationEpochs.get(instanceId) ?? 0) !== mutationEpoch) {
+      if (propagateErrors) throw pendingRequestSyncSuperseded
+      return
+    }
     const local = getQuestionQueue(instanceId)
 
     // Remove any stale local requests missing from server.
     for (const entry of local) {
+      if (!legacyKnown && questionRegistry.getSource(instanceId, entry.id) === "legacy") continue
       if (!remoteIds.has(entry.id)) {
         removeQuestionFromQueue(instanceId, entry.id)
         removeQuestionV2(instanceId, entry.id)
@@ -573,7 +618,64 @@ async function syncPendingQuestions(instanceId: string): Promise<void> {
     reconcilePendingSessionIndicators(instanceId)
   } catch (error) {
     log.warn("Failed to sync pending questions", { instanceId, error })
+    if (propagateErrors) throw error
   }
+}
+
+async function runPendingRequestSync(
+  instanceId: string,
+  generation: number,
+  token: { cancelled: boolean },
+): Promise<void> {
+  for (let attempt = 0; attempt < 3 && !token.cancelled; attempt += 1) {
+    const epoch = (pendingRequestSyncEpochs.get(instanceId) ?? 0) + 1
+    pendingRequestSyncEpochs.set(instanceId, epoch)
+    const isCurrent = () => !token.cancelled
+      && pendingRequestSyncEpochs.get(instanceId) === epoch
+      && pendingRequestSyncGenerations.get(instanceId) === generation
+    try {
+      await Promise.all([
+        syncPendingPermissions(instanceId, true, isCurrent),
+        syncPendingQuestions(instanceId, true, isCurrent),
+      ])
+      return
+    } catch (error) {
+      if (error !== pendingRequestSyncSuperseded) throw error
+    }
+  }
+  if (!token.cancelled && pendingRequestSyncGenerations.get(instanceId) === generation) {
+    throw new Error("Pending request sync did not stabilize")
+  }
+}
+
+function syncPendingRequests(
+  instanceId: string,
+  registerInvalidation?: (invalidate: () => void) => void,
+): Promise<void> {
+  const generation = pendingRequestSyncGenerations.get(instanceId)
+  if (generation === undefined) return Promise.resolve()
+  const existing = pendingRequestSyncs.get(instanceId)
+  if (existing?.generation === generation) {
+    registerInvalidation?.(() => {
+      if (pendingRequestSyncs.get(instanceId)?.token !== existing.token) return
+      existing.token.cancelled = true
+      invalidatePendingRequestSync(instanceId)
+      pendingRequestSyncs.delete(instanceId)
+    })
+    return existing.promise
+  }
+  const token = { cancelled: false }
+  const promise = runPendingRequestSync(instanceId, generation, token).finally(() => {
+    if (pendingRequestSyncs.get(instanceId)?.promise === promise) pendingRequestSyncs.delete(instanceId)
+  })
+  pendingRequestSyncs.set(instanceId, { generation, token, promise })
+  registerInvalidation?.(() => {
+    if (pendingRequestSyncs.get(instanceId)?.token !== token) return
+    token.cancelled = true
+    invalidatePendingRequestSync(instanceId)
+    pendingRequestSyncs.delete(instanceId)
+  })
+  return promise
 }
 
 function startInstanceSessionHydration(instanceId: string, force = false): {
@@ -619,8 +721,7 @@ async function hydrateInstanceData(instanceId: string, options?: {
     const instance = instances().get(instanceId)
     if (!instance?.client) return
     await fetchCommands(instanceId, instance.client)
-    await syncPendingPermissions(instanceId)
-    await syncPendingQuestions(instanceId)
+    await syncPendingRequests(instanceId)
   } catch (error) {
     log.error("Failed to fetch initial data", error)
     if (options?.propagateErrors) throw error
@@ -904,6 +1005,7 @@ function addInstance(instance: Instance) {
   const occurrence = Array.from(instances().values())
     .filter((existing) => normalizeInstanceFolderPath(existing.folder) === normalizeInstanceFolderPath(instance.folder))
     .length
+  pendingRequestSyncGenerations.set(instance.id, ++nextPendingRequestSyncGeneration)
   setInstances((prev) => {
     const next = new Map(prev)
     next.set(instance.id, instance)
@@ -983,6 +1085,8 @@ function removeInstance(id: string, options: { authoritative?: boolean } = {}) {
   initialHydrations.delete(id)
   initialSessionHydrations.delete(id)
   initialWorkspaceMetadataHydrations.delete(id)
+  invalidatePendingRequestSync(id)
+  pendingRequestSyncGenerations.delete(id)
   settleInstanceReadyWaiters(id, new Error(`Workspace ${id} was removed before it became ready`))
 
   if (activeInstanceId() === id) {
@@ -1392,6 +1496,7 @@ function recomputeActiveInterruption(instanceId: string): void {
 }
 
 function addPermissionToQueue(instanceId: string, permission: PermissionRequest, source?: PermissionSource): PermissionRequest | undefined {
+  bumpEpoch(pendingPermissionMutationEpochs, instanceId)
   let inserted = false
   let updated = false
   let previousPermission: PermissionRequest | undefined
@@ -1445,6 +1550,7 @@ function addPermissionToQueue(instanceId: string, permission: PermissionRequest,
 }
 
 function removePermissionFromQueue(instanceId: string, permissionId: string): void {
+  bumpEpoch(pendingPermissionMutationEpochs, instanceId)
   let removedPermission: PermissionRequest | null = null
 
   setPermissionQueues((prev) => {
@@ -1537,6 +1643,7 @@ function clearSyncedYoloSessionsForInstance(instanceId: string): void {
 }
 
 function clearPermissionQueue(instanceId: string): void {
+  bumpEpoch(pendingPermissionMutationEpochs, instanceId)
   permissionRegistry.clear(instanceId, getPermissionQueue(instanceId), (sessionId) => {
     setSessionPendingPermission(instanceId, sessionId, false)
   })
@@ -1554,6 +1661,7 @@ function clearPermissionQueue(instanceId: string): void {
 }
 
 function addQuestionToQueue(instanceId: string, request: QuestionRequest, source: QuestionSource = "v2"): void {
+  bumpEpoch(pendingQuestionMutationEpochs, instanceId)
   let inserted = false
   questionRegistry.setSource(instanceId, request.id, source)
 
@@ -1589,6 +1697,7 @@ function addQuestionToQueue(instanceId: string, request: QuestionRequest, source
 }
 
 function removeQuestionFromQueue(instanceId: string, requestId: string): void {
+  bumpEpoch(pendingQuestionMutationEpochs, instanceId)
   const removedSessionId = getQuestionSessionId(getQuestionQueue(instanceId).find((q) => q.id === requestId))
 
   setQuestionQueues((prev) => {
@@ -1614,6 +1723,7 @@ function removeQuestionFromQueue(instanceId: string, requestId: string): void {
 }
 
 function clearQuestionQueue(instanceId: string): void {
+  bumpEpoch(pendingQuestionMutationEpochs, instanceId)
   questionRegistry.clear(instanceId, getQuestionQueue(instanceId), (sessionId) => {
     setSessionPendingQuestion(instanceId, sessionId, false)
   })
@@ -1890,5 +2000,7 @@ export {
   fetchLspStatus,
   disposeInstance,
   reconcilePendingSessionIndicators,
+  syncPendingRequests,
+  invalidatePendingRequestSync,
   clearReloadableInstanceState,
 }

--- a/packages/ui/src/stores/message-v2/bridge.ts
+++ b/packages/ui/src/stores/message-v2/bridge.ts
@@ -63,7 +63,13 @@ export function seedSessionMessagesV2(
     createdAt: message.timestamp,
     updatedAt: message.timestamp,
     parts: message.parts,
-    isEphemeral: message.status === "sending" || message.status === "streaming",
+    // Ephemeral marks records that stand in for something not yet confirmed
+    // by the server. A user message present in a REST snapshot IS confirmed,
+    // even when its end time is not recorded yet (status "streaming" via the
+    // shared derivation) — the live SSE path keeps such user records
+    // non-ephemeral, so the REST path must match. Assistant streaming records
+    // keep the pre-existing ephemeral treatment.
+    isEphemeral: message.status === "sending" || (message.type === "assistant" && message.status === "streaming"),
     bumpRevision: false,
   }))
 

--- a/packages/ui/src/stores/message-v2/instance-store.test.ts
+++ b/packages/ui/src/stores/message-v2/instance-store.test.ts
@@ -135,13 +135,14 @@ describe("message-v2 hydrateMessages vs pending optimistic sends", () => {
       status: "sending",
       parts: [{ type: "text", text: "hello world" } as any],
       isEphemeral: true,
+      createdAt: 1000,
     })
     assert.deepEqual(store.getSessionMessageIds("session-1"), ["msg-temp-1"])
 
     // Snapshot contains the SAME send under the real server id (different id,
     // same text) while the temp is still present and un-replaced.
     store.hydrateMessages("session-1", [
-      { id: "msg-real-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "hello world" } as any] },
+      { id: "msg-real-1", sessionId: "session-1", role: "user", status: "complete", createdAt: 2000, parts: [{ type: "text", text: "hello world" } as any] },
     ])
 
     const ids = store.getSessionMessageIds("session-1")
@@ -214,10 +215,11 @@ describe("message-v2 hydrateMessages vs pending optimistic sends", () => {
       id: "msg-temp-img", sessionId: "session-1", role: "user", status: "sending",
       parts: [{ type: "file", filename: "photo.png", url: "https://x/photo.png", mime: "image/png" } as any],
       isEphemeral: true,
+      createdAt: 1000,
     })
 
     store.hydrateMessages("session-1", [
-      { id: "msg-real-img", sessionId: "session-1", role: "user", status: "complete",
+      { id: "msg-real-img", sessionId: "session-1", role: "user", status: "complete", createdAt: 2000,
         parts: [{ type: "file", filename: "photo.png", url: "https://x/photo.png", mime: "image/png" } as any] },
     ])
 
@@ -236,16 +238,16 @@ describe("message-v2 hydrateMessages vs pending optimistic sends", () => {
 
     store.upsertMessage({
       id: "msg-temp-1", sessionId: "session-1", role: "user", status: "sending",
-      parts: [{ type: "text", text: "ok" } as any], isEphemeral: true,
+      parts: [{ type: "text", text: "ok" } as any], isEphemeral: true, createdAt: 1000,
     })
     store.upsertMessage({
       id: "msg-temp-2", sessionId: "session-1", role: "user", status: "sending",
-      parts: [{ type: "text", text: "ok" } as any], isEphemeral: true,
+      parts: [{ type: "text", text: "ok" } as any], isEphemeral: true, createdAt: 1100,
     })
 
     // Snapshot confirms only ONE of the two sends.
     store.hydrateMessages("session-1", [
-      { id: "msg-real-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "ok" } as any] },
+      { id: "msg-real-1", sessionId: "session-1", role: "user", status: "complete", createdAt: 2000, parts: [{ type: "text", text: "ok" } as any] },
     ])
 
     const ids = store.getSessionMessageIds("session-1")
@@ -255,8 +257,8 @@ describe("message-v2 hydrateMessages vs pending optimistic sends", () => {
 
     // When the second confirmation arrives, the remaining temp is dropped.
     store.hydrateMessages("session-1", [
-      { id: "msg-real-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "ok" } as any] },
-      { id: "msg-real-2", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "ok" } as any] },
+      { id: "msg-real-1", sessionId: "session-1", role: "user", status: "complete", createdAt: 2000, parts: [{ type: "text", text: "ok" } as any] },
+      { id: "msg-real-2", sessionId: "session-1", role: "user", status: "complete", createdAt: 2100, parts: [{ type: "text", text: "ok" } as any] },
     ])
     assert.deepEqual(store.getSessionMessageIds("session-1"), ["msg-real-1", "msg-real-2"])
   })
@@ -307,17 +309,64 @@ describe("message-v2 hydrateMessages vs pending optimistic sends", () => {
       id: "msg-temp-pasted", sessionId: "session-1", role: "user", status: "sending",
       parts: [{ type: "text", text: "big pasted text" } as any],
       isEphemeral: true,
+      createdAt: 1000,
       clientPromptDisplayMetadata: displayMetadata as any,
     })
 
     store.hydrateMessages("session-1", [
-      { id: "msg-real-pasted", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "big pasted text" } as any] },
+      { id: "msg-real-pasted", sessionId: "session-1", role: "user", status: "complete", createdAt: 2000, parts: [{ type: "text", text: "big pasted text" } as any] },
     ])
 
     const real = store.getMessage("msg-real-pasted")
     assert.ok(real, "real record exists")
     assert.deepEqual(real?.clientPromptDisplayMetadata, displayMetadata, "metadata transferred from the superseded temp")
     assert.equal(store.getMessage("msg-temp-pasted"), undefined, "temp dropped")
+  })
+
+  it("does not supersede a pending send with an OLDER unrelated server message of identical content", () => {
+    // Gatekeeper reproduction: a local pending "deploy" created at t=5000 was
+    // deleted by an unrelated server "deploy" created at t=1000. A server
+    // message can only confirm a send that happened BEFORE it was created.
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+
+    store.upsertMessage({
+      id: "msg-temp-deploy", sessionId: "session-1", role: "user", status: "sending",
+      parts: [{ type: "text", text: "deploy" } as any], isEphemeral: true, createdAt: 5000,
+    })
+
+    store.hydrateMessages("session-1", [
+      { id: "msg-real-old", sessionId: "session-1", role: "user", status: "complete", createdAt: 1000, parts: [{ type: "text", text: "deploy" } as any] },
+    ])
+
+    const ids = store.getSessionMessageIds("session-1")
+    assert.deepEqual(ids, ["msg-real-old", "msg-temp-deploy"], "older identical server message must not consume the newer pending send")
+    assert.equal(store.getMessage("msg-temp-deploy")?.status, "sending")
+  })
+
+  it("dedupes repeated snapshot ids so one record cannot consume multiple pending sends", () => {
+    // Gatekeeper reproduction: with two pending "ok" sends and ONE server
+    // record duplicated in the snapshot, both temps were deleted and the
+    // session ids became [real, real]. Duplicated input ids are collapsed
+    // before candidate construction.
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+
+    store.upsertMessage({
+      id: "msg-temp-1", sessionId: "session-1", role: "user", status: "sending",
+      parts: [{ type: "text", text: "ok" } as any], isEphemeral: true, createdAt: 1000,
+    })
+    store.upsertMessage({
+      id: "msg-temp-2", sessionId: "session-1", role: "user", status: "sending",
+      parts: [{ type: "text", text: "ok" } as any], isEphemeral: true, createdAt: 1100,
+    })
+
+    const duplicated = { id: "msg-real-1", sessionId: "session-1", role: "user" as const, status: "complete" as const, createdAt: 2000, parts: [{ type: "text", text: "ok" } as any] }
+    store.hydrateMessages("session-1", [duplicated, duplicated])
+
+    const ids = store.getSessionMessageIds("session-1")
+    assert.deepEqual(ids, ["msg-real-1", "msg-temp-2"], "one real record consumes exactly one pending send; ids never repeat")
+    assert.equal(store.getMessage("msg-temp-2")?.status, "sending")
   })
 
   it("does not bump messageInfoVersion when the hydrated info is unchanged", () => {

--- a/packages/ui/src/stores/message-v2/instance-store.test.ts
+++ b/packages/ui/src/stores/message-v2/instance-store.test.ts
@@ -42,3 +42,79 @@ describe("message-v2 permission state", () => {
   })
 
 })
+
+describe("message-v2 hydrateMessages vs pending optimistic sends", () => {
+  it("keeps a locally-pending 'sending' message visible when a force reload snapshot doesn't include it yet", () => {
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+
+    // Simulate the optimistic bubble created when the user hits send,
+    // before the server has echoed the message back in any REST snapshot.
+    store.upsertMessage({
+      id: "msg-temp-1",
+      sessionId: "session-1",
+      role: "user",
+      status: "sending",
+      parts: [{ type: "text", text: "hello" } as any],
+      isEphemeral: true,
+    })
+    assert.deepEqual(store.getSessionMessageIds("session-1"), ["msg-temp-1"])
+
+    // A force reload (e.g. triggered by an SSE reconnect after backgrounding)
+    // resolves with a server snapshot that doesn't include the pending send
+    // yet -- it hasn't been echoed back by the server at snapshot time.
+    store.hydrateMessages("session-1", [
+      { id: "msg-older", sessionId: "session-1", role: "assistant", status: "complete", parts: [{ type: "text", text: "hi" } as any] },
+    ])
+
+    // The optimistic bubble must still be visible -- not silently dropped --
+    // and must still be findable (status "sending", isEphemeral) so a later
+    // SSE echo can cleanly replace it instead of creating a duplicate record.
+    const idsAfterHydrate = store.getSessionMessageIds("session-1")
+    assert.ok(idsAfterHydrate.includes("msg-temp-1"), "pending optimistic message should remain visible")
+    assert.ok(idsAfterHydrate.includes("msg-older"))
+    const pending = store.getMessage("msg-temp-1")
+    assert.equal(pending?.status, "sending")
+    assert.equal(pending?.isEphemeral, true)
+
+    // Once the server confirms the send with its real id, replaceMessageId
+    // swaps it in place -- no duplicate id should ever appear.
+    store.replaceMessageId({ oldId: "msg-temp-1", newId: "msg-real-1" })
+    const idsAfterReplace = store.getSessionMessageIds("session-1")
+    assert.equal(idsAfterReplace.filter((id) => id === "msg-real-1" || id === "msg-temp-1").length, 1)
+    assert.ok(!idsAfterReplace.includes("msg-temp-1"))
+
+    // A subsequent force reload that now DOES include the confirmed message
+    // must not produce a duplicate entry either.
+    store.hydrateMessages("session-1", [
+      { id: "msg-older", sessionId: "session-1", role: "assistant", status: "complete", parts: [{ type: "text", text: "hi" } as any] },
+      { id: "msg-real-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "hello" } as any] },
+    ])
+    const finalIds = store.getSessionMessageIds("session-1")
+    assert.equal(finalIds.filter((id) => id === "msg-real-1").length, 1)
+    assert.equal(new Set(finalIds).size, finalIds.length, "no duplicate ids should ever appear")
+  })
+
+  it("drops a pending 'sending' message once the server snapshot confirms it under the same id", () => {
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+
+    store.upsertMessage({
+      id: "msg-1",
+      sessionId: "session-1",
+      role: "user",
+      status: "sending",
+      parts: [{ type: "text", text: "hello" } as any],
+      isEphemeral: true,
+    })
+
+    // Server snapshot echoes the SAME id back, now complete -- the normal case.
+    store.hydrateMessages("session-1", [
+      { id: "msg-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "hello" } as any] },
+    ])
+
+    const ids = store.getSessionMessageIds("session-1")
+    assert.deepEqual(ids, ["msg-1"])
+    assert.equal(store.getMessage("msg-1")?.status, "complete")
+  })
+})

--- a/packages/ui/src/stores/message-v2/instance-store.test.ts
+++ b/packages/ui/src/stores/message-v2/instance-store.test.ts
@@ -117,4 +117,143 @@ describe("message-v2 hydrateMessages vs pending optimistic sends", () => {
     assert.deepEqual(ids, ["msg-1"])
     assert.equal(store.getMessage("msg-1")?.status, "complete")
   })
+
+  it("drops the optimistic bubble when the snapshot confirms the send under a DIFFERENT server id (no duplicate)", () => {
+    // Reviewer's blocking case: the optimistic id is client-only and is never
+    // sent to the server, so the normal confirmation arrives under a different
+    // real id. If the force-reload snapshot already contains that real id,
+    // preserving the temp id would leave BOTH visible ("real, temp") because
+    // the SSE message.updated handler finds the real record and skips the
+    // temp-id replacement. The temp must be matched by content and dropped.
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+
+    store.upsertMessage({
+      id: "msg-temp-1",
+      sessionId: "session-1",
+      role: "user",
+      status: "sending",
+      parts: [{ type: "text", text: "hello world" } as any],
+      isEphemeral: true,
+    })
+    assert.deepEqual(store.getSessionMessageIds("session-1"), ["msg-temp-1"])
+
+    // Snapshot contains the SAME send under the real server id (different id,
+    // same text) while the temp is still present and un-replaced.
+    store.hydrateMessages("session-1", [
+      { id: "msg-real-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "hello world" } as any] },
+    ])
+
+    const ids = store.getSessionMessageIds("session-1")
+    assert.deepEqual(ids, ["msg-real-1"], "only the real server id should remain")
+    assert.ok(!ids.includes("msg-temp-1"), "the optimistic temp id must be dropped, not duplicated")
+    assert.equal(store.getMessage("msg-temp-1"), undefined, "orphaned optimistic record must be cleaned up")
+    assert.equal(new Set(ids).size, ids.length, "no duplicate ids")
+  })
+
+  it("does not preserve a different-text pending send as a false match", () => {
+    // Guard the content match: an unrelated optimistic send (different text)
+    // must still be preserved even if the snapshot brings other user messages.
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+
+    store.upsertMessage({
+      id: "msg-temp-1",
+      sessionId: "session-1",
+      role: "user",
+      status: "sending",
+      parts: [{ type: "text", text: "my in-flight message" } as any],
+      isEphemeral: true,
+    })
+
+    store.hydrateMessages("session-1", [
+      { id: "msg-real-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "a completely different earlier message" } as any] },
+    ])
+
+    const ids = store.getSessionMessageIds("session-1")
+    assert.ok(ids.includes("msg-temp-1"), "unrelated in-flight send must stay visible")
+    assert.ok(ids.includes("msg-real-1"))
+    assert.equal(store.getMessage("msg-temp-1")?.status, "sending")
+  })
+
+  it("does not falsely drop a second identical-text send against an already-loaded earlier one", () => {
+    // Duplicate-text guard: only a NEW server id counts as the confirmation.
+    // An earlier "ok" already in messageIds must not supersede a second,
+    // still-in-flight "ok".
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+
+    // Earlier confirmed "ok" already loaded under its real id.
+    store.hydrateMessages("session-1", [
+      { id: "msg-ok-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "ok" } as any] },
+    ])
+    // Second "ok" now in flight (optimistic).
+    store.upsertMessage({
+      id: "msg-temp-ok", sessionId: "session-1", role: "user", status: "sending",
+      parts: [{ type: "text", text: "ok" } as any], isEphemeral: true,
+    })
+
+    // A reconnect snapshot that still only has the FIRST "ok" (second not yet
+    // registered by the server). The temp must be preserved, not dropped.
+    store.hydrateMessages("session-1", [
+      { id: "msg-ok-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "ok" } as any] },
+    ])
+
+    const ids = store.getSessionMessageIds("session-1")
+    assert.ok(ids.includes("msg-temp-ok"), "second in-flight identical-text send must survive")
+    assert.equal(store.getMessage("msg-temp-ok")?.status, "sending")
+  })
+
+  it("matches an attachment-only optimistic send by file signature (no text)", () => {
+    // The content signature covers file parts, so an image/attachment send
+    // with no caption is still de-duplicated on confirmation.
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+
+    store.upsertMessage({
+      id: "msg-temp-img", sessionId: "session-1", role: "user", status: "sending",
+      parts: [{ type: "file", filename: "photo.png", url: "https://x/photo.png", mime: "image/png" } as any],
+      isEphemeral: true,
+    })
+
+    store.hydrateMessages("session-1", [
+      { id: "msg-real-img", sessionId: "session-1", role: "user", status: "complete",
+        parts: [{ type: "file", filename: "photo.png", url: "https://x/photo.png", mime: "image/png" } as any] },
+    ])
+
+    const ids = store.getSessionMessageIds("session-1")
+    assert.deepEqual(ids, ["msg-real-img"], "attachment-only send must de-dupe on confirmation")
+    assert.equal(store.getMessage("msg-temp-img"), undefined)
+  })
+
+  it("does not bump messageInfoVersion when the hydrated info is unchanged", () => {
+    // Issue 4: an identical snapshot (common on a reconnect force-reload) must
+    // not invalidate message-block render caches via messageInfoVersion.
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+
+    const info = { id: "msg-1", sessionID: "session-1", role: "user", time: { created: 1000 } } as any
+    store.hydrateMessages(
+      "session-1",
+      [{ id: "msg-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "hi" } as any] }],
+      [info],
+    )
+    const versionAfterFirst = store.state.messageInfoVersion["msg-1"]
+
+    // Re-hydrate with an identical info object.
+    store.hydrateMessages(
+      "session-1",
+      [{ id: "msg-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "hi" } as any] }],
+      [{ id: "msg-1", sessionID: "session-1", role: "user", time: { created: 1000 } } as any],
+    )
+    assert.equal(store.state.messageInfoVersion["msg-1"], versionAfterFirst, "identical info must not bump the version")
+
+    // A changed info DOES bump the version.
+    store.hydrateMessages(
+      "session-1",
+      [{ id: "msg-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "hi" } as any] }],
+      [{ id: "msg-1", sessionID: "session-1", role: "user", time: { created: 1000, end: 2000 } } as any],
+    )
+    assert.equal(store.state.messageInfoVersion["msg-1"], (versionAfterFirst ?? 0) + 1, "changed info must bump the version")
+  })
 })

--- a/packages/ui/src/stores/message-v2/instance-store.test.ts
+++ b/packages/ui/src/stores/message-v2/instance-store.test.ts
@@ -107,6 +107,27 @@ describe("message-v2 hydrateMessages vs pending optimistic sends", () => {
     assert.deepEqual(record?.clientPromptDisplayMetadata, displayMetadata, "metadata survives the same-id confirmation")
   })
 
+  it("retains client part identity through a metadata-only same-id snapshot", () => {
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+    store.upsertMessage({
+      id: "msg-1", sessionId: "session-1", role: "user", status: "sending",
+      parts: [{ id: "client-part", type: "text", text: "hello", synthetic: true } as any], isEphemeral: true,
+    })
+    store.markSendPending("msg-1")
+    store.hydrateMessages("session-1", [
+      { id: "msg-1", sessionId: "session-1", role: "user", status: "complete", isEphemeral: false },
+    ])
+
+    store.confirmServerMessage("msg-1", { clearOptimisticParts: true })
+    store.applyPartUpdate({
+      messageId: "msg-1",
+      part: { id: "server-part", type: "text", text: "hello" } as any,
+    })
+
+    assert.deepEqual(store.getMessage("msg-1")?.partIds, ["server-part"])
+  })
+
   it("dedupes repeated snapshot ids so messageIds never repeat", () => {
     // Gatekeeper reproduction: a duplicated server record made the id appear
     // twice in session.messageIds ([real, real]).
@@ -120,7 +141,7 @@ describe("message-v2 hydrateMessages vs pending optimistic sends", () => {
   })
 
   it("drops a definitively failed send on the next authoritative snapshot", () => {
-    // promptAsync rejection retires the in-flight marker (clearSendPending).
+    // promptAsync rejection retires the in-flight marker and marks the bubble.
     // The failed bubble stays visible until the next authoritative snapshot,
     // which must then drop it instead of preserving it forever as "sending".
     const store = createInstanceMessageStore("instance-1")
@@ -133,7 +154,8 @@ describe("message-v2 hydrateMessages vs pending optimistic sends", () => {
     store.markSendPending("msg-failed")
 
     // The request fails terminally.
-    store.clearSendPending("msg-failed")
+    store.failSend("msg-failed")
+    assert.equal(store.getMessage("msg-failed")?.status, "error")
 
     // Immediately after the failure the bubble is still visible (unchanged
     // pre-existing UX); the next authoritative snapshot drops it.
@@ -144,13 +166,88 @@ describe("message-v2 hydrateMessages vs pending optimistic sends", () => {
     assert.equal(store.getMessage("msg-failed"), undefined, "failed send must not survive authoritative hydration")
   })
 
+  it("settles an accepted send without waiting for an SSE echo", () => {
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+    store.upsertMessage({
+      id: "msg-accepted", sessionId: "session-1", role: "user", status: "sending",
+      parts: [{ type: "text", text: "hello", synthetic: true } as any], isEphemeral: true,
+    })
+    store.markSendPending("msg-accepted")
+
+    store.acceptSend("msg-accepted")
+
+    assert.equal(store.getMessage("msg-accepted")?.status, "sent")
+    assert.equal(store.getMessage("msg-accepted")?.isEphemeral, false)
+    store.reconcileEmptyAuthoritativeSnapshot("session-1")
+    assert.deepEqual(store.getSessionMessageIds("session-1"), ["msg-accepted"])
+    store.reconcileEmptyAuthoritativeSnapshot("session-1")
+    assert.deepEqual(store.getSessionMessageIds("session-1"), ["msg-accepted"])
+
+    store.confirmServerMessage("msg-accepted", { clearOptimisticParts: true })
+    store.applyPartUpdate({
+      messageId: "msg-accepted",
+      part: { id: "server-part", type: "text", text: "hello", synthetic: false } as any,
+    })
+    assert.deepEqual(store.getMessage("msg-accepted")?.partIds, ["server-part"])
+    assert.equal(store.getMessage("msg-accepted")?.isEphemeral, false)
+  })
+
+  it("clears only client-created parts when the server confirms a send", () => {
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+    store.upsertMessage({
+      id: "msg-1", sessionId: "session-1", role: "user", status: "sending",
+      parts: [{ id: "client-part", type: "text", text: "hello", synthetic: true } as any], isEphemeral: true,
+    })
+    store.markSendPending("msg-1")
+    store.applyPartUpdate({
+      messageId: "msg-1",
+      part: { id: "server-synthetic", type: "text", text: "server", synthetic: true } as any,
+    })
+
+    store.confirmServerMessage("msg-1", { clearOptimisticParts: true })
+
+    assert.deepEqual(store.getMessage("msg-1")?.partIds, ["server-synthetic"])
+  })
+
+  it("drops an unconfirmed accepted send once idle message authority settles", () => {
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+    store.upsertMessage({
+      id: "msg-unconfirmed", sessionId: "session-1", role: "user", status: "sending",
+      parts: [{ type: "text", text: "hello", synthetic: true } as any], isEphemeral: true,
+    })
+    store.markSendPending("msg-unconfirmed")
+    store.acceptSend("msg-unconfirmed")
+
+    store.retirePendingSends("session-1")
+    store.reconcileEmptyAuthoritativeSnapshot("session-1")
+
+    assert.equal(store.getMessage("msg-unconfirmed"), undefined)
+  })
+
   it("preserves only still-pending sends across an authoritative empty snapshot", () => {
     const store = createInstanceMessageStore("instance-1")
     store.addOrUpdateSession({ id: "session-1" })
 
     store.hydrateMessages("session-1", [
-      { id: "msg-stale", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "old" } as any] },
-    ])
+      { id: "msg-stale", sessionId: "session-1", role: "assistant", status: "complete", parts: [{ id: "todo-1", type: "tool", tool: "todowrite", state: { status: "completed", input: { todos: [] } } } as any] },
+    ], [{
+      id: "msg-stale", sessionID: "session-1", role: "assistant", time: { created: 1 },
+      tokens: { input: 2, output: 3, reasoning: 0, cache: { read: 0, write: 0 } }, cost: 1,
+    } as any])
+    store.bufferPendingPart({ messageId: "msg-stale", part: { type: "text", text: "late" } as any, receivedAt: Date.now() })
+    store.upsertPermission({
+      permission: { id: "permission-stale", sessionID: "session-1", action: "edit", resources: [] },
+      messageId: "msg-stale",
+      enqueuedAt: 1,
+    })
+    store.upsertQuestion({
+      request: { id: "question-stale", sessionID: "session-1", questions: [] },
+      messageId: "msg-stale",
+      enqueuedAt: 1,
+    })
     store.upsertMessage({
       id: "msg-inflight", sessionId: "session-1", role: "user", status: "sending",
       parts: [{ type: "text", text: "new" } as any], isEphemeral: true,
@@ -158,10 +255,56 @@ describe("message-v2 hydrateMessages vs pending optimistic sends", () => {
     store.markSendPending("msg-inflight")
 
     // Server authoritatively reports zero messages on a forced reconnect load.
+    store.retirePendingSends("session-1")
     store.reconcileEmptyAuthoritativeSnapshot("session-1")
 
     assert.deepEqual(store.getSessionMessageIds("session-1"), ["msg-inflight"], "stale records cleared, in-flight send preserved")
     assert.equal(store.getMessage("msg-stale"), undefined)
+    assert.equal(store.state.pendingParts["msg-stale"], undefined)
+    assert.equal(store.state.permissions.byMessage["msg-stale"], undefined)
+    assert.equal(store.state.permissions.queue.length, 0)
+    assert.equal(store.state.questions.byMessage["msg-stale"], undefined)
+    assert.equal(store.state.questions.queue.length, 0)
+    assert.equal(store.state.usage["session-1"].totalInputTokens, 0)
+    assert.equal(store.getLatestTodoSnapshot("session-1"), undefined)
+  })
+
+  it("removes omitted records and derived state from a non-empty authoritative snapshot", () => {
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+    store.hydrateMessages("session-1", [{
+      id: "msg-old", sessionId: "session-1", role: "assistant", status: "complete",
+      parts: [{ id: "todo-old", type: "tool", tool: "todowrite", state: { status: "completed", input: { todos: [] } } } as any],
+    }], [{
+      id: "msg-old", sessionID: "session-1", role: "assistant", time: { created: 1 },
+      tokens: { input: 2, output: 3, reasoning: 0, cache: { read: 0, write: 0 } }, cost: 1,
+    } as any])
+    store.bufferPendingPart({ messageId: "msg-old", part: { type: "text", text: "late" } as any, receivedAt: Date.now() })
+    store.upsertPermission({
+      permission: { id: "permission-old", sessionID: "session-1", action: "edit", resources: [] },
+      messageId: "msg-old",
+      enqueuedAt: 1,
+    })
+    store.upsertQuestion({
+      request: { id: "question-old", sessionID: "session-1", questions: [] },
+      messageId: "msg-old",
+      enqueuedAt: 1,
+    })
+
+    store.hydrateMessages("session-1", [{
+      id: "msg-new", sessionId: "session-1", role: "user", status: "complete",
+      parts: [{ type: "text", text: "new" } as any],
+    }], [{ id: "msg-new", sessionID: "session-1", role: "user", time: { created: 2 } } as any])
+
+    assert.deepEqual(store.getSessionMessageIds("session-1"), ["msg-new"])
+    assert.equal(store.getMessage("msg-old"), undefined)
+    assert.equal(store.state.pendingParts["msg-old"], undefined)
+    assert.equal(store.state.permissions.byMessage["msg-old"], undefined)
+    assert.equal(store.state.permissions.queue.length, 0)
+    assert.equal(store.state.questions.byMessage["msg-old"], undefined)
+    assert.equal(store.state.questions.queue.length, 0)
+    assert.equal(store.state.usage["session-1"].totalInputTokens, 0)
+    assert.equal(store.getLatestTodoSnapshot("session-1"), undefined)
   })
 
   it("does not bump messageInfoVersion when the hydrated info is unchanged", () => {

--- a/packages/ui/src/stores/message-v2/instance-store.test.ts
+++ b/packages/ui/src/stores/message-v2/instance-store.test.ts
@@ -44,12 +44,13 @@ describe("message-v2 permission state", () => {
 })
 
 describe("message-v2 hydrateMessages vs pending optimistic sends", () => {
-  it("keeps a locally-pending 'sending' message visible when a force reload snapshot doesn't include it yet", () => {
+  it("keeps an in-flight pending 'sending' message visible when a force reload snapshot doesn't include it yet", () => {
     const store = createInstanceMessageStore("instance-1")
     store.addOrUpdateSession({ id: "session-1" })
 
-    // Simulate the optimistic bubble created when the user hits send,
-    // before the server has echoed the message back in any REST snapshot.
+    // Simulate the optimistic bubble created when the user hits send, before
+    // the server has echoed the message back in any REST snapshot. The send
+    // path registers it as in-flight right after the optimistic insert.
     store.upsertMessage({
       id: "msg-temp-1",
       sessionId: "session-1",
@@ -58,6 +59,7 @@ describe("message-v2 hydrateMessages vs pending optimistic sends", () => {
       parts: [{ type: "text", text: "hello" } as any],
       isEphemeral: true,
     })
+    store.markSendPending("msg-temp-1")
     assert.deepEqual(store.getSessionMessageIds("session-1"), ["msg-temp-1"])
 
     // A force reload (e.g. triggered by an SSE reconnect after backgrounding)
@@ -68,310 +70,103 @@ describe("message-v2 hydrateMessages vs pending optimistic sends", () => {
     ])
 
     // The optimistic bubble must still be visible -- not silently dropped --
-    // and must still be findable (status "sending", isEphemeral) so a later
-    // SSE echo can cleanly replace it instead of creating a duplicate record.
+    // so the eventual same-id confirmation can update it in place.
     const idsAfterHydrate = store.getSessionMessageIds("session-1")
-    assert.ok(idsAfterHydrate.includes("msg-temp-1"), "pending optimistic message should remain visible")
-    assert.ok(idsAfterHydrate.includes("msg-older"))
+    assert.deepEqual(idsAfterHydrate, ["msg-older", "msg-temp-1"])
     const pending = store.getMessage("msg-temp-1")
     assert.equal(pending?.status, "sending")
     assert.equal(pending?.isEphemeral, true)
-
-    // Once the server confirms the send with its real id, replaceMessageId
-    // swaps it in place -- no duplicate id should ever appear.
-    store.replaceMessageId({ oldId: "msg-temp-1", newId: "msg-real-1" })
-    const idsAfterReplace = store.getSessionMessageIds("session-1")
-    assert.equal(idsAfterReplace.filter((id) => id === "msg-real-1" || id === "msg-temp-1").length, 1)
-    assert.ok(!idsAfterReplace.includes("msg-temp-1"))
-
-    // A subsequent force reload that now DOES include the confirmed message
-    // must not produce a duplicate entry either.
-    store.hydrateMessages("session-1", [
-      { id: "msg-older", sessionId: "session-1", role: "assistant", status: "complete", parts: [{ type: "text", text: "hi" } as any] },
-      { id: "msg-real-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "hello" } as any] },
-    ])
-    const finalIds = store.getSessionMessageIds("session-1")
-    assert.equal(finalIds.filter((id) => id === "msg-real-1").length, 1)
-    assert.equal(new Set(finalIds).size, finalIds.length, "no duplicate ids should ever appear")
   })
 
-  it("drops a pending 'sending' message once the server snapshot confirms it under the same id", () => {
-    const store = createInstanceMessageStore("instance-1")
-    store.addOrUpdateSession({ id: "session-1" })
-
-    store.upsertMessage({
-      id: "msg-1",
-      sessionId: "session-1",
-      role: "user",
-      status: "sending",
-      parts: [{ type: "text", text: "hello" } as any],
-      isEphemeral: true,
-    })
-
-    // Server snapshot echoes the SAME id back, now complete -- the normal case.
-    store.hydrateMessages("session-1", [
-      { id: "msg-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "hello" } as any] },
-    ])
-
-    const ids = store.getSessionMessageIds("session-1")
-    assert.deepEqual(ids, ["msg-1"])
-    assert.equal(store.getMessage("msg-1")?.status, "complete")
-  })
-
-  it("drops the optimistic bubble when the snapshot confirms the send under a DIFFERENT server id (no duplicate)", () => {
-    // Reviewer's blocking case: the optimistic id is client-only and is never
-    // sent to the server, so the normal confirmation arrives under a different
-    // real id. If the force-reload snapshot already contains that real id,
-    // preserving the temp id would leave BOTH visible ("real, temp") because
-    // the SSE message.updated handler finds the real record and skips the
-    // temp-id replacement. The temp must be matched by content and dropped.
-    const store = createInstanceMessageStore("instance-1")
-    store.addOrUpdateSession({ id: "session-1" })
-
-    store.upsertMessage({
-      id: "msg-temp-1",
-      sessionId: "session-1",
-      role: "user",
-      status: "sending",
-      parts: [{ type: "text", text: "hello world" } as any],
-      isEphemeral: true,
-      createdAt: 1000,
-    })
-    assert.deepEqual(store.getSessionMessageIds("session-1"), ["msg-temp-1"])
-
-    // Snapshot contains the SAME send under the real server id (different id,
-    // same text) while the temp is still present and un-replaced.
-    store.hydrateMessages("session-1", [
-      { id: "msg-real-1", sessionId: "session-1", role: "user", status: "complete", createdAt: 2000, parts: [{ type: "text", text: "hello world" } as any] },
-    ])
-
-    const ids = store.getSessionMessageIds("session-1")
-    assert.deepEqual(ids, ["msg-real-1"], "only the real server id should remain")
-    assert.ok(!ids.includes("msg-temp-1"), "the optimistic temp id must be dropped, not duplicated")
-    assert.equal(store.getMessage("msg-temp-1"), undefined, "orphaned optimistic record must be cleaned up")
-    assert.equal(new Set(ids).size, ids.length, "no duplicate ids")
-  })
-
-  it("does not preserve a different-text pending send as a false match", () => {
-    // Guard the content match: an unrelated optimistic send (different text)
-    // must still be preserved even if the snapshot brings other user messages.
-    const store = createInstanceMessageStore("instance-1")
-    store.addOrUpdateSession({ id: "session-1" })
-
-    store.upsertMessage({
-      id: "msg-temp-1",
-      sessionId: "session-1",
-      role: "user",
-      status: "sending",
-      parts: [{ type: "text", text: "my in-flight message" } as any],
-      isEphemeral: true,
-    })
-
-    store.hydrateMessages("session-1", [
-      { id: "msg-real-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "a completely different earlier message" } as any] },
-    ])
-
-    const ids = store.getSessionMessageIds("session-1")
-    assert.ok(ids.includes("msg-temp-1"), "unrelated in-flight send must stay visible")
-    assert.ok(ids.includes("msg-real-1"))
-    assert.equal(store.getMessage("msg-temp-1")?.status, "sending")
-  })
-
-  it("does not falsely drop a second identical-text send against an already-loaded earlier one", () => {
-    // Duplicate-text guard: only a NEW server id counts as the confirmation.
-    // An earlier "ok" already in messageIds must not supersede a second,
-    // still-in-flight "ok".
-    const store = createInstanceMessageStore("instance-1")
-    store.addOrUpdateSession({ id: "session-1" })
-
-    // Earlier confirmed "ok" already loaded under its real id.
-    store.hydrateMessages("session-1", [
-      { id: "msg-ok-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "ok" } as any] },
-    ])
-    // Second "ok" now in flight (optimistic).
-    store.upsertMessage({
-      id: "msg-temp-ok", sessionId: "session-1", role: "user", status: "sending",
-      parts: [{ type: "text", text: "ok" } as any], isEphemeral: true,
-    })
-
-    // A reconnect snapshot that still only has the FIRST "ok" (second not yet
-    // registered by the server). The temp must be preserved, not dropped.
-    store.hydrateMessages("session-1", [
-      { id: "msg-ok-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "ok" } as any] },
-    ])
-
-    const ids = store.getSessionMessageIds("session-1")
-    assert.ok(ids.includes("msg-temp-ok"), "second in-flight identical-text send must survive")
-    assert.equal(store.getMessage("msg-temp-ok")?.status, "sending")
-  })
-
-  it("matches an attachment-only optimistic send by file signature (no text)", () => {
-    // The content signature covers file parts, so an image/attachment send
-    // with no caption is still de-duplicated on confirmation.
-    const store = createInstanceMessageStore("instance-1")
-    store.addOrUpdateSession({ id: "session-1" })
-
-    store.upsertMessage({
-      id: "msg-temp-img", sessionId: "session-1", role: "user", status: "sending",
-      parts: [{ type: "file", filename: "photo.png", url: "https://x/photo.png", mime: "image/png" } as any],
-      isEphemeral: true,
-      createdAt: 1000,
-    })
-
-    store.hydrateMessages("session-1", [
-      { id: "msg-real-img", sessionId: "session-1", role: "user", status: "complete", createdAt: 2000,
-        parts: [{ type: "file", filename: "photo.png", url: "https://x/photo.png", mime: "image/png" } as any] },
-    ])
-
-    const ids = store.getSessionMessageIds("session-1")
-    assert.deepEqual(ids, ["msg-real-img"], "attachment-only send must de-dupe on confirmation")
-    assert.equal(store.getMessage("msg-temp-img"), undefined)
-  })
-
-  it("matches confirmations one-to-one: two identical sends + one confirmation keeps the second pending", () => {
-    // Regression for the shared-Set matching bug: with two simultaneous
-    // optimistic "ok" sends and only ONE server confirmation, both temps were
-    // dropped and the still-unsent second message was lost. Each confirmation
-    // must be consumed exactly once.
-    const store = createInstanceMessageStore("instance-1")
-    store.addOrUpdateSession({ id: "session-1" })
-
-    store.upsertMessage({
-      id: "msg-temp-1", sessionId: "session-1", role: "user", status: "sending",
-      parts: [{ type: "text", text: "ok" } as any], isEphemeral: true, createdAt: 1000,
-    })
-    store.upsertMessage({
-      id: "msg-temp-2", sessionId: "session-1", role: "user", status: "sending",
-      parts: [{ type: "text", text: "ok" } as any], isEphemeral: true, createdAt: 1100,
-    })
-
-    // Snapshot confirms only ONE of the two sends.
-    store.hydrateMessages("session-1", [
-      { id: "msg-real-1", sessionId: "session-1", role: "user", status: "complete", createdAt: 2000, parts: [{ type: "text", text: "ok" } as any] },
-    ])
-
-    const ids = store.getSessionMessageIds("session-1")
-    assert.deepEqual(ids, ["msg-real-1", "msg-temp-2"], "exactly one temp superseded; the other stays pending")
-    assert.equal(store.getMessage("msg-temp-1"), undefined)
-    assert.equal(store.getMessage("msg-temp-2")?.status, "sending")
-
-    // When the second confirmation arrives, the remaining temp is dropped.
-    store.hydrateMessages("session-1", [
-      { id: "msg-real-1", sessionId: "session-1", role: "user", status: "complete", createdAt: 2000, parts: [{ type: "text", text: "ok" } as any] },
-      { id: "msg-real-2", sessionId: "session-1", role: "user", status: "complete", createdAt: 2100, parts: [{ type: "text", text: "ok" } as any] },
-    ])
-    assert.deepEqual(store.getSessionMessageIds("session-1"), ["msg-real-1", "msg-real-2"])
-  })
-
-  it("does not collide multi-part content with a single part containing the delimiter", () => {
-    // Collision-safety: a server message with parts ["A", "B"] must not match
-    // an optimistic send whose single text part is "A\nT:B" (the old
-    // newline-joined signature), and trailing whitespace must not be trimmed
-    // into a false match.
-    const store = createInstanceMessageStore("instance-1")
-    store.addOrUpdateSession({ id: "session-1" })
-
-    store.upsertMessage({
-      id: "msg-temp-collision", sessionId: "session-1", role: "user", status: "sending",
-      parts: [{ type: "text", text: "A\nT:B" } as any], isEphemeral: true,
-    })
-    store.upsertMessage({
-      id: "msg-temp-trailing", sessionId: "session-1", role: "user", status: "sending",
-      parts: [{ type: "text", text: "A " } as any], isEphemeral: true,
-    })
-
-    store.hydrateMessages("session-1", [
-      // Two-part message ["A", "B"] — old signature equaled "A\nT:B".
-      {
-        id: "msg-real-parts", sessionId: "session-1", role: "user", status: "complete",
-        parts: [{ type: "text", text: "A" } as any, { type: "text", text: "B" } as any],
-      },
-      // "A" must not match the pending "A " (trailing space).
-      { id: "msg-real-trim", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "A" } as any] },
-    ])
-
-    const ids = store.getSessionMessageIds("session-1")
-    assert.ok(ids.includes("msg-temp-collision"), "delimiter-collision temp must survive")
-    assert.ok(ids.includes("msg-temp-trailing"), "trailing-whitespace temp must survive")
-    assert.equal(store.getMessage("msg-temp-collision")?.status, "sending")
-    assert.equal(store.getMessage("msg-temp-trailing")?.status, "sending")
-  })
-
-  it("transfers clientPromptDisplayMetadata to the confirming server record on different-id reconcile", () => {
-    // The server never sees clientPromptDisplayMetadata; when a snapshot
-    // confirms an optimistic send under a new id, the real record must
-    // inherit the temp's metadata (same as the SSE replaceMessageId path).
+  it("reconciles a same-id confirmation in place, retiring the pending marker and keeping metadata", () => {
+    // Identity reconciliation: the client sends its optimistic id as
+    // messageID, so the server confirms the send under the SAME id. The
+    // record is updated in place (no duplicate, no replaceMessageId needed),
+    // and the client-only prompt-display metadata carries over via `previous`.
     const store = createInstanceMessageStore("instance-1")
     store.addOrUpdateSession({ id: "session-1" })
 
     const displayMetadata = { segments: [{ kind: "pasted" as const, length: 1200 }] }
     store.upsertMessage({
-      id: "msg-temp-pasted", sessionId: "session-1", role: "user", status: "sending",
-      parts: [{ type: "text", text: "big pasted text" } as any],
-      isEphemeral: true,
-      createdAt: 1000,
+      id: "msg-1", sessionId: "session-1", role: "user", status: "sending",
+      parts: [{ type: "text", text: "hello" } as any], isEphemeral: true,
       clientPromptDisplayMetadata: displayMetadata as any,
     })
+    store.markSendPending("msg-1")
 
     store.hydrateMessages("session-1", [
-      { id: "msg-real-pasted", sessionId: "session-1", role: "user", status: "complete", createdAt: 2000, parts: [{ type: "text", text: "big pasted text" } as any] },
+      // The REST bridge always sets isEphemeral explicitly (false for a
+      // confirmed non-streaming message), so mirror that here.
+      { id: "msg-1", sessionId: "session-1", role: "user", status: "complete", isEphemeral: false, parts: [{ type: "text", text: "hello" } as any] },
     ])
 
-    const real = store.getMessage("msg-real-pasted")
-    assert.ok(real, "real record exists")
-    assert.deepEqual(real?.clientPromptDisplayMetadata, displayMetadata, "metadata transferred from the superseded temp")
-    assert.equal(store.getMessage("msg-temp-pasted"), undefined, "temp dropped")
+    const record = store.getMessage("msg-1")
+    assert.deepEqual(store.getSessionMessageIds("session-1"), ["msg-1"])
+    assert.equal(record?.status, "complete")
+    assert.equal(record?.isEphemeral, false)
+    assert.deepEqual(record?.clientPromptDisplayMetadata, displayMetadata, "metadata survives the same-id confirmation")
   })
 
-  it("does not supersede a pending send with an OLDER unrelated server message of identical content", () => {
-    // Gatekeeper reproduction: a local pending "deploy" created at t=5000 was
-    // deleted by an unrelated server "deploy" created at t=1000. A server
-    // message can only confirm a send that happened BEFORE it was created.
+  it("dedupes repeated snapshot ids so messageIds never repeat", () => {
+    // Gatekeeper reproduction: a duplicated server record made the id appear
+    // twice in session.messageIds ([real, real]).
     const store = createInstanceMessageStore("instance-1")
     store.addOrUpdateSession({ id: "session-1" })
-
-    store.upsertMessage({
-      id: "msg-temp-deploy", sessionId: "session-1", role: "user", status: "sending",
-      parts: [{ type: "text", text: "deploy" } as any], isEphemeral: true, createdAt: 5000,
-    })
-
-    store.hydrateMessages("session-1", [
-      { id: "msg-real-old", sessionId: "session-1", role: "user", status: "complete", createdAt: 1000, parts: [{ type: "text", text: "deploy" } as any] },
-    ])
-
-    const ids = store.getSessionMessageIds("session-1")
-    assert.deepEqual(ids, ["msg-real-old", "msg-temp-deploy"], "older identical server message must not consume the newer pending send")
-    assert.equal(store.getMessage("msg-temp-deploy")?.status, "sending")
-  })
-
-  it("dedupes repeated snapshot ids so one record cannot consume multiple pending sends", () => {
-    // Gatekeeper reproduction: with two pending "ok" sends and ONE server
-    // record duplicated in the snapshot, both temps were deleted and the
-    // session ids became [real, real]. Duplicated input ids are collapsed
-    // before candidate construction.
-    const store = createInstanceMessageStore("instance-1")
-    store.addOrUpdateSession({ id: "session-1" })
-
-    store.upsertMessage({
-      id: "msg-temp-1", sessionId: "session-1", role: "user", status: "sending",
-      parts: [{ type: "text", text: "ok" } as any], isEphemeral: true, createdAt: 1000,
-    })
-    store.upsertMessage({
-      id: "msg-temp-2", sessionId: "session-1", role: "user", status: "sending",
-      parts: [{ type: "text", text: "ok" } as any], isEphemeral: true, createdAt: 1100,
-    })
 
     const duplicated = { id: "msg-real-1", sessionId: "session-1", role: "user" as const, status: "complete" as const, createdAt: 2000, parts: [{ type: "text", text: "ok" } as any] }
     store.hydrateMessages("session-1", [duplicated, duplicated])
 
-    const ids = store.getSessionMessageIds("session-1")
-    assert.deepEqual(ids, ["msg-real-1", "msg-temp-2"], "one real record consumes exactly one pending send; ids never repeat")
-    assert.equal(store.getMessage("msg-temp-2")?.status, "sending")
+    assert.deepEqual(store.getSessionMessageIds("session-1"), ["msg-real-1"])
+  })
+
+  it("drops a definitively failed send on the next authoritative snapshot", () => {
+    // promptAsync rejection retires the in-flight marker (clearSendPending).
+    // The failed bubble stays visible until the next authoritative snapshot,
+    // which must then drop it instead of preserving it forever as "sending".
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+
+    store.upsertMessage({
+      id: "msg-failed", sessionId: "session-1", role: "user", status: "sending",
+      parts: [{ type: "text", text: "do the thing" } as any], isEphemeral: true,
+    })
+    store.markSendPending("msg-failed")
+
+    // The request fails terminally.
+    store.clearSendPending("msg-failed")
+
+    // Immediately after the failure the bubble is still visible (unchanged
+    // pre-existing UX); the next authoritative snapshot drops it.
+    store.hydrateMessages("session-1", [
+      { id: "msg-older", sessionId: "session-1", role: "assistant", status: "complete", parts: [{ type: "text", text: "hi" } as any] },
+    ])
+    assert.deepEqual(store.getSessionMessageIds("session-1"), ["msg-older"])
+    assert.equal(store.getMessage("msg-failed"), undefined, "failed send must not survive authoritative hydration")
+  })
+
+  it("preserves only still-pending sends across an authoritative empty snapshot", () => {
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+
+    store.hydrateMessages("session-1", [
+      { id: "msg-stale", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "old" } as any] },
+    ])
+    store.upsertMessage({
+      id: "msg-inflight", sessionId: "session-1", role: "user", status: "sending",
+      parts: [{ type: "text", text: "new" } as any], isEphemeral: true,
+    })
+    store.markSendPending("msg-inflight")
+
+    // Server authoritatively reports zero messages on a forced reconnect load.
+    store.reconcileEmptyAuthoritativeSnapshot("session-1")
+
+    assert.deepEqual(store.getSessionMessageIds("session-1"), ["msg-inflight"], "stale records cleared, in-flight send preserved")
+    assert.equal(store.getMessage("msg-stale"), undefined)
   })
 
   it("does not bump messageInfoVersion when the hydrated info is unchanged", () => {
-    // Issue 4: an identical snapshot (common on a reconnect force-reload) must
-    // not invalidate message-block render caches via messageInfoVersion.
+    // An identical snapshot (common on a reconnect force-reload) must not
+    // invalidate message-block render caches via messageInfoVersion.
     const store = createInstanceMessageStore("instance-1")
     store.addOrUpdateSession({ id: "session-1" })
 

--- a/packages/ui/src/stores/message-v2/instance-store.test.ts
+++ b/packages/ui/src/stores/message-v2/instance-store.test.ts
@@ -226,6 +226,100 @@ describe("message-v2 hydrateMessages vs pending optimistic sends", () => {
     assert.equal(store.getMessage("msg-temp-img"), undefined)
   })
 
+  it("matches confirmations one-to-one: two identical sends + one confirmation keeps the second pending", () => {
+    // Regression for the shared-Set matching bug: with two simultaneous
+    // optimistic "ok" sends and only ONE server confirmation, both temps were
+    // dropped and the still-unsent second message was lost. Each confirmation
+    // must be consumed exactly once.
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+
+    store.upsertMessage({
+      id: "msg-temp-1", sessionId: "session-1", role: "user", status: "sending",
+      parts: [{ type: "text", text: "ok" } as any], isEphemeral: true,
+    })
+    store.upsertMessage({
+      id: "msg-temp-2", sessionId: "session-1", role: "user", status: "sending",
+      parts: [{ type: "text", text: "ok" } as any], isEphemeral: true,
+    })
+
+    // Snapshot confirms only ONE of the two sends.
+    store.hydrateMessages("session-1", [
+      { id: "msg-real-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "ok" } as any] },
+    ])
+
+    const ids = store.getSessionMessageIds("session-1")
+    assert.deepEqual(ids, ["msg-real-1", "msg-temp-2"], "exactly one temp superseded; the other stays pending")
+    assert.equal(store.getMessage("msg-temp-1"), undefined)
+    assert.equal(store.getMessage("msg-temp-2")?.status, "sending")
+
+    // When the second confirmation arrives, the remaining temp is dropped.
+    store.hydrateMessages("session-1", [
+      { id: "msg-real-1", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "ok" } as any] },
+      { id: "msg-real-2", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "ok" } as any] },
+    ])
+    assert.deepEqual(store.getSessionMessageIds("session-1"), ["msg-real-1", "msg-real-2"])
+  })
+
+  it("does not collide multi-part content with a single part containing the delimiter", () => {
+    // Collision-safety: a server message with parts ["A", "B"] must not match
+    // an optimistic send whose single text part is "A\nT:B" (the old
+    // newline-joined signature), and trailing whitespace must not be trimmed
+    // into a false match.
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+
+    store.upsertMessage({
+      id: "msg-temp-collision", sessionId: "session-1", role: "user", status: "sending",
+      parts: [{ type: "text", text: "A\nT:B" } as any], isEphemeral: true,
+    })
+    store.upsertMessage({
+      id: "msg-temp-trailing", sessionId: "session-1", role: "user", status: "sending",
+      parts: [{ type: "text", text: "A " } as any], isEphemeral: true,
+    })
+
+    store.hydrateMessages("session-1", [
+      // Two-part message ["A", "B"] — old signature equaled "A\nT:B".
+      {
+        id: "msg-real-parts", sessionId: "session-1", role: "user", status: "complete",
+        parts: [{ type: "text", text: "A" } as any, { type: "text", text: "B" } as any],
+      },
+      // "A" must not match the pending "A " (trailing space).
+      { id: "msg-real-trim", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "A" } as any] },
+    ])
+
+    const ids = store.getSessionMessageIds("session-1")
+    assert.ok(ids.includes("msg-temp-collision"), "delimiter-collision temp must survive")
+    assert.ok(ids.includes("msg-temp-trailing"), "trailing-whitespace temp must survive")
+    assert.equal(store.getMessage("msg-temp-collision")?.status, "sending")
+    assert.equal(store.getMessage("msg-temp-trailing")?.status, "sending")
+  })
+
+  it("transfers clientPromptDisplayMetadata to the confirming server record on different-id reconcile", () => {
+    // The server never sees clientPromptDisplayMetadata; when a snapshot
+    // confirms an optimistic send under a new id, the real record must
+    // inherit the temp's metadata (same as the SSE replaceMessageId path).
+    const store = createInstanceMessageStore("instance-1")
+    store.addOrUpdateSession({ id: "session-1" })
+
+    const displayMetadata = { segments: [{ kind: "pasted" as const, length: 1200 }] }
+    store.upsertMessage({
+      id: "msg-temp-pasted", sessionId: "session-1", role: "user", status: "sending",
+      parts: [{ type: "text", text: "big pasted text" } as any],
+      isEphemeral: true,
+      clientPromptDisplayMetadata: displayMetadata as any,
+    })
+
+    store.hydrateMessages("session-1", [
+      { id: "msg-real-pasted", sessionId: "session-1", role: "user", status: "complete", parts: [{ type: "text", text: "big pasted text" } as any] },
+    ])
+
+    const real = store.getMessage("msg-real-pasted")
+    assert.ok(real, "real record exists")
+    assert.deepEqual(real?.clientPromptDisplayMetadata, displayMetadata, "metadata transferred from the superseded temp")
+    assert.equal(store.getMessage("msg-temp-pasted"), undefined, "temp dropped")
+  })
+
   it("does not bump messageInfoVersion when the hydrated info is unchanged", () => {
     // Issue 4: an identical snapshot (common on a reconnect force-reload) must
     // not invalidate message-block render caches via messageInfoVersion.

--- a/packages/ui/src/stores/message-v2/instance-store.ts
+++ b/packages/ui/src/stores/message-v2/instance-store.ts
@@ -431,20 +431,74 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     }
   }
 
+  // Compares incoming parts against the previously stored parts for a message.
+  // Used by hydrateMessages (full reload / force refresh) to avoid bumping
+  // revision -- and therefore invalidating downstream render caches -- for
+  // messages whose content is byte-identical to what's already in the store.
+  // Cheap: parts are small (text chunks, tool state); JSON.stringify is fine
+  // here versus the cost of a full re-render of every message in the session.
+  function havePartsChanged(
+    previousPartIds: string[] | undefined,
+    previousParts: MessageRecord["parts"] | undefined,
+    nextIds: string[],
+    nextMap: MessageRecord["parts"],
+  ): boolean {
+    if (!previousPartIds || !previousParts) return true
+    if (previousPartIds.length !== nextIds.length) return true
+    for (let i = 0; i < nextIds.length; i++) {
+      if (previousPartIds[i] !== nextIds[i]) return true
+    }
+    for (const id of nextIds) {
+      const prevPart = previousParts[id]
+      const nextPart = nextMap[id]
+      if (prevPart === nextPart) continue
+      if (!prevPart || !nextPart) return true
+      if (JSON.stringify(prevPart.data) !== JSON.stringify(nextPart.data)) return true
+    }
+    return false
+  }
+
   function hydrateMessages(sessionId: string, inputs: MessageUpsertInput[], infos?: Iterable<MessageInfo>) {
     if (!Array.isArray(inputs) || inputs.length === 0) return
 
     ensureSessionEntry(sessionId)
 
-    const incomingIds = inputs.map((item) => item.id)
+    const serverIds = inputs.map((item) => item.id)
+    const serverIdSet = new Set(serverIds)
+
+    // Preserve locally-optimistic "sending" messages that the server hasn't
+    // echoed back yet in this snapshot (e.g. a force reload -- triggered by
+    // an SSE reconnect -- raced a message the user just sent). Without this,
+    // a wholesale replace of messageIds drops the pending bubble from the
+    // session's visible list, but its record stays orphaned in state.messages
+    // (nothing deletes it). If the real "message.updated"/"message.part.updated"
+    // SSE event for it then arrives, findPendingSyntheticMessageId can no
+    // longer find the pending id in the (already-overwritten) messageIds list
+    // to swap it for the real one via replaceMessageId, so the handler falls
+    // through to creating a brand-new record instead -- and once the next
+    // hydrate DOES include the server-confirmed message, both the orphaned
+    // optimistic bubble and the new server-confirmed one can end up visible,
+    // i.e. the message appears duplicated.
+    const previousMessageIds = state.sessions[sessionId]?.messageIds ?? []
+    const pendingOptimisticIds = previousMessageIds.filter((id) => {
+      if (serverIdSet.has(id)) return false
+      const record = state.messages[id]
+      return Boolean(record && record.isEphemeral && record.status === "sending")
+    })
+
+    const incomingIds = pendingOptimisticIds.length > 0 ? [...serverIds, ...pendingOptimisticIds] : serverIds
 
     const normalizedRecords: Record<string, MessageRecord> = {}
     const now = Date.now()
 
     inputs.forEach((input) => {
       const normalizedParts = normalizeParts(input.id, input.parts)
-      const shouldBump = Boolean(input.bumpRevision || normalizedParts)
       const previous = state.messages[input.id]
+      const partsChanged = normalizedParts
+        ? havePartsChanged(previous?.partIds, previous?.parts, normalizedParts.ids, normalizedParts.map)
+        : false
+      const statusChanged = previous ? previous.status !== input.status : true
+      const shouldBump = Boolean(input.bumpRevision || partsChanged || statusChanged)
       const clientPromptDisplayMetadata = resolveClientPromptDisplayText(instanceId, input, previous)
       normalizedRecords[input.id] = {
         id: input.id,

--- a/packages/ui/src/stores/message-v2/instance-store.ts
+++ b/packages/ui/src/stores/message-v2/instance-store.ts
@@ -216,6 +216,9 @@ export interface InstanceMessageStore {
   setState: SetStoreFunction<InstanceMessageState>
   addOrUpdateSession: (input: SessionUpsertInput) => void
   hydrateMessages: (sessionId: string, inputs: MessageUpsertInput[], infos?: Iterable<MessageInfo>) => void
+  reconcileEmptyAuthoritativeSnapshot: (sessionId: string) => void
+  markSendPending: (messageId: string) => void
+  clearSendPending: (messageId: string) => void
   upsertMessage: (input: MessageUpsertInput) => void
   applyPartUpdate: (input: PartUpdateInput) => void
   applyPartDelta: (input: {
@@ -265,6 +268,17 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
   const TODO_TOOL_NAME = "todowrite"
 
   const messageInfoCache = new Map<string, MessageInfo>()
+
+  // Ids of optimistic user sends that are still IN FLIGHT (request not yet
+  // resolved terminally). The client sends its optimistic id to the server as
+  // messageID, so a confirmed send reappears in snapshots under the SAME id
+  // and is reconciled in place. Between the optimistic insert and that
+  // confirmation, the record is absent from server snapshots; this set is how
+  // hydration knows to PRESERVE it (still pending) versus DROP it (a request
+  // that already failed, or a stale ephemeral record the server does not
+  // know about). Entries are removed on confirmation, on terminal status, and
+  // on explicit send failure (clearSendPending).
+  const pendingSendIds = new Set<string>()
 
   function findLastAssistantMessageId(messageIds: readonly string[]): string | undefined {
     for (let index = messageIds.length - 1; index >= 0; index -= 1) {
@@ -458,44 +472,14 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     return false
   }
 
-  // Content signature (text + file parts, in order) of a message. Used only to
-  // match an optimistic "sending" bubble against its server-confirmed
-  // counterpart during hydration: the client temp id and the real server id
-  // differ, so content is the only stable link. Covers text-only, attachment-
-  // only, and mixed sends. Non-content parts (tool/reasoning/etc.) are ignored.
-  //
-  // The signature is a JSON-serialized array of typed tokens: escaping makes
-  // delimiter/whitespace collisions impossible (under the previous newline-
-  // joined string form, parts ["A","B"] collided with one part "A\nT:B", and
-  // .trim() collapsed trailing whitespace). Returns null when the message has
-  // no content parts at all — there is nothing to match on.
-  type MessageContentToken =
-    | readonly [type: "text", text: string]
-    | readonly [type: "file", filename: string, url: string, mime: string]
-
-  function partContentToken(part: ClientPart | undefined): MessageContentToken | null {
-    if (!part) return null
-    if (part.type === "text") return ["text", (part as { text?: string }).text ?? ""]
-    if (part.type === "file") {
-      const p = part as { filename?: string; url?: string; mime?: string }
-      return ["file", p.filename ?? "", p.url ?? "", p.mime ?? ""]
-    }
-    return null
-  }
-
-  function signatureFromTokens(tokens: Array<MessageContentToken | null>): string | null {
-    const content = tokens.filter((token): token is MessageContentToken => token !== null)
-    if (content.length === 0) return null
-    return JSON.stringify(content)
-  }
-
-  function recordContentSignature(partIds: string[], parts: MessageRecord["parts"]): string | null {
-    return signatureFromTokens(partIds.map((partId) => partContentToken(parts[partId]?.data)))
-  }
-
-  function inputContentSignature(parts: ClientPart[] | undefined): string | null {
-    return signatureFromTokens((parts ?? []).map((part) => partContentToken(part)))
-  }
+  // NOTE: optimistic sends are reconciled purely by IDENTITY. The client
+  // serializes its optimistic id as `messageID` on the prompt request, so a
+  // confirmed send always reappears under the SAME id and is updated in place
+  // by the normal hydrate/upsert paths. There is intentionally no
+  // content-signature fallback: guessing ownership from identical text could
+  // delete an unrelated local send (or an identical prompt from another
+  // client) and cross-attach its metadata. Sends the server has not yet
+  // echoed are preserved via `pendingSendIds` instead (see hydrateMessages).
 
   function hydrateMessages(sessionId: string, inputs: MessageUpsertInput[], infos?: Iterable<MessageInfo>) {
     if (!Array.isArray(inputs) || inputs.length === 0) return
@@ -539,70 +523,23 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     //      messageIds so the eventual SSE echo can swap it in place via
     //      replaceMessageId. These are preserved.
     const previousMessageIds = state.sessions[sessionId]?.messageIds ?? []
-    const previousMessageIdSet = new Set(previousMessageIds)
-    // Content matching is only a FALLBACK for sends the server could not
-    // confirm by identity (the client now sends its optimistic id as
-    // messageID, so a confirming snapshot entry normally has the SAME id and
-    // is reconciled in place above). Two guards keep the fallback safe:
-    //
-    //  - New ids only: a confirmation always arrives as a new server id, so
-    //    an in-flight duplicate-text send ("ok" sent twice) is not falsely
-    //    matched against the earlier, already-loaded "ok".
-    //
-    //  - Temporal correlation: a server message can only confirm a send that
-    //    happened BEFORE the server created it. Without this, an unrelated
-    //    older server message with identical content would wrongly supersede
-    //    a newer pending send (e.g. a server "deploy" created at t=1000
-    //    deleting a local pending "deploy" created at t=5000).
-    //
-    // Each candidate is CONSUMED on match (one-to-one, in send/snapshot
-    // order): with two simultaneous "ok" sends and only one confirmation
-    // back, the first temp is superseded and the second stays pending —
-    // shared set membership would wrongly drop both.
-    type ConfirmationCandidate = { id: string; createdAt: number | undefined }
-    const candidatesBySignature = new Map<string, ConfirmationCandidate[]>()
-    dedupedInputs.forEach((input) => {
-      if (input.role !== "user" || previousMessageIdSet.has(input.id)) return
-      const signature = inputContentSignature(input.parts)
-      if (signature === null) return
-      const candidate: ConfirmationCandidate = { id: input.id, createdAt: input.createdAt }
-      const queue = candidatesBySignature.get(signature)
-      if (queue) {
-        queue.push(candidate)
-      } else {
-        candidatesBySignature.set(signature, [candidate])
-      }
-    })
+    // For each previous ephemeral "sending" record absent from this snapshot,
+    // preserve it ONLY while it is a still-in-flight pending send; otherwise
+    // it is stale — a send that already failed, or an ephemeral record the
+    // authoritative server does not know about — and is dropped so it cannot
+    // linger as a permanent "sending" bubble.
     const pendingOptimisticIds: string[] = []
-    const supersededOptimisticIds: string[] = []
-    // temp id -> confirming server id, so the superseded bubble's client-only
-    // prompt-display metadata can be transferred to the real record below
-    // (the SSE replaceMessageId path does the same via movePromptDisplayOverride).
-    const supersededByServerId = new Map<string, string>()
+    const droppedOptimisticIds: string[] = []
     for (const id of previousMessageIds) {
       if (serverIdSet.has(id)) continue
       const record = state.messages[id]
       if (!record || !record.isEphemeral || record.status !== "sending") continue
-      const signature = recordContentSignature(record.partIds, record.parts)
-      const queue = signature !== null ? candidatesBySignature.get(signature) : undefined
-      const candidate = queue?.[0]
-      if (
-        candidate &&
-        typeof candidate.createdAt === "number" &&
-        candidate.createdAt >= record.createdAt
-      ) {
-        queue?.shift()
-        supersededOptimisticIds.push(id) // case (A)
-        supersededByServerId.set(id, candidate.id)
+      if (pendingSendIds.has(id)) {
+        pendingOptimisticIds.push(id) // case (B): still in flight — keep visible
       } else {
-        pendingOptimisticIds.push(id) // case (B)
+        droppedOptimisticIds.push(id) // stale/failed — drop
       }
     }
-    // Reverse lookup for the normalize loop: server id -> superseded temp id.
-    const tempIdByServerId = new Map<string, string>()
-    supersededByServerId.forEach((serverId, tempId) => {
-      tempIdByServerId.set(serverId, tempId)
-    })
 
     const incomingIds = pendingOptimisticIds.length > 0 ? [...serverIds, ...pendingOptimisticIds] : serverIds
 
@@ -617,14 +554,10 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
         : false
       const statusChanged = previous ? previous.status !== input.status : true
       const shouldBump = Boolean(input.bumpRevision || partsChanged || statusChanged)
-      // When this server record confirms an optimistic send under a new id,
-      // the optimistic record carries the client-only prompt-display metadata
-      // (the server never sees it). Use it as the metadata fallback so the
-      // replacement keeps the pasted-text/path presentation the SSE
-      // replaceMessageId path would have preserved.
-      const supersededTempId = tempIdByServerId.get(input.id)
-      const metadataFallback = previous ?? (supersededTempId ? state.messages[supersededTempId] : undefined)
-      const clientPromptDisplayMetadata = resolveClientPromptDisplayText(instanceId, input, metadataFallback)
+      // Identity reconciliation: a confirmed send reappears under its own id,
+      // so `previous` IS the optimistic record and its client-only
+      // prompt-display metadata carries over unchanged.
+      const clientPromptDisplayMetadata = resolveClientPromptDisplayText(instanceId, input, previous)
       normalizedRecords[input.id] = {
         id: input.id,
         sessionId: input.sessionId,
@@ -655,25 +588,23 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
       nextMessages[id] = record
     })
 
-    // Case (A) above: physically remove optimistic bubbles the server already
-    // confirmed under a real id, so no orphaned duplicate lingers in the store.
-    // Non-store side effects (caches/overrides) are cleared here; the actual
-    // store-key deletion happens in the batch below via produce, because
+    // Physically remove stale ephemeral bubbles (a failed send, or an
+    // ephemeral record the authoritative snapshot does not include). Non-store
+    // side effects (caches/overrides) are cleared here; the actual store-key
+    // deletion happens in the batch below via produce, because
     // setState("messages", () => obj) MERGES and would not drop absent keys.
-    if (supersededOptimisticIds.length > 0) {
-      supersededOptimisticIds.forEach((id) => {
+    if (droppedOptimisticIds.length > 0) {
+      droppedOptimisticIds.forEach((id) => {
         messageInfoCache.delete(id)
-        // Transfer (not just clear) the persisted prompt-display override to
-        // the confirming server id, mirroring replaceMessageId.
-        const serverId = supersededByServerId.get(id)
-        if (serverId) {
-          movePromptDisplayOverride(instanceId, sessionId, id, serverId)
-        } else {
-          clearPromptDisplayOverride(instanceId, sessionId, id)
-        }
+        pendingSendIds.delete(id)
+        clearPromptDisplayOverride(instanceId, sessionId, id)
       })
-      clearRecordDisplayCacheForMessages(instanceId, supersededOptimisticIds)
+      clearRecordDisplayCacheForMessages(instanceId, droppedOptimisticIds)
     }
+
+    // A send that reappears under its own id is confirmed — it is no longer in
+    // flight, so retire its pending marker.
+    serverIds.forEach((id) => pendingSendIds.delete(id))
 
     if (infoList) {
       for (const info of infoList) {
@@ -698,13 +629,13 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
       setState("pendingParts", () => nextPendingParts)
       setState("permissions", "byMessage", () => nextPermissionsByMessage)
 
-      // setState with an object merges, so keys removed above (superseded
-      // optimistic bubbles) must be deleted explicitly to actually drop them.
-      if (supersededOptimisticIds.length > 0) {
+      // setState with an object merges, so keys removed above (stale
+      // ephemeral bubbles) must be deleted explicitly to actually drop them.
+      if (droppedOptimisticIds.length > 0) {
         setState(
           "messages",
           produce((draft) => {
-            supersededOptimisticIds.forEach((id) => {
+            droppedOptimisticIds.forEach((id) => {
               delete draft[id]
             })
           }),
@@ -712,7 +643,7 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
         setState(
           "messageInfoVersion",
           produce((draft) => {
-            supersededOptimisticIds.forEach((id) => {
+            droppedOptimisticIds.forEach((id) => {
               delete draft[id]
             })
           }),
@@ -734,6 +665,74 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
         maybeUpdateLatestTodoFromRecord(record)
       })
 
+      bumpSessionRevision(sessionId)
+    })
+  }
+
+  // Register an optimistic user send as in-flight. Called right after the
+  // optimistic record is inserted, so hydration preserves it until the server
+  // confirms it (same id) or the request fails (clearSendPending).
+  function markSendPending(messageId: string) {
+    if (messageId) pendingSendIds.add(messageId)
+  }
+
+  // Retire an optimistic send's in-flight marker. Called on a definitive
+  // send failure (promptAsync rejection) so a later authoritative snapshot
+  // no longer preserves the failed bubble.
+  function clearSendPending(messageId: string) {
+    pendingSendIds.delete(messageId)
+  }
+
+  // Apply an AUTHORITATIVE empty snapshot (server returned zero messages for
+  // this session on a forced reconnect load). hydrateMessages ignores empty
+  // input, so this path exists to clear stale records the server no longer
+  // knows about while still preserving genuinely in-flight optimistic sends.
+  function reconcileEmptyAuthoritativeSnapshot(sessionId: string) {
+    const session = state.sessions[sessionId]
+    if (!session) return
+    const previousMessageIds = session.messageIds ?? []
+    const keptPendingIds: string[] = []
+    const droppedIds: string[] = []
+    for (const id of previousMessageIds) {
+      const record = state.messages[id]
+      if (record && record.isEphemeral && record.status === "sending" && pendingSendIds.has(id)) {
+        keptPendingIds.push(id)
+      } else {
+        droppedIds.push(id)
+      }
+    }
+    if (droppedIds.length === 0) return
+
+    droppedIds.forEach((id) => {
+      messageInfoCache.delete(id)
+      pendingSendIds.delete(id)
+      clearPromptDisplayOverride(instanceId, sessionId, id)
+    })
+    clearRecordDisplayCacheForMessages(instanceId, droppedIds)
+
+    batch(() => {
+      setState(
+        "messages",
+        produce((draft) => {
+          droppedIds.forEach((id) => {
+            delete draft[id]
+          })
+        }),
+      )
+      setState(
+        "messageInfoVersion",
+        produce((draft) => {
+          droppedIds.forEach((id) => {
+            delete draft[id]
+          })
+        }),
+      )
+      setState("sessions", sessionId, (current) => ({
+        ...current,
+        messageIds: keptPendingIds,
+        updatedAt: Date.now(),
+      }))
+      recomputeLastAssistantMessageId(sessionId, keptPendingIds)
       bumpSessionRevision(sessionId)
     })
   }
@@ -799,6 +798,14 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
 
     if (nextRecord) {
       maybeUpdateLatestTodoFromRecord(nextRecord)
+    }
+
+    // A record that is no longer an in-flight optimistic "sending" bubble
+    // (confirmed by identity via SSE/REST, or otherwise terminal) must not
+    // keep a pending marker, or a later authoritative snapshot could preserve
+    // a stale entry.
+    if (nextRecord && !(nextRecord.isEphemeral && nextRecord.status === "sending")) {
+      pendingSendIds.delete(input.id)
     }
 
     insertMessageIntoSession(input.sessionId, input.id)
@@ -963,6 +970,8 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
   function removeMessage(messageId: string, fallbackSessionId?: string) {
     if (!messageId) return
 
+    pendingSendIds.delete(messageId)
+
     const record = state.messages[messageId]
     const sessionIds = new Set<string>()
 
@@ -1085,6 +1094,12 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     if (!existing) return
 
     movePromptDisplayOverride(instanceId, existing.sessionId, options.oldId, options.newId)
+
+    // The optimistic send is now confirmed under its real id; retire the
+    // pending marker (carry it to the new id only if still mid-flight).
+    if (pendingSendIds.delete(options.oldId) && existing.isEphemeral && existing.status === "sending") {
+      pendingSendIds.add(options.newId)
+    }
 
     const cloned: MessageRecord = {
       ...existing,
@@ -1464,6 +1479,7 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
  
     storeLog.info("Clearing session data", { instanceId, sessionId, messageCount: messageIds.length })
     clearRecordDisplayCacheForMessages(instanceId, messageIds)
+    messageIds.forEach((id) => pendingSendIds.delete(id))
  
     batch(() => {
       setState("messages", (prev) => {
@@ -1558,6 +1574,7 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
    function clearInstance() {
      clearPromptDisplayOverridesForInstance(instanceId, Object.keys(state.sessions))
      messageInfoCache.clear()
+     pendingSendIds.clear()
       setState(reconcile(createInitialState(instanceId)))
     }
 
@@ -1572,6 +1589,9 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
      setState,
      addOrUpdateSession,
       hydrateMessages,
+      reconcileEmptyAuthoritativeSnapshot,
+      markSendPending,
+      clearSendPending,
       upsertMessage,
       applyPartUpdate,
       applyPartDelta,

--- a/packages/ui/src/stores/message-v2/instance-store.ts
+++ b/packages/ui/src/stores/message-v2/instance-store.ts
@@ -502,7 +502,19 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
 
     ensureSessionEntry(sessionId)
 
-    const serverIds = inputs.map((item) => item.id)
+    // Defensive dedupe by message id: a snapshot should not contain the same
+    // id twice, but if it does, every duplicate would be enqueued below as an
+    // additional confirmation candidate (consuming extra pending sends) and
+    // the id would repeat in session.messageIds. First occurrence wins,
+    // preserving snapshot order.
+    const seenInputIds = new Set<string>()
+    const dedupedInputs = inputs.filter((input) => {
+      if (seenInputIds.has(input.id)) return false
+      seenInputIds.add(input.id)
+      return true
+    })
+
+    const serverIds = dedupedInputs.map((item) => item.id)
     const serverIdSet = new Set(serverIds)
 
     // Reconcile locally-optimistic "sending" messages against this snapshot.
@@ -528,28 +540,37 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     //      replaceMessageId. These are preserved.
     const previousMessageIds = state.sessions[sessionId]?.messageIds ?? []
     const previousMessageIdSet = new Set(previousMessageIds)
-    // Candidate confirmations: user messages the server returned under a NEW
-    // id (not already in messageIds), indexed by content signature as FIFO
-    // queues. Restricting to new ids is what makes a confirmation
-    // distinguishable from a pre-existing older message with identical
-    // content: a send's confirmation always arrives as a new server id, so an
-    // in-flight duplicate-text send ("ok" sent twice) is not falsely matched
-    // against the earlier, already-loaded "ok".
+    // Content matching is only a FALLBACK for sends the server could not
+    // confirm by identity (the client now sends its optimistic id as
+    // messageID, so a confirming snapshot entry normally has the SAME id and
+    // is reconciled in place above). Two guards keep the fallback safe:
+    //
+    //  - New ids only: a confirmation always arrives as a new server id, so
+    //    an in-flight duplicate-text send ("ok" sent twice) is not falsely
+    //    matched against the earlier, already-loaded "ok".
+    //
+    //  - Temporal correlation: a server message can only confirm a send that
+    //    happened BEFORE the server created it. Without this, an unrelated
+    //    older server message with identical content would wrongly supersede
+    //    a newer pending send (e.g. a server "deploy" created at t=1000
+    //    deleting a local pending "deploy" created at t=5000).
     //
     // Each candidate is CONSUMED on match (one-to-one, in send/snapshot
     // order): with two simultaneous "ok" sends and only one confirmation
     // back, the first temp is superseded and the second stays pending —
     // shared set membership would wrongly drop both.
-    const candidatesBySignature = new Map<string, string[]>()
-    inputs.forEach((input) => {
+    type ConfirmationCandidate = { id: string; createdAt: number | undefined }
+    const candidatesBySignature = new Map<string, ConfirmationCandidate[]>()
+    dedupedInputs.forEach((input) => {
       if (input.role !== "user" || previousMessageIdSet.has(input.id)) return
       const signature = inputContentSignature(input.parts)
       if (signature === null) return
+      const candidate: ConfirmationCandidate = { id: input.id, createdAt: input.createdAt }
       const queue = candidatesBySignature.get(signature)
       if (queue) {
-        queue.push(input.id)
+        queue.push(candidate)
       } else {
-        candidatesBySignature.set(signature, [input.id])
+        candidatesBySignature.set(signature, [candidate])
       }
     })
     const pendingOptimisticIds: string[] = []
@@ -564,10 +585,15 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
       if (!record || !record.isEphemeral || record.status !== "sending") continue
       const signature = recordContentSignature(record.partIds, record.parts)
       const queue = signature !== null ? candidatesBySignature.get(signature) : undefined
-      if (queue && queue.length > 0) {
-        const serverId = queue.shift() as string
+      const candidate = queue?.[0]
+      if (
+        candidate &&
+        typeof candidate.createdAt === "number" &&
+        candidate.createdAt >= record.createdAt
+      ) {
+        queue?.shift()
         supersededOptimisticIds.push(id) // case (A)
-        supersededByServerId.set(id, serverId)
+        supersededByServerId.set(id, candidate.id)
       } else {
         pendingOptimisticIds.push(id) // case (B)
       }
@@ -583,7 +609,7 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     const normalizedRecords: Record<string, MessageRecord> = {}
     const now = Date.now()
 
-    inputs.forEach((input) => {
+    dedupedInputs.forEach((input) => {
       const normalizedParts = normalizeParts(input.id, input.parts)
       const previous = state.messages[input.id]
       const partsChanged = normalizedParts

--- a/packages/ui/src/stores/message-v2/instance-store.ts
+++ b/packages/ui/src/stores/message-v2/instance-store.ts
@@ -458,6 +458,37 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     return false
   }
 
+  // Content signature (text + file parts, in order) of a message. Used only to
+  // match an optimistic "sending" bubble against its server-confirmed
+  // counterpart during hydration: the client temp id and the real server id
+  // differ, so content is the only stable link. Covers text-only, attachment-
+  // only, and mixed sends. Non-content parts (tool/reasoning/etc.) are ignored.
+  function partContentToken(part: ClientPart | undefined): string | null {
+    if (!part) return null
+    if (part.type === "text") return `T:${(part as { text?: string }).text ?? ""}`
+    if (part.type === "file") {
+      const p = part as { filename?: string; url?: string; mime?: string }
+      return `F:${p.filename ?? ""}:${p.url ?? ""}:${p.mime ?? ""}`
+    }
+    return null
+  }
+
+  function recordContentSignature(partIds: string[], parts: MessageRecord["parts"]): string {
+    return partIds
+      .map((partId) => partContentToken(parts[partId]?.data))
+      .filter((token): token is string => token !== null)
+      .join("\n")
+      .trim()
+  }
+
+  function inputContentSignature(parts: ClientPart[] | undefined): string {
+    return (parts ?? [])
+      .map((part) => partContentToken(part))
+      .filter((token): token is string => token !== null)
+      .join("\n")
+      .trim()
+  }
+
   function hydrateMessages(sessionId: string, inputs: MessageUpsertInput[], infos?: Iterable<MessageInfo>) {
     if (!Array.isArray(inputs) || inputs.length === 0) return
 
@@ -466,25 +497,54 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     const serverIds = inputs.map((item) => item.id)
     const serverIdSet = new Set(serverIds)
 
-    // Preserve locally-optimistic "sending" messages that the server hasn't
-    // echoed back yet in this snapshot (e.g. a force reload -- triggered by
-    // an SSE reconnect -- raced a message the user just sent). Without this,
-    // a wholesale replace of messageIds drops the pending bubble from the
-    // session's visible list, but its record stays orphaned in state.messages
-    // (nothing deletes it). If the real "message.updated"/"message.part.updated"
-    // SSE event for it then arrives, findPendingSyntheticMessageId can no
-    // longer find the pending id in the (already-overwritten) messageIds list
-    // to swap it for the real one via replaceMessageId, so the handler falls
-    // through to creating a brand-new record instead -- and once the next
-    // hydrate DOES include the server-confirmed message, both the orphaned
-    // optimistic bubble and the new server-confirmed one can end up visible,
-    // i.e. the message appears duplicated.
+    // Reconcile locally-optimistic "sending" messages against this snapshot.
+    //
+    // When the user sends a message the client creates an optimistic record
+    // with a client-only id (isEphemeral + status "sending"). That id is NOT
+    // sent to the server, so the server confirms the send under a DIFFERENT,
+    // real id. A force reload (triggered by an SSE reconnect) replaces
+    // session.messageIds wholesale with the snapshot's ids, which drops the
+    // optimistic id from the visible list while leaving its record orphaned
+    // in state.messages. Two cases must be handled differently:
+    //
+    //  (A) The snapshot ALREADY contains the server-confirmed counterpart
+    //      (a user message with the same content). Preserving the temp id here
+    //      would leave BOTH visible: the SSE message.updated handler finds
+    //      the real record via getMessage() and never runs the temp-id
+    //      replacement, so the temp bubble is never removed -> visible
+    //      duplicate ("real, temp"). These must be dropped and cleaned up.
+    //
+    //  (B) The snapshot does NOT yet contain the send (server hasn't
+    //      registered it). The bubble must stay visible AND stay in
+    //      messageIds so the eventual SSE echo can swap it in place via
+    //      replaceMessageId. These are preserved.
     const previousMessageIds = state.sessions[sessionId]?.messageIds ?? []
-    const pendingOptimisticIds = previousMessageIds.filter((id) => {
-      if (serverIdSet.has(id)) return false
+    const previousMessageIdSet = new Set(previousMessageIds)
+    // Content signatures of user messages the server returned this snapshot
+    // under a NEW id (not already in messageIds). Restricting to new ids is
+    // what makes a confirmation distinguishable from a pre-existing older
+    // message with identical content: a send's confirmation always arrives as
+    // a new server id, so an in-flight duplicate-text send ("ok" sent twice)
+    // is not falsely matched against the earlier, already-loaded "ok".
+    const serverUserContentSignatures = new Set(
+      inputs
+        .filter((input) => input.role === "user" && !previousMessageIdSet.has(input.id))
+        .map((input) => inputContentSignature(input.parts))
+        .filter((signature) => signature.length > 0),
+    )
+    const pendingOptimisticIds: string[] = []
+    const supersededOptimisticIds: string[] = []
+    for (const id of previousMessageIds) {
+      if (serverIdSet.has(id)) continue
       const record = state.messages[id]
-      return Boolean(record && record.isEphemeral && record.status === "sending")
-    })
+      if (!record || !record.isEphemeral || record.status !== "sending") continue
+      const signature = recordContentSignature(record.partIds, record.parts)
+      if (signature.length > 0 && serverUserContentSignatures.has(signature)) {
+        supersededOptimisticIds.push(id) // case (A)
+      } else {
+        pendingOptimisticIds.push(id) // case (B)
+      }
+    }
 
     const incomingIds = pendingOptimisticIds.length > 0 ? [...serverIds, ...pendingOptimisticIds] : serverIds
 
@@ -530,12 +590,33 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
       nextMessages[id] = record
     })
 
+    // Case (A) above: physically remove optimistic bubbles the server already
+    // confirmed under a real id, so no orphaned duplicate lingers in the store.
+    // Non-store side effects (caches/overrides) are cleared here; the actual
+    // store-key deletion happens in the batch below via produce, because
+    // setState("messages", () => obj) MERGES and would not drop absent keys.
+    if (supersededOptimisticIds.length > 0) {
+      supersededOptimisticIds.forEach((id) => {
+        messageInfoCache.delete(id)
+        clearPromptDisplayOverride(instanceId, sessionId, id)
+      })
+      clearRecordDisplayCacheForMessages(instanceId, supersededOptimisticIds)
+    }
+
     if (infoList) {
       for (const info of infoList) {
         const messageId = info.id as string
+        // Only bump the info version -- which participates in message-block's
+        // render-cache signature -- when the info content actually changed.
+        // An identical snapshot (the common case on a reconnect force-reload)
+        // must not invalidate those caches.
+        const previousInfo = messageInfoCache.get(messageId)
+        const infoChanged = !previousInfo || JSON.stringify(previousInfo) !== JSON.stringify(info)
         messageInfoCache.set(messageId, info)
-        const currentVersion = nextMessageInfoVersion[messageId] ?? 0
-        nextMessageInfoVersion[messageId] = currentVersion + 1
+        if (infoChanged) {
+          const currentVersion = nextMessageInfoVersion[messageId] ?? 0
+          nextMessageInfoVersion[messageId] = currentVersion + 1
+        }
       }
     }
 
@@ -544,6 +625,27 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
       setState("messageInfoVersion", () => nextMessageInfoVersion)
       setState("pendingParts", () => nextPendingParts)
       setState("permissions", "byMessage", () => nextPermissionsByMessage)
+
+      // setState with an object merges, so keys removed above (superseded
+      // optimistic bubbles) must be deleted explicitly to actually drop them.
+      if (supersededOptimisticIds.length > 0) {
+        setState(
+          "messages",
+          produce((draft) => {
+            supersededOptimisticIds.forEach((id) => {
+              delete draft[id]
+            })
+          }),
+        )
+        setState(
+          "messageInfoVersion",
+          produce((draft) => {
+            supersededOptimisticIds.forEach((id) => {
+              delete draft[id]
+            })
+          }),
+        )
+      }
 
       if (usageState) {
         setState("usage", sessionId, usageState)

--- a/packages/ui/src/stores/message-v2/instance-store.ts
+++ b/packages/ui/src/stores/message-v2/instance-store.ts
@@ -218,7 +218,11 @@ export interface InstanceMessageStore {
   hydrateMessages: (sessionId: string, inputs: MessageUpsertInput[], infos?: Iterable<MessageInfo>) => void
   reconcileEmptyAuthoritativeSnapshot: (sessionId: string) => void
   markSendPending: (messageId: string) => void
-  clearSendPending: (messageId: string) => void
+  acceptSend: (messageId: string) => void
+  confirmServerMessage: (messageId: string, options?: { clearOptimisticParts?: boolean }) => void
+  failSend: (messageId: string) => void
+  failPendingSends: (sessionId: string) => void
+  retirePendingSends: (sessionId: string) => void
   upsertMessage: (input: MessageUpsertInput) => void
   applyPartUpdate: (input: PartUpdateInput) => void
   applyPartDelta: (input: {
@@ -269,16 +273,18 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
 
   const messageInfoCache = new Map<string, MessageInfo>()
 
-  // Ids of optimistic user sends that are still IN FLIGHT (request not yet
-  // resolved terminally). The client sends its optimistic id to the server as
-  // messageID, so a confirmed send reappears in snapshots under the SAME id
-  // and is reconciled in place. Between the optimistic insert and that
-  // confirmation, the record is absent from server snapshots; this set is how
-  // hydration knows to PRESERVE it (still pending) versus DROP it (a request
-  // that already failed, or a stale ephemeral record the server does not
-  // know about). Entries are removed on confirmation, on terminal status, and
-  // on explicit send failure (clearSendPending).
+  // Requests awaiting same-ID persistence confirmation.
   const pendingSendIds = new Set<string>()
+  const optimisticPartIdsByMessage = new Map<string, Set<string>>()
+
+  function forgetPendingSend(messageId: string): void {
+    pendingSendIds.delete(messageId)
+    optimisticPartIdsByMessage.delete(messageId)
+  }
+
+  function preservePendingSendOnOmission(messageId: string): boolean {
+    return pendingSendIds.has(messageId)
+  }
 
   function findLastAssistantMessageId(messageIds: readonly string[]): string | undefined {
     for (let index = messageIds.length - 1; index >= 0; index -= 1) {
@@ -500,28 +506,11 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
 
     const serverIds = dedupedInputs.map((item) => item.id)
     const serverIdSet = new Set(serverIds)
+    const serverIdsWithParts = new Set(dedupedInputs.filter((item) => item.parts?.length).map((item) => item.id))
 
-    // Reconcile locally-optimistic "sending" messages against this snapshot.
-    //
-    // When the user sends a message the client creates an optimistic record
-    // with a client-only id (isEphemeral + status "sending"). That id is NOT
-    // sent to the server, so the server confirms the send under a DIFFERENT,
-    // real id. A force reload (triggered by an SSE reconnect) replaces
-    // session.messageIds wholesale with the snapshot's ids, which drops the
-    // optimistic id from the visible list while leaving its record orphaned
-    // in state.messages. Two cases must be handled differently:
-    //
-    //  (A) The snapshot ALREADY contains the server-confirmed counterpart
-    //      (a user message with the same content). Preserving the temp id here
-    //      would leave BOTH visible: the SSE message.updated handler finds
-    //      the real record via getMessage() and never runs the temp-id
-    //      replacement, so the temp bubble is never removed -> visible
-    //      duplicate ("real, temp"). These must be dropped and cleaned up.
-    //
-    //  (B) The snapshot does NOT yet contain the send (server hasn't
-    //      registered it). The bubble must stay visible AND stay in
-    //      messageIds so the eventual SSE echo can swap it in place via
-    //      replaceMessageId. These are preserved.
+    // Preserve only requests that have not received a promptAsync response
+    // yet. Accepted prompts are confirmed under the same messageID, while
+    // rejected requests are marked failed and can be removed by this snapshot.
     const previousMessageIds = state.sessions[sessionId]?.messageIds ?? []
     // For each previous ephemeral "sending" record absent from this snapshot,
     // preserve it ONLY while it is a still-in-flight pending send; otherwise
@@ -529,15 +518,14 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     // authoritative server does not know about — and is dropped so it cannot
     // linger as a permanent "sending" bubble.
     const pendingOptimisticIds: string[] = []
-    const droppedOptimisticIds: string[] = []
+    const omittedIds: string[] = []
     for (const id of previousMessageIds) {
       if (serverIdSet.has(id)) continue
       const record = state.messages[id]
-      if (!record || !record.isEphemeral || record.status !== "sending") continue
-      if (pendingSendIds.has(id)) {
-        pendingOptimisticIds.push(id) // case (B): still in flight — keep visible
+      if (record && preservePendingSendOnOmission(id)) {
+        pendingOptimisticIds.push(id)
       } else {
-        droppedOptimisticIds.push(id) // stale/failed — drop
+        omittedIds.push(id)
       }
     }
 
@@ -588,23 +576,27 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
       nextMessages[id] = record
     })
 
-    // Physically remove stale ephemeral bubbles (a failed send, or an
-    // ephemeral record the authoritative snapshot does not include). Non-store
-    // side effects (caches/overrides) are cleared here; the actual store-key
-    // deletion happens in the batch below via produce, because
-    // setState("messages", () => obj) MERGES and would not drop absent keys.
-    if (droppedOptimisticIds.length > 0) {
-      droppedOptimisticIds.forEach((id) => {
+    // The snapshot is authoritative: remove every omitted record except a
+    // request that is still awaiting same-ID persistence confirmation.
+    if (omittedIds.length > 0) {
+      omittedIds.forEach((id) => {
         messageInfoCache.delete(id)
-        pendingSendIds.delete(id)
+        forgetPendingSend(id)
         clearPromptDisplayOverride(instanceId, sessionId, id)
+        delete nextMessages[id]
+        delete nextMessageInfoVersion[id]
+        delete nextPendingParts[id]
+        delete nextPermissionsByMessage[id]
       })
-      clearRecordDisplayCacheForMessages(instanceId, droppedOptimisticIds)
+      clearRecordDisplayCacheForMessages(instanceId, omittedIds)
     }
 
     // A send that reappears under its own id is confirmed — it is no longer in
     // flight, so retire its pending marker.
-    serverIds.forEach((id) => pendingSendIds.delete(id))
+    serverIds.forEach((id) => {
+      pendingSendIds.delete(id)
+      if (serverIdsWithParts.has(id)) optimisticPartIdsByMessage.delete(id)
+    })
 
     if (infoList) {
       for (const info of infoList) {
@@ -629,13 +621,12 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
       setState("pendingParts", () => nextPendingParts)
       setState("permissions", "byMessage", () => nextPermissionsByMessage)
 
-      // setState with an object merges, so keys removed above (stale
-      // ephemeral bubbles) must be deleted explicitly to actually drop them.
-      if (droppedOptimisticIds.length > 0) {
+      // Solid store object updates merge, so omitted keys are deleted explicitly.
+      if (omittedIds.length > 0) {
         setState(
           "messages",
           produce((draft) => {
-            droppedOptimisticIds.forEach((id) => {
+            omittedIds.forEach((id) => {
               delete draft[id]
             })
           }),
@@ -643,9 +634,39 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
         setState(
           "messageInfoVersion",
           produce((draft) => {
-            droppedOptimisticIds.forEach((id) => {
+            omittedIds.forEach((id) => {
               delete draft[id]
             })
+          }),
+        )
+        setState(
+          "pendingParts",
+          produce((draft) => {
+            omittedIds.forEach((id) => {
+              delete draft[id]
+            })
+          }),
+        )
+        setState(
+          "permissions",
+          produce((draft) => {
+            const omitted = new Set(omittedIds)
+            omittedIds.forEach((id) => {
+              delete draft.byMessage[id]
+            })
+            draft.queue = draft.queue.filter((entry) => !entry.messageId || !omitted.has(entry.messageId))
+            draft.active = draft.queue[0] ?? null
+          }),
+        )
+        setState(
+          "questions",
+          produce((draft) => {
+            const omitted = new Set(omittedIds)
+            omittedIds.forEach((id) => {
+              delete draft.byMessage[id]
+            })
+            draft.queue = draft.queue.filter((entry) => !entry.messageId || !omitted.has(entry.messageId))
+            draft.active = draft.queue[0] ?? null
           }),
         )
       }
@@ -661,6 +682,7 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
       }))
       recomputeLastAssistantMessageId(sessionId, incomingIds)
 
+      clearLatestTodoSnapshot(sessionId)
       Object.values(normalizedRecords).forEach((record) => {
         maybeUpdateLatestTodoFromRecord(record)
       })
@@ -669,18 +691,87 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     })
   }
 
-  // Register an optimistic user send as in-flight. Called right after the
-  // optimistic record is inserted, so hydration preserves it until the server
-  // confirms it (same id) or the request fails (clearSendPending).
+  // Register an optimistic user send while promptAsync is unresolved.
   function markSendPending(messageId: string) {
-    if (messageId) pendingSendIds.add(messageId)
+    if (!messageId) return
+    pendingSendIds.add(messageId)
+    const record = state.messages[messageId]
+    optimisticPartIdsByMessage.set(messageId, new Set(record?.partIds ?? []))
   }
 
-  // Retire an optimistic send's in-flight marker. Called on a definitive
-  // send failure (promptAsync rejection) so a later authoritative snapshot
-  // no longer preserves the failed bubble.
-  function clearSendPending(messageId: string) {
+  function updateSendRecord(messageId: string, status: "sent" | "error") {
+    const record = state.messages[messageId]
+    if (!record || (record.status !== "sending" && !(status === "error" && record.status === "sent"))) return
+    setState(
+      "messages",
+      messageId,
+      produce((draft) => {
+        draft.status = status
+        draft.isEphemeral = status === "error"
+        draft.updatedAt = Date.now()
+        draft.revision += 1
+      }),
+    )
+    bumpSessionRevision(record.sessionId)
+  }
+
+  // A 204 response means processing was accepted, but the marker remains until
+  // REST or SSE confirms persistence under the same messageID.
+  function acceptSend(messageId: string) {
+    updateSendRecord(messageId, "sent")
+  }
+
+  function confirmServerMessage(messageId: string, options?: { clearOptimisticParts?: boolean }) {
+    const clientPartIds = optimisticPartIdsByMessage.get(messageId)
     pendingSendIds.delete(messageId)
+    if (options?.clearOptimisticParts) optimisticPartIdsByMessage.delete(messageId)
+    const record = state.messages[messageId]
+    if (!record) return
+    const optimisticPartIds = options?.clearOptimisticParts && record.role === "user"
+      ? record.partIds.filter((id) => clientPartIds?.has(id))
+      : []
+    const shouldSettleUser = record.role === "user" && (record.status === "sending" || record.status === "error")
+    const changed = Boolean(record.isEphemeral || optimisticPartIds.length > 0 || shouldSettleUser)
+    if (!changed) return
+    setState(
+      "messages",
+      messageId,
+      produce((draft) => {
+        draft.isEphemeral = false
+        if (shouldSettleUser) draft.status = "sent"
+        if (optimisticPartIds.length > 0) {
+          const optimisticIds = new Set(optimisticPartIds)
+          draft.partIds = draft.partIds.filter((id) => !optimisticIds.has(id))
+          optimisticPartIds.forEach((id) => {
+            delete draft.parts[id]
+          })
+        }
+        draft.updatedAt = Date.now()
+        draft.revision += 1
+      }),
+    )
+    bumpSessionRevision(record.sessionId)
+  }
+
+  // Request preparation or prompt submission failed. Keep an error bubble
+  // until the next authoritative snapshot rather than preserving "sending".
+  function failSend(messageId: string) {
+    if (!pendingSendIds.has(messageId)) return
+    pendingSendIds.delete(messageId)
+    updateSendRecord(messageId, "error")
+  }
+
+  function failPendingSends(sessionId: string) {
+    for (const messageId of Array.from(pendingSendIds)) {
+      if (state.messages[messageId]?.sessionId === sessionId) failSend(messageId)
+    }
+  }
+
+  function retirePendingSends(sessionId: string) {
+    for (const messageId of Array.from(pendingSendIds)) {
+      const record = state.messages[messageId]
+      if (record?.sessionId === sessionId && record.status === "sent") pendingSendIds.delete(messageId)
+    }
   }
 
   // Apply an AUTHORITATIVE empty snapshot (server returned zero messages for
@@ -695,7 +786,7 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     const droppedIds: string[] = []
     for (const id of previousMessageIds) {
       const record = state.messages[id]
-      if (record && record.isEphemeral && record.status === "sending" && pendingSendIds.has(id)) {
+      if (record && preservePendingSendOnOmission(id)) {
         keptPendingIds.push(id)
       } else {
         droppedIds.push(id)
@@ -705,7 +796,7 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
 
     droppedIds.forEach((id) => {
       messageInfoCache.delete(id)
-      pendingSendIds.delete(id)
+      forgetPendingSend(id)
       clearPromptDisplayOverride(instanceId, sessionId, id)
     })
     clearRecordDisplayCacheForMessages(instanceId, droppedIds)
@@ -727,6 +818,38 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
           })
         }),
       )
+      setState(
+        "pendingParts",
+        produce((draft) => {
+          droppedIds.forEach((id) => {
+            delete draft[id]
+          })
+        }),
+      )
+      setState(
+        "permissions",
+        produce((draft) => {
+          const dropped = new Set(droppedIds)
+          droppedIds.forEach((id) => {
+            delete draft.byMessage[id]
+          })
+          draft.queue = draft.queue.filter((entry) => !entry.messageId || !dropped.has(entry.messageId))
+          draft.active = draft.queue[0] ?? null
+        }),
+      )
+      setState(
+        "questions",
+        produce((draft) => {
+          const dropped = new Set(droppedIds)
+          droppedIds.forEach((id) => {
+            delete draft.byMessage[id]
+          })
+          draft.queue = draft.queue.filter((entry) => !entry.messageId || !dropped.has(entry.messageId))
+          draft.active = draft.queue[0] ?? null
+        }),
+      )
+      setState("usage", sessionId, createEmptyUsageState())
+      setState("latestTodos", sessionId, undefined)
       setState("sessions", sessionId, (current) => ({
         ...current,
         messageIds: keptPendingIds,
@@ -970,7 +1093,7 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
   function removeMessage(messageId: string, fallbackSessionId?: string) {
     if (!messageId) return
 
-    pendingSendIds.delete(messageId)
+    forgetPendingSend(messageId)
 
     const record = state.messages[messageId]
     const sessionIds = new Set<string>()
@@ -1097,8 +1220,11 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
 
     // The optimistic send is now confirmed under its real id; retire the
     // pending marker (carry it to the new id only if still mid-flight).
-    if (pendingSendIds.delete(options.oldId) && existing.isEphemeral && existing.status === "sending") {
+    if (pendingSendIds.has(options.oldId) && existing.isEphemeral && existing.status === "sending") {
+      const optimisticParts = optimisticPartIdsByMessage.get(options.oldId)
+      forgetPendingSend(options.oldId)
       pendingSendIds.add(options.newId)
+      if (optimisticParts) optimisticPartIdsByMessage.set(options.newId, optimisticParts)
     }
 
     const cloned: MessageRecord = {
@@ -1479,7 +1605,7 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
  
     storeLog.info("Clearing session data", { instanceId, sessionId, messageCount: messageIds.length })
     clearRecordDisplayCacheForMessages(instanceId, messageIds)
-    messageIds.forEach((id) => pendingSendIds.delete(id))
+    messageIds.forEach((id) => forgetPendingSend(id))
  
     batch(() => {
       setState("messages", (prev) => {
@@ -1575,6 +1701,7 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
      clearPromptDisplayOverridesForInstance(instanceId, Object.keys(state.sessions))
      messageInfoCache.clear()
      pendingSendIds.clear()
+     optimisticPartIdsByMessage.clear()
       setState(reconcile(createInitialState(instanceId)))
     }
 
@@ -1591,7 +1718,11 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
       hydrateMessages,
       reconcileEmptyAuthoritativeSnapshot,
       markSendPending,
-      clearSendPending,
+      acceptSend,
+      confirmServerMessage,
+      failSend,
+      failPendingSends,
+      retirePendingSends,
       upsertMessage,
       applyPartUpdate,
       applyPartDelta,

--- a/packages/ui/src/stores/message-v2/instance-store.ts
+++ b/packages/ui/src/stores/message-v2/instance-store.ts
@@ -463,30 +463,38 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
   // counterpart during hydration: the client temp id and the real server id
   // differ, so content is the only stable link. Covers text-only, attachment-
   // only, and mixed sends. Non-content parts (tool/reasoning/etc.) are ignored.
-  function partContentToken(part: ClientPart | undefined): string | null {
+  //
+  // The signature is a JSON-serialized array of typed tokens: escaping makes
+  // delimiter/whitespace collisions impossible (under the previous newline-
+  // joined string form, parts ["A","B"] collided with one part "A\nT:B", and
+  // .trim() collapsed trailing whitespace). Returns null when the message has
+  // no content parts at all — there is nothing to match on.
+  type MessageContentToken =
+    | readonly [type: "text", text: string]
+    | readonly [type: "file", filename: string, url: string, mime: string]
+
+  function partContentToken(part: ClientPart | undefined): MessageContentToken | null {
     if (!part) return null
-    if (part.type === "text") return `T:${(part as { text?: string }).text ?? ""}`
+    if (part.type === "text") return ["text", (part as { text?: string }).text ?? ""]
     if (part.type === "file") {
       const p = part as { filename?: string; url?: string; mime?: string }
-      return `F:${p.filename ?? ""}:${p.url ?? ""}:${p.mime ?? ""}`
+      return ["file", p.filename ?? "", p.url ?? "", p.mime ?? ""]
     }
     return null
   }
 
-  function recordContentSignature(partIds: string[], parts: MessageRecord["parts"]): string {
-    return partIds
-      .map((partId) => partContentToken(parts[partId]?.data))
-      .filter((token): token is string => token !== null)
-      .join("\n")
-      .trim()
+  function signatureFromTokens(tokens: Array<MessageContentToken | null>): string | null {
+    const content = tokens.filter((token): token is MessageContentToken => token !== null)
+    if (content.length === 0) return null
+    return JSON.stringify(content)
   }
 
-  function inputContentSignature(parts: ClientPart[] | undefined): string {
-    return (parts ?? [])
-      .map((part) => partContentToken(part))
-      .filter((token): token is string => token !== null)
-      .join("\n")
-      .trim()
+  function recordContentSignature(partIds: string[], parts: MessageRecord["parts"]): string | null {
+    return signatureFromTokens(partIds.map((partId) => partContentToken(parts[partId]?.data)))
+  }
+
+  function inputContentSignature(parts: ClientPart[] | undefined): string | null {
+    return signatureFromTokens((parts ?? []).map((part) => partContentToken(part)))
   }
 
   function hydrateMessages(sessionId: string, inputs: MessageUpsertInput[], infos?: Iterable<MessageInfo>) {
@@ -520,31 +528,55 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     //      replaceMessageId. These are preserved.
     const previousMessageIds = state.sessions[sessionId]?.messageIds ?? []
     const previousMessageIdSet = new Set(previousMessageIds)
-    // Content signatures of user messages the server returned this snapshot
-    // under a NEW id (not already in messageIds). Restricting to new ids is
-    // what makes a confirmation distinguishable from a pre-existing older
-    // message with identical content: a send's confirmation always arrives as
-    // a new server id, so an in-flight duplicate-text send ("ok" sent twice)
-    // is not falsely matched against the earlier, already-loaded "ok".
-    const serverUserContentSignatures = new Set(
-      inputs
-        .filter((input) => input.role === "user" && !previousMessageIdSet.has(input.id))
-        .map((input) => inputContentSignature(input.parts))
-        .filter((signature) => signature.length > 0),
-    )
+    // Candidate confirmations: user messages the server returned under a NEW
+    // id (not already in messageIds), indexed by content signature as FIFO
+    // queues. Restricting to new ids is what makes a confirmation
+    // distinguishable from a pre-existing older message with identical
+    // content: a send's confirmation always arrives as a new server id, so an
+    // in-flight duplicate-text send ("ok" sent twice) is not falsely matched
+    // against the earlier, already-loaded "ok".
+    //
+    // Each candidate is CONSUMED on match (one-to-one, in send/snapshot
+    // order): with two simultaneous "ok" sends and only one confirmation
+    // back, the first temp is superseded and the second stays pending —
+    // shared set membership would wrongly drop both.
+    const candidatesBySignature = new Map<string, string[]>()
+    inputs.forEach((input) => {
+      if (input.role !== "user" || previousMessageIdSet.has(input.id)) return
+      const signature = inputContentSignature(input.parts)
+      if (signature === null) return
+      const queue = candidatesBySignature.get(signature)
+      if (queue) {
+        queue.push(input.id)
+      } else {
+        candidatesBySignature.set(signature, [input.id])
+      }
+    })
     const pendingOptimisticIds: string[] = []
     const supersededOptimisticIds: string[] = []
+    // temp id -> confirming server id, so the superseded bubble's client-only
+    // prompt-display metadata can be transferred to the real record below
+    // (the SSE replaceMessageId path does the same via movePromptDisplayOverride).
+    const supersededByServerId = new Map<string, string>()
     for (const id of previousMessageIds) {
       if (serverIdSet.has(id)) continue
       const record = state.messages[id]
       if (!record || !record.isEphemeral || record.status !== "sending") continue
       const signature = recordContentSignature(record.partIds, record.parts)
-      if (signature.length > 0 && serverUserContentSignatures.has(signature)) {
+      const queue = signature !== null ? candidatesBySignature.get(signature) : undefined
+      if (queue && queue.length > 0) {
+        const serverId = queue.shift() as string
         supersededOptimisticIds.push(id) // case (A)
+        supersededByServerId.set(id, serverId)
       } else {
         pendingOptimisticIds.push(id) // case (B)
       }
     }
+    // Reverse lookup for the normalize loop: server id -> superseded temp id.
+    const tempIdByServerId = new Map<string, string>()
+    supersededByServerId.forEach((serverId, tempId) => {
+      tempIdByServerId.set(serverId, tempId)
+    })
 
     const incomingIds = pendingOptimisticIds.length > 0 ? [...serverIds, ...pendingOptimisticIds] : serverIds
 
@@ -559,7 +591,14 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
         : false
       const statusChanged = previous ? previous.status !== input.status : true
       const shouldBump = Boolean(input.bumpRevision || partsChanged || statusChanged)
-      const clientPromptDisplayMetadata = resolveClientPromptDisplayText(instanceId, input, previous)
+      // When this server record confirms an optimistic send under a new id,
+      // the optimistic record carries the client-only prompt-display metadata
+      // (the server never sees it). Use it as the metadata fallback so the
+      // replacement keeps the pasted-text/path presentation the SSE
+      // replaceMessageId path would have preserved.
+      const supersededTempId = tempIdByServerId.get(input.id)
+      const metadataFallback = previous ?? (supersededTempId ? state.messages[supersededTempId] : undefined)
+      const clientPromptDisplayMetadata = resolveClientPromptDisplayText(instanceId, input, metadataFallback)
       normalizedRecords[input.id] = {
         id: input.id,
         sessionId: input.sessionId,
@@ -598,7 +637,14 @@ export function createInstanceMessageStore(instanceId: string, hooks?: MessageSt
     if (supersededOptimisticIds.length > 0) {
       supersededOptimisticIds.forEach((id) => {
         messageInfoCache.delete(id)
-        clearPromptDisplayOverride(instanceId, sessionId, id)
+        // Transfer (not just clear) the persisted prompt-display override to
+        // the confirming server id, mirroring replaceMessageId.
+        const serverId = supersededByServerId.get(id)
+        if (serverId) {
+          movePromptDisplayOverride(instanceId, sessionId, id, serverId)
+        } else {
+          clearPromptDisplayOverride(instanceId, sessionId, id)
+        }
       })
       clearRecordDisplayCacheForMessages(instanceId, supersededOptimisticIds)
     }

--- a/packages/ui/src/stores/message-v2/message-status.test.ts
+++ b/packages/ui/src/stores/message-v2/message-status.test.ts
@@ -4,22 +4,30 @@ import { describe, it } from "node:test"
 import { deriveMessageStatus } from "./message-status.ts"
 
 // This derivation is the single source of truth shared by the live SSE path
-// (session-events) and the REST snapshot path (session-api). It must behave
-// identically for user and assistant infos — a user message without a
-// recorded end time is just as in-flight as an assistant one.
+// (session-events) and the REST snapshot path (session-api). It follows the
+// OpenCode SDK contract: assistant completion is `time.completed`; user
+// messages are complete once persisted; only assistants carry `error`.
 describe("deriveMessageStatus", () => {
-  it("derives streaming when no end time is recorded", () => {
-    assert.equal(deriveMessageStatus({ time: {} }), "streaming")
-    assert.equal(deriveMessageStatus({ time: { end: 0 } }), "streaming")
-    assert.equal(deriveMessageStatus({}), "streaming")
+  it("treats persisted user messages as complete (no server pending state)", () => {
+    assert.equal(deriveMessageStatus({ role: "user", time: { } }), "complete")
+    assert.equal(deriveMessageStatus({ role: "user", time: { completed: undefined } }), "complete")
   })
 
-  it("derives complete once an end time is recorded", () => {
-    assert.equal(deriveMessageStatus({ time: { end: 1720000000000 } }), "complete")
+  it("derives assistant completion from time.completed", () => {
+    assert.equal(deriveMessageStatus({ role: "assistant", time: { completed: 1720000000000 } }), "complete")
   })
 
-  it("derives error when an error is present, regardless of end time", () => {
-    assert.equal(deriveMessageStatus({ error: { name: "Error", data: {} } }), "error")
-    assert.equal(deriveMessageStatus({ error: { name: "Error", data: {} }, time: { end: 1720000000000 } }), "error")
+  it("derives assistant streaming when time.completed is absent or zero", () => {
+    assert.equal(deriveMessageStatus({ role: "assistant", time: {} }), "streaming")
+    assert.equal(deriveMessageStatus({ role: "assistant", time: { completed: 0 } }), "streaming")
+    assert.equal(deriveMessageStatus({ role: "assistant" }), "streaming")
+  })
+
+  it("derives error when an assistant error is present, regardless of completion", () => {
+    assert.equal(deriveMessageStatus({ role: "assistant", error: { name: "Error", data: {} } }), "error")
+    assert.equal(
+      deriveMessageStatus({ role: "assistant", error: { name: "Error", data: {} }, time: { completed: 1720000000000 } }),
+      "error",
+    )
   })
 })

--- a/packages/ui/src/stores/message-v2/message-status.test.ts
+++ b/packages/ui/src/stores/message-v2/message-status.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { deriveMessageStatus } from "./message-status.ts"
+
+// This derivation is the single source of truth shared by the live SSE path
+// (session-events) and the REST snapshot path (session-api). It must behave
+// identically for user and assistant infos — a user message without a
+// recorded end time is just as in-flight as an assistant one.
+describe("deriveMessageStatus", () => {
+  it("derives streaming when no end time is recorded", () => {
+    assert.equal(deriveMessageStatus({ time: {} }), "streaming")
+    assert.equal(deriveMessageStatus({ time: { end: 0 } }), "streaming")
+    assert.equal(deriveMessageStatus({}), "streaming")
+  })
+
+  it("derives complete once an end time is recorded", () => {
+    assert.equal(deriveMessageStatus({ time: { end: 1720000000000 } }), "complete")
+  })
+
+  it("derives error when an error is present, regardless of end time", () => {
+    assert.equal(deriveMessageStatus({ error: { name: "Error", data: {} } }), "error")
+    assert.equal(deriveMessageStatus({ error: { name: "Error", data: {} }, time: { end: 1720000000000 } }), "error")
+  })
+})

--- a/packages/ui/src/stores/message-v2/message-status.ts
+++ b/packages/ui/src/stores/message-v2/message-status.ts
@@ -2,15 +2,24 @@ import type { MessageStatus } from "./types"
 
 /**
  * Single source of truth for deriving a message's lifecycle status from its
- * server-side info (`error` + `time.end`). Used by BOTH the live SSE path
- * (session-events) and the REST snapshot path (session-api) so a force-reload
- * can never disagree with the streaming derivation — for either role. A user
- * message without `time.end` is just as in-flight as an assistant one: the
- * server may simply not have recorded the end yet when the snapshot was
- * taken, and forcing it to "complete" would disagree with the SSE echo.
+ * server-side info, shared by the live SSE path (session-events) and the REST
+ * snapshot path (session-api) so a force-reload can never disagree with the
+ * streaming derivation.
+ *
+ * Follows the OpenCode SDK contract (1.17.x):
+ *   - Only assistant messages carry `error` and a completion timestamp.
+ *   - Assistant completion is `time.completed` (NOT `time.end`, which is a
+ *     part-level field, not message completion).
+ *   - User messages expose only `time.created` and are complete once
+ *     persisted — they have no pending/streaming server state.
  */
-export function deriveMessageStatus(info: { error?: unknown; time?: { end?: number } | null }): MessageStatus {
-  const hasError = Boolean(info.error)
-  const hasEnded = typeof info.time?.end === "number" && info.time.end > 0
-  return hasError ? "error" : hasEnded ? "complete" : "streaming"
+export function deriveMessageStatus(info: {
+  role?: string
+  error?: unknown
+  time?: { completed?: number } | null
+}): MessageStatus {
+  if (info.error) return "error"
+  if (info.role === "user") return "complete"
+  const completed = info.time?.completed
+  return typeof completed === "number" && completed > 0 ? "complete" : "streaming"
 }

--- a/packages/ui/src/stores/message-v2/message-status.ts
+++ b/packages/ui/src/stores/message-v2/message-status.ts
@@ -1,0 +1,16 @@
+import type { MessageStatus } from "./types"
+
+/**
+ * Single source of truth for deriving a message's lifecycle status from its
+ * server-side info (`error` + `time.end`). Used by BOTH the live SSE path
+ * (session-events) and the REST snapshot path (session-api) so a force-reload
+ * can never disagree with the streaming derivation — for either role. A user
+ * message without `time.end` is just as in-flight as an assistant one: the
+ * server may simply not have recorded the end yet when the snapshot was
+ * taken, and forcing it to "complete" would disagree with the SSE echo.
+ */
+export function deriveMessageStatus(info: { error?: unknown; time?: { end?: number } | null }): MessageStatus {
+  const hasError = Boolean(info.error)
+  const hasEnded = typeof info.time?.end === "number" && info.time.end > 0
+  return hasError ? "error" : hasEnded ? "complete" : "streaming"
+}

--- a/packages/ui/src/stores/opencode-workspaces.ts
+++ b/packages/ui/src/stores/opencode-workspaces.ts
@@ -33,6 +33,7 @@ type OpenCodeWorkspace = {
 }
 
 const workspaceIdByWorktreeSlug = new Map<string, Map<string, string>>()
+const workspaceIdBySession = new Map<string, Map<string, string>>()
 const workspaceSyncs = new Map<string, Promise<void>>()
 
 async function getInstance(instanceId: string) {
@@ -46,7 +47,20 @@ function getCachedOpenCodeWorkspaceIdForWorktree(instanceId: string, slug: strin
 }
 
 function getCachedOpenCodeWorkspaceIdForSession(instanceId: string, sessionId: string): string | null {
-  return getCachedOpenCodeWorkspaceIdForWorktree(instanceId, getWorktreeSlugForSession(instanceId, sessionId))
+  return workspaceIdBySession.get(instanceId)?.get(sessionId)
+    ?? getCachedOpenCodeWorkspaceIdForWorktree(instanceId, getWorktreeSlugForSession(instanceId, sessionId))
+}
+
+function rememberOpenCodeWorkspaceIdForSession(instanceId: string, sessionId: string, workspaceId: string): void {
+  const sessions = workspaceIdBySession.get(instanceId) ?? new Map<string, string>()
+  sessions.set(sessionId, workspaceId)
+  workspaceIdBySession.set(instanceId, sessions)
+}
+
+function forgetOpenCodeWorkspaceIdForSession(instanceId: string, sessionId: string): void {
+  const sessions = workspaceIdBySession.get(instanceId)
+  sessions?.delete(sessionId)
+  if (sessions?.size === 0) workspaceIdBySession.delete(instanceId)
 }
 
 async function syncOpenCodeWorkspaces(instanceId: string): Promise<void> {
@@ -103,6 +117,8 @@ async function getOpenCodeWorkspaceIdForWorktree(instanceId: string, slug: strin
 }
 
 async function getOpenCodeWorkspaceIdForSession(instanceId: string, sessionId: string): Promise<string | null> {
+  const cached = getCachedOpenCodeWorkspaceIdForSession(instanceId, sessionId)
+  if (cached) return cached
   const slug = getWorktreeSlugForSession(instanceId, sessionId)
   return getOpenCodeWorkspaceIdForWorktree(instanceId, slug)
 }
@@ -110,6 +126,7 @@ async function getOpenCodeWorkspaceIdForSession(instanceId: string, sessionId: s
 function clearOpenCodeWorkspaceCache(instanceId: string): void {
   workspaceSyncs.delete(instanceId)
   workspaceIdByWorktreeSlug.delete(instanceId)
+  workspaceIdBySession.delete(instanceId)
 }
 
 async function removeOpenCodeWorkspaceForWorktree(instanceId: string, slug: string): Promise<void> {
@@ -132,6 +149,8 @@ export {
   getCachedOpenCodeWorkspaceIdForWorktree,
   getOpenCodeWorkspaceIdForSession,
   getOpenCodeWorkspaceIdForWorktree,
+  forgetOpenCodeWorkspaceIdForSession,
+  rememberOpenCodeWorkspaceIdForSession,
   reloadOpenCodeWorkspaces,
   removeOpenCodeWorkspaceForWorktree,
   syncOpenCodeWorkspaces,

--- a/packages/ui/src/stores/permission-lifecycle.test.ts
+++ b/packages/ui/src/stores/permission-lifecycle.test.ts
@@ -5,9 +5,15 @@ import { sdkManager } from "../lib/sdk-manager"
 import type { Instance } from "../types/instance"
 import {
   addInstance,
+  addPermissionToQueue,
+  addQuestionToQueue,
   clearPermissionQueue,
+  clearQuestionQueue,
   getPermissionQueue,
+  getQuestionQueue,
   sendPermissionResponse,
+  syncPendingRequests,
+  updateInstance,
 } from "./instances"
 import { messageStoreBus } from "./message-v2/bus"
 import { handlePermissionUpdated } from "./session-events"
@@ -31,6 +37,7 @@ function addTestInstance(id: string, client: OpencodeClient): void {
 afterEach(() => {
   for (const instanceId of instanceIds.splice(0)) {
     clearPermissionQueue(instanceId)
+    clearQuestionQueue(instanceId)
     messageStoreBus.unregisterInstance(instanceId)
     sdkManager.destroyClientsForInstance(instanceId)
   }
@@ -93,4 +100,61 @@ test("standalone permission.updated remains a legacy permission request", async 
 
   assert.equal(legacyReplies, 1)
   assert.equal(v2Replies, 0)
+})
+
+test("pending request sync cannot erase newer SSE mutations", async () => {
+  const newPermission = {
+    id: "new-permission", sessionID: "session", permission: "edit", patterns: ["*"], metadata: {},
+  }
+  const newQuestion = { id: "new-question", sessionID: "session", questions: [] }
+  let resolvePermissions!: (value: { data: never[] }) => void
+  let resolveQuestions!: (value: { data: never[] }) => void
+  let permissionCalls = 0
+  let questionCalls = 0
+  const client = {
+    permission: { list: () => ++permissionCalls === 1
+      ? new Promise((resolve) => { resolvePermissions = resolve })
+      : Promise.resolve({ data: [newPermission] }) },
+    question: { list: () => ++questionCalls === 1
+      ? new Promise((resolve) => { resolveQuestions = resolve })
+      : Promise.resolve({ data: [newQuestion] }) },
+    v2: {
+      permission: { request: { list: async () => ({ data: { data: [] } }) } },
+      question: { request: { list: async () => ({ data: { data: [] } }) } },
+    },
+  } as unknown as OpencodeClient
+  addTestInstance("pending-request-race", client)
+  addPermissionToQueue("pending-request-race", { id: "stale-permission", sessionID: "session" } as never)
+  addQuestionToQueue("pending-request-race", { id: "stale-question", sessionID: "session" } as never)
+
+  const sync = syncPendingRequests("pending-request-race")
+  assert.equal(syncPendingRequests("pending-request-race"), sync)
+  await new Promise<void>((resolve) => setImmediate(resolve))
+  updateInstance("pending-request-race", { pid: 2 })
+  addPermissionToQueue("pending-request-race", newPermission as never)
+  addQuestionToQueue("pending-request-race", newQuestion as never)
+  resolvePermissions({ data: [] })
+  resolveQuestions({ data: [] })
+
+  await sync
+  assert.deepEqual(getPermissionQueue("pending-request-race").map(({ id }) => id), ["new-permission"])
+  assert.deepEqual(getQuestionQueue("pending-request-race").map(({ id }) => id), ["new-question"])
+})
+
+test("pending request sync still loads V2 requests when legacy listing fails", async () => {
+  const client = {
+    permission: { list: async () => ({ error: { message: "legacy unavailable" } }) },
+    question: { list: async () => ({ data: [] }) },
+    v2: {
+      permission: { request: { list: async () => ({ data: { data: [{
+        id: "v2-permission", sessionID: "session", permission: "edit", patterns: ["*"], metadata: {},
+      }] } }) } },
+      question: { request: { list: async () => ({ data: { data: [] } }) } },
+    },
+  } as unknown as OpencodeClient
+  addTestInstance("partial-pending-api", client)
+
+  await syncPendingRequests("partial-pending-api")
+
+  assert.deepEqual(getPermissionQueue("partial-pending-api").map(({ id }) => id), ["v2-permission"])
 })

--- a/packages/ui/src/stores/session-actions.ts
+++ b/packages/ui/src/stores/session-actions.ts
@@ -185,9 +185,7 @@ async function sendMessage(
     clientPromptDisplayMetadata: preparedPrompt.displayMetadata,
   })
 
-  // Register the optimistic send as in-flight so an authoritative snapshot
-  // (e.g. a reconnect force-reload) preserves it until the server confirms it
-  // under the same id or the request fails below.
+  // Preserve the optimistic bubble only while promptAsync is unresolved.
   store.markSendPending(messageId)
 
   withSession(instanceId, sessionId, () => {
@@ -238,14 +236,13 @@ async function sendMessage(
         "session.promptAsync",
       )
       admission.complete()
+      store.acceptSend(messageId)
     } catch (error) {
       admission.rollback()
-      // The send definitively failed: retire the in-flight marker so a later
-      // authoritative snapshot no longer preserves this optimistic bubble.
-      store.clearSendPending(messageId)
       throw error
     }
   } catch (error) {
+    store.failSend(messageId)
     log.error("Failed to send prompt", error)
     throw error
   }

--- a/packages/ui/src/stores/session-actions.ts
+++ b/packages/ui/src/stores/session-actions.ts
@@ -190,6 +190,12 @@ async function sendMessage(
   })
 
   const requestBody = {
+    // Send the optimistic message id so the server confirms THIS send under
+    // the same id. Hydration then reconciles by identity (same id in the
+    // snapshot) instead of content matching, and the SSE echo updates the
+    // existing record in place — no duplicate bubble, no ambiguity between
+    // identical texts.
+    messageID: messageId,
     parts: requestParts,
     ...(session.agent && { agent: session.agent }),
     ...(session.model.providerId &&

--- a/packages/ui/src/stores/session-actions.ts
+++ b/packages/ui/src/stores/session-actions.ts
@@ -185,6 +185,11 @@ async function sendMessage(
     clientPromptDisplayMetadata: preparedPrompt.displayMetadata,
   })
 
+  // Register the optimistic send as in-flight so an authoritative snapshot
+  // (e.g. a reconnect force-reload) preserves it until the server confirms it
+  // under the same id or the request fails below.
+  store.markSendPending(messageId)
+
   withSession(instanceId, sessionId, () => {
     /* trigger reactivity for legacy session data */
   })
@@ -235,6 +240,9 @@ async function sendMessage(
       admission.complete()
     } catch (error) {
       admission.rollback()
+      // The send definitively failed: retire the in-flight marker so a later
+      // authoritative snapshot no longer preserves this optimistic bubble.
+      store.clearSendPending(messageId)
       throw error
     }
   } catch (error) {

--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -56,6 +56,7 @@ import {
 import { deleteSessionAttachments } from "./attachments"
 import { DEFAULT_MODEL_OUTPUT_LIMIT, getDefaultModel, isModelValid } from "./session-models"
 import { normalizeMessagePart } from "./message-v2/normalizers"
+import { deriveMessageStatus } from "./message-v2/message-status"
 import { updateSessionInfo } from "./message-v2/session-info"
 import { seedSessionMessagesV2, reconcilePendingPermissionsV2, reconcilePendingQuestionsV2 } from "./message-v2/bridge"
 import { messageStoreBus } from "./message-v2/bus"
@@ -1129,15 +1130,13 @@ async function loadMessages(
         const parts: any[] = (apiMessage.parts || []).map((part: any) => normalizeMessagePart(part))
 
         // Derive the real status instead of forcing "complete": a forced
-        // refresh (e.g. after an SSE reconnect) can load an assistant message
-        // that is still generating (no end time). Marking it "complete" would
+        // refresh (e.g. after an SSE reconnect) can load a message whose end
+        // time the server has not recorded yet. Marking it "complete" would
         // demote an in-flight message and disable streaming-specific UI until
-        // the next qualifying SSE update arrives. User messages are always
-        // complete; only assistant messages without an end time stream.
-        const hasError = Boolean(info.error)
-        const hasEnded = typeof info.time?.end === "number" && info.time.end > 0
-        const status: Message["status"] =
-          role === "user" ? "complete" : hasError ? "error" : hasEnded ? "complete" : "streaming"
+        // the next qualifying SSE update arrives. The derivation is shared
+        // with the live SSE path (deriveMessageStatus) for BOTH roles, so a
+        // user message without time.end is treated identically either way.
+        const status: Message["status"] = deriveMessageStatus(info)
 
         const message: Message = {
           id: messageId,

--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -30,6 +30,7 @@ import {
   setAgents,
   setMessagesLoaded,
   advanceMessageLoadEpoch,
+  invalidateSessionMessageLoad,
   isCurrentMessageLoad,
   setSessionMessagesLoadError,
   setProviders,
@@ -74,7 +75,12 @@ import {
   removeLegacyParentSessionMapping,
   setWorktreeSlugForParentSession,
 } from "./worktrees"
-import { getOpenCodeWorkspaceIdForSession, getOpenCodeWorkspaceIdForWorktree } from "./opencode-workspaces"
+import {
+  forgetOpenCodeWorkspaceIdForSession,
+  getOpenCodeWorkspaceIdForSession,
+  getOpenCodeWorkspaceIdForWorktree,
+  rememberOpenCodeWorkspaceIdForSession,
+} from "./opencode-workspaces"
 import { hydrateSessionMetadataWithClient } from "./session-metadata"
 import { preferSessionMetadata, shouldReplaceSessionMetadata } from "./session-metadata-completeness"
 import {
@@ -85,6 +91,7 @@ import {
   isProjectSessionListComplete,
 } from "./session-list-options"
 import { mergeFetchedSessionRuntimeState, resolveAuthoritativeGenerationRecovery } from "./session-generation-recovery"
+import { normalizeWorkspacePath } from "./app-session-reconciliation"
 
 const log = getLogger("api")
 const sessionListRequestIds = new Map<string, number>()
@@ -152,11 +159,29 @@ function rememberSessionWorkspace(instanceId: string, sessionId: string, workspa
   sessionWorkspaceHints.set(instanceId, hints)
 }
 
-async function recordSessionWorkspaceHints(instanceId: string, apiSessions: SDKSession[]): Promise<void> {
+async function recordSessionWorkspaceHints(
+  instanceId: string,
+  apiSessions: SDKSession[],
+  isCurrent: () => boolean,
+): Promise<void> {
   const hints = new Map(sessionWorkspaceHints.get(instanceId) ?? new Map<string, string>())
+  apiSessions.forEach((session) => hints.delete(session.id))
   const workspaceBySlug = new Map<string, Promise<string | null>>()
+  const explicitWorkspaceBySession = new Map<string, string>()
   await Promise.all(apiSessions.map(async (session) => {
-    const directory = (session as SDKSession & { directory?: string }).directory
+    const located = session as SDKSession & {
+      directory?: string
+      workspace?: string
+      workspaceID?: string
+      workspaceId?: string
+    }
+    const explicitWorkspace = located.workspace ?? located.workspaceID ?? located.workspaceId
+    if (explicitWorkspace) {
+      hints.set(session.id, explicitWorkspace)
+      explicitWorkspaceBySession.set(session.id, explicitWorkspace)
+      return
+    }
+    const directory = located.directory
     const slug = getWorktreeSlugForDirectory(instanceId, directory)
     if (!slug || slug === "root") return
     let workspace = workspaceBySlug.get(slug)
@@ -167,7 +192,12 @@ async function recordSessionWorkspaceHints(instanceId: string, apiSessions: SDKS
     const workspaceId = await workspace
     if (workspaceId) hints.set(session.id, workspaceId)
   }))
+  if (!isCurrent()) return
   sessionWorkspaceHints.set(instanceId, hints)
+  for (const session of apiSessions) forgetOpenCodeWorkspaceIdForSession(instanceId, session.id)
+  for (const [sessionId, workspaceId] of explicitWorkspaceBySession) {
+    rememberOpenCodeWorkspaceIdForSession(instanceId, sessionId, workspaceId)
+  }
 }
 
 interface SessionForkResponse {
@@ -385,7 +415,11 @@ async function ensureV2ParentChainsLoaded(instanceId: string, apiSessions: SDKSe
   })
 }
 
-async function fetchSessions(instanceId: string, options?: { reset?: boolean }): Promise<void> {
+async function fetchSessions(instanceId: string, options?: {
+  reset?: boolean
+  strictStatus?: boolean
+  registerInvalidation?: (invalidate: () => void) => void
+}): Promise<void> {
   const instance = instances().get(instanceId)
   if (!instance || !instance.client) {
     throw new Error("Instance not ready")
@@ -393,6 +427,9 @@ async function fetchSessions(instanceId: string, options?: { reset?: boolean }):
 
   const rootClient = getRootClient(instanceId)
   const requestId = beginSessionListRequest(instanceId)
+  options?.registerInvalidation?.(() => {
+    if (isLatestSessionListRequest(instanceId, requestId)) clearSessionListRequestState(instanceId)
+  })
 
   setLoading((prev) => {
     const next = { ...prev }
@@ -407,39 +444,85 @@ async function fetchSessions(instanceId: string, options?: { reset?: boolean }):
 
     log.info("session.list", { instanceId, limit: PROJECT_SESSION_LIST_LIMIT, directory: sessionListOptions.directory, scope: "project" })
     const response = await fetchV2Sessions(instanceId, sessionListOptions)
-    if (!isLatestSessionListRequest(instanceId, requestId)) return
-    await recordSessionWorkspaceHints(instanceId, getV2SessionItems(response))
-
-    let statusById: Record<string, any> = {}
-    let statusResponseKnown = false
-    try {
-      const statusResponse = await rootClient.session.status()
-      if (statusResponse.data && typeof statusResponse.data === "object") {
-        statusResponseKnown = true
-        statusById = statusResponse.data as Record<string, any>
-      }
-    } catch (error) {
-      log.error("Failed to fetch session status:", error)
+    if (!isLatestSessionListRequest(instanceId, requestId)) {
+      if (options?.strictStatus) throw new Error("Foreground session refresh was superseded")
+      return
     }
-    if (!isLatestSessionListRequest(instanceId, requestId)) return
+    const apiSessions = getV2SessionItems(response)
+    await recordSessionWorkspaceHints(instanceId, apiSessions, () => isLatestSessionListRequest(instanceId, requestId))
+    if (!isLatestSessionListRequest(instanceId, requestId)) {
+      if (options?.strictStatus) throw new Error("Foreground session refresh was superseded")
+      return
+    }
+
+    const statusLocationBySessionId = new Map<string, string>()
+    const statusLocations = new Map<string, { directory?: string; workspace?: string }>()
+    await Promise.all(apiSessions.map(async (apiSession) => {
+      const sessionLocation = apiSession as SDKSession & {
+        directory?: string
+        workspace?: string
+        workspaceID?: string
+        workspaceId?: string
+      }
+      const directory = sessionLocation.directory
+      const slug = getWorktreeSlugForDirectory(instanceId, directory)
+      const explicitWorkspace = sessionLocation.workspace ?? sessionLocation.workspaceID ?? sessionLocation.workspaceId
+      const workspacePayload = explicitWorkspace
+        ? { workspace: explicitWorkspace }
+        : await getSessionWorkspacePayload(instanceId, apiSession.id)
+      const requiresWorkspace = (slug && slug !== "root")
+        || Boolean(directory && normalizeWorkspacePath(directory) !== normalizeWorkspacePath(instance.folder))
+      if (requiresWorkspace && !workspacePayload.workspace) {
+        if (options?.strictStatus) {
+          throw new Error(`Unable to resolve OpenCode workspace for session ${apiSession.id}`)
+        }
+        return
+      }
+      const location = { ...sessionListOptions, ...workspacePayload }
+      const key = JSON.stringify(location)
+      statusLocations.set(key, location)
+      statusLocationBySessionId.set(apiSession.id, key)
+    }))
+    if (!isLatestSessionListRequest(instanceId, requestId)) {
+      if (options?.strictStatus) throw new Error("Foreground session refresh was superseded")
+      return
+    }
+
+    const statusSnapshots = new Map<string, Record<string, any>>()
+    await Promise.all(Array.from(statusLocations, async ([key, location]) => {
+      try {
+        const statusResponse = await requestData<Record<string, any>>(rootClient.session.status(location), "session.status")
+        if (statusResponse && typeof statusResponse === "object") statusSnapshots.set(key, statusResponse)
+      } catch (error) {
+        log.error("Failed to fetch session status:", error)
+        if (options?.strictStatus) throw error
+      }
+    }))
+    if (!isLatestSessionListRequest(instanceId, requestId)) {
+      if (options?.strictStatus) throw new Error("Foreground session refresh was superseded")
+      return
+    }
 
     const sessionMap = new Map<string, Session>()
 
     for (const apiSession of getV2SessionItems(response)) {
       const existingSession = existingSessions?.get(apiSession.id)
       const existingStatus = existingSession?.status
+      const statusSnapshot = statusSnapshots.get(statusLocationBySessionId.get(apiSession.id) ?? "")
+      const statusResponseKnown = Boolean(statusSnapshot)
+      const statusById = statusSnapshot ?? {}
       const rawStatus = (apiSession as any)?.status ?? statusById[apiSession.id]
       const hasType = rawStatus && typeof rawStatus === "object" && typeof rawStatus.type === "string"
       const runtimeStatusKnown = Boolean(hasType || statusResponseKnown || existingSession?.runtimeStatusKnown)
 
       let status: SessionStatus
       let retry = existingSession?.retry ?? null
-      if (existingStatus === "compacting") {
+      if (existingStatus === "compacting" && !hasType && !statusResponseKnown) {
         status = "compacting"
         retry = null
       } else {
-        status = hasType ? mapSdkSessionStatus(rawStatus) : existingStatus ?? "idle"
-        retry = hasType ? mapSdkSessionRetry(rawStatus) : retry
+        status = hasType ? mapSdkSessionStatus(rawStatus) : statusResponseKnown ? "idle" : existingStatus ?? "idle"
+        retry = hasType ? mapSdkSessionRetry(rawStatus) : statusResponseKnown ? null : retry
       }
       sessionMap.set(apiSession.id, {
         ...toClientSessionV2(instanceId, apiSession, existingSession),
@@ -1034,7 +1117,11 @@ async function fetchProviders(instanceId: string): Promise<void> {
 async function loadMessages(
   instanceId: string,
   sessionId: string,
-  options?: { force?: boolean; skipChildren?: boolean },
+  options?: {
+    force?: boolean
+    skipChildren?: boolean
+    registerInvalidation?: (invalidate: () => void) => void
+  },
 ): Promise<void> {
   const force = options?.force ?? false
   const skipChildren = options?.skipChildren ?? false
@@ -1079,6 +1166,9 @@ async function loadMessages(
   }
 
   const loadEpoch = advanceMessageLoadEpoch(instanceId, sessionId)
+  options?.registerInvalidation?.(() => {
+    if (isCurrentMessageLoad(instanceId, sessionId, loadEpoch)) invalidateSessionMessageLoad(instanceId, sessionId)
+  })
   const messageRevision = messageStoreBus.getOrCreate(instanceId).getSessionRevision(sessionId)
   let retryAfterRevisionConflict = false
 
@@ -1104,6 +1194,11 @@ async function loadMessages(
       return
     }
 
+    const latestSession = sessions().get(instanceId)?.get(sessionId)
+    if (latestSession?.runtimeStatusKnown && latestSession.status === "idle") {
+      messageStoreBus.getOrCreate(instanceId).retirePendingSends(sessionId)
+    }
+
     setSessionMessagesLoadError(instanceId, sessionId, null)
 
     if (apiMessages.length === 0) {
@@ -1126,8 +1221,16 @@ async function loadMessages(
         })
       }
     } else {
+      const seenMessageIds = new Set<string>()
+      const authoritativeApiMessages = apiMessages.filter((apiMessage: any) => {
+        const id = apiMessage?.info?.id ?? apiMessage?.id
+        if (typeof id !== "string") return true
+        if (seenMessageIds.has(id)) return false
+        seenMessageIds.add(id)
+        return true
+      })
       const messagesInfo = new Map<string, any>()
-      const messages: Message[] = apiMessages.map((apiMessage: any) => {
+      const messages: Message[] = authoritativeApiMessages.map((apiMessage: any) => {
         const info = apiMessage.info || apiMessage
         const role = info.role || "assistant"
         const messageId = info.id || String(Date.now())
@@ -1161,8 +1264,8 @@ async function loadMessages(
       let providerID = ""
       let modelID = ""
 
-      for (let i = apiMessages.length - 1; i >= 0; i--) {
-        const apiMessage = apiMessages[i]
+      for (let i = authoritativeApiMessages.length - 1; i >= 0; i--) {
+        const apiMessage = authoritativeApiMessages[i]
         const info = apiMessage.info || apiMessage
 
         if (info.role === "assistant") {
@@ -1237,7 +1340,12 @@ async function loadMessages(
 
   if (retryAfterRevisionConflict && sessions().get(instanceId)?.has(sessionId)) {
     await new Promise((resolve) => setTimeout(resolve, 50))
-    return loadMessages(instanceId, sessionId, { force: true, skipChildren })
+    if (!isCurrentMessageLoad(instanceId, sessionId, loadEpoch)) return
+    return loadMessages(instanceId, sessionId, {
+      force: true,
+      skipChildren,
+      registerInvalidation: options?.registerInvalidation,
+    })
   }
 
   if (!isCurrentMessageLoad(instanceId, sessionId, loadEpoch) || !sessions().get(instanceId)?.has(sessionId)) return

--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -1128,13 +1128,24 @@ async function loadMessages(
 
         const parts: any[] = (apiMessage.parts || []).map((part: any) => normalizeMessagePart(part))
 
+        // Derive the real status instead of forcing "complete": a forced
+        // refresh (e.g. after an SSE reconnect) can load an assistant message
+        // that is still generating (no end time). Marking it "complete" would
+        // demote an in-flight message and disable streaming-specific UI until
+        // the next qualifying SSE update arrives. User messages are always
+        // complete; only assistant messages without an end time stream.
+        const hasError = Boolean(info.error)
+        const hasEnded = typeof info.time?.end === "number" && info.time.end > 0
+        const status: Message["status"] =
+          role === "user" ? "complete" : hasError ? "error" : hasEnded ? "complete" : "streaming"
+
         const message: Message = {
           id: messageId,
           sessionId,
           type: role === "user" ? "user" : "assistant",
           parts,
           timestamp: info.time?.created || Date.now(),
-          status: "complete" as const,
+          status,
           version: 0,
         }
 

--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -1110,6 +1110,13 @@ async function loadMessages(
       if (messageStoreBus.getOrCreate(instanceId).getSessionRevision(sessionId) !== messageRevision) {
         retryAfterRevisionConflict = true
       } else {
+        // Authoritative empty snapshot: on a forced reconnect load the server
+        // returned zero messages, so clear any stale records left over from
+        // before the reconnect (hydrateMessages ignores empty input). Still
+        // in-flight optimistic sends are preserved by the store.
+        if (force) {
+          messageStoreBus.getOrCreate(instanceId).reconcileEmptyAuthoritativeSnapshot(sessionId)
+        }
         setMessagesLoaded((prev) => {
           const next = new Map(prev)
           const loadedSet = next.get(instanceId) || new Set()
@@ -1130,12 +1137,11 @@ async function loadMessages(
         const parts: any[] = (apiMessage.parts || []).map((part: any) => normalizeMessagePart(part))
 
         // Derive the real status instead of forcing "complete": a forced
-        // refresh (e.g. after an SSE reconnect) can load a message whose end
-        // time the server has not recorded yet. Marking it "complete" would
-        // demote an in-flight message and disable streaming-specific UI until
-        // the next qualifying SSE update arrives. The derivation is shared
-        // with the live SSE path (deriveMessageStatus) for BOTH roles, so a
-        // user message without time.end is treated identically either way.
+        // refresh (e.g. after an SSE reconnect) can load an assistant message
+        // still generating (no time.completed). The derivation is shared with
+        // the live SSE path (deriveMessageStatus) and follows the SDK
+        // contract — user messages are complete once persisted; assistant
+        // completion is time.completed.
         const status: Message["status"] = deriveMessageStatus(info)
 
         const message: Message = {

--- a/packages/ui/src/stores/session-events.ts
+++ b/packages/ui/src/stores/session-events.ts
@@ -77,7 +77,6 @@ import { getOpenCodeWorkspaceIdForWorktree } from "./opencode-workspaces"
 import {
   applyPartUpdateV2,
   applyPartDeltaV2,
-  replaceMessageIdV2,
   reconcilePendingPermissionsV2,
   reconcilePendingQuestionsV2,
   upsertMessageInfoV2,
@@ -90,7 +89,6 @@ import {
   setSessionRevertV2,
 } from "./message-v2/bridge"
 import { messageStoreBus } from "./message-v2/bus"
-import type { InstanceMessageStore } from "./message-v2/instance-store"
 import { handleConversationAssistantPartUpdated } from "./conversation-speech"
 
 const log = getLogger("sse")
@@ -266,29 +264,8 @@ function ensureSessionStatus(
   void pending.finally(() => pendingSessionFetches.delete(key))
 }
 
-type MessageRole = "user" | "assistant"
-
-
-function resolveMessageRole(info?: MessageInfo | null): MessageRole {
+function resolveMessageRole(info?: MessageInfo | null): "user" | "assistant" {
   return info?.role === "user" ? "user" : "assistant"
-}
-
-function findPendingSyntheticMessageId(
-  store: InstanceMessageStore,
-  sessionId: string,
-  role: MessageRole,
-): string | undefined {
-  const messageIds = store.getSessionMessageIds(sessionId)
-  for (const messageId of messageIds) {
-    const record = store.getMessage(messageId)
-    if (!record) continue
-    if (record.sessionId !== sessionId) continue
-    if (record.role !== role) continue
-    if (record.status !== "sending") continue
-    if (!record.isEphemeral) continue
-    return record.id
-  }
-  return undefined
 }
 
 function handleMessageUpdate(instanceId: string, event: MessageUpdateEvent | MessagePartUpdatedEvent): void {
@@ -312,18 +289,11 @@ function handleMessageUpdate(instanceId: string, event: MessageUpdateEvent | Mes
     }
 
     const store = messageStoreBus.getOrCreate(instanceId)
-    const role: MessageRole = resolveMessageRole(messageInfo)
+    const role = resolveMessageRole(messageInfo)
     const createdAt = typeof messageInfo?.time?.created === "number" ? messageInfo.time.created : Date.now()
 
-
-    let record = store.getMessage(messageId)
-    if (!record) {
-      const pendingId = findPendingSyntheticMessageId(store, sessionId, role)
-      if (pendingId && pendingId !== messageId) {
-        replaceMessageIdV2(instanceId, pendingId, messageId, { clearParts: role === "user" })
-        record = store.getMessage(messageId)
-      }
-    }
+    store.confirmServerMessage(messageId, { clearOptimisticParts: true })
+    const record = store.getMessage(messageId)
 
     if (!record) {
       store.upsertMessage({
@@ -391,21 +361,15 @@ function handleMessageUpdate(instanceId: string, event: MessageUpdateEvent | Mes
 
     const store = messageStoreBus.getOrCreate(instanceId)
 
-    const role: MessageRole = info.role === "user" ? "user" : "assistant"
+    const role = info.role === "user" ? "user" : "assistant"
     const status: MessageStatus = deriveMessageStatus({
       role: info.role,
       error: (info as any).error,
       time: info.time as { completed?: number } | undefined,
     })
 
-    let record = store.getMessage(messageId)
-    if (!record) {
-      const pendingId = findPendingSyntheticMessageId(store, sessionId, role)
-      if (pendingId && pendingId !== messageId) {
-        replaceMessageIdV2(instanceId, pendingId, messageId, { clearParts: role === "user" })
-        record = store.getMessage(messageId)
-      }
-    }
+    store.confirmServerMessage(messageId)
+    const record = store.getMessage(messageId)
 
     if (!record) {
       const createdAt = info.time?.created ?? Date.now()
@@ -621,8 +585,10 @@ function handleSessionCompacted(instanceId: string, event: EventSessionCompacted
   })
 }
 
-function handleSessionError(_instanceId: string, event: EventSessionError): void {
+function handleSessionError(instanceId: string, event: EventSessionError): void {
   const error = event.properties?.error
+  const sessionId = event.properties?.sessionID
+  if (sessionId) messageStoreBus.getOrCreate(instanceId).failPendingSends(sessionId)
   log.error(`[SSE] Session error:`, error)
 
   let message = tGlobal("sessionEvents.sessionError.unknown")

--- a/packages/ui/src/stores/session-events.ts
+++ b/packages/ui/src/stores/session-events.ts
@@ -392,7 +392,11 @@ function handleMessageUpdate(instanceId: string, event: MessageUpdateEvent | Mes
     const store = messageStoreBus.getOrCreate(instanceId)
 
     const role: MessageRole = info.role === "user" ? "user" : "assistant"
-    const status: MessageStatus = deriveMessageStatus({ error: (info as any).error, time: timeInfo })
+    const status: MessageStatus = deriveMessageStatus({
+      role: info.role,
+      error: (info as any).error,
+      time: info.time as { completed?: number } | undefined,
+    })
 
     let record = store.getMessage(messageId)
     if (!record) {

--- a/packages/ui/src/stores/session-events.ts
+++ b/packages/ui/src/stores/session-events.ts
@@ -14,6 +14,7 @@ import type {
   EventSessionStatus,
 } from "@opencode-ai/sdk"
 import type { MessageStatus } from "./message-v2/types"
+import { deriveMessageStatus } from "./message-v2/message-status"
 
 import { getLogger } from "../lib/logger"
 import type { EventSessionDeleted } from "../lib/sse-manager"
@@ -391,9 +392,7 @@ function handleMessageUpdate(instanceId: string, event: MessageUpdateEvent | Mes
     const store = messageStoreBus.getOrCreate(instanceId)
 
     const role: MessageRole = info.role === "user" ? "user" : "assistant"
-    const hasError = Boolean((info as any).error)
-    const hasEnded = typeof timeInfo.end === "number" && timeInfo.end > 0
-    const status: MessageStatus = hasError ? "error" : hasEnded ? "complete" : "streaming"
+    const status: MessageStatus = deriveMessageStatus({ error: (info as any).error, time: timeInfo })
 
     let record = store.getMessage(messageId)
     if (!record) {

--- a/packages/ui/src/stores/session-request-authority.test.ts
+++ b/packages/ui/src/stores/session-request-authority.test.ts
@@ -2,10 +2,12 @@ import assert from "node:assert/strict"
 import { describe, it } from "node:test"
 
 import { sdkManager } from "../lib/sdk-manager.ts"
+import { serverApi } from "../lib/api-client.ts"
+import { getOpenCodeWorkspaceIdForSession } from "./opencode-workspaces.ts"
 import type { Session } from "../types/session.ts"
 import { addInstance, removeInstance } from "./instances.ts"
 import { messageStoreBus } from "./message-v2/bus.ts"
-import { loadMessages, removeSessionRuntimeState, searchSessions } from "./session-api.ts"
+import { fetchSessions, loadMessages, removeSessionRuntimeState, searchSessions } from "./session-api.ts"
 import {
   clearInstanceDeletedSessionAuthority,
   getSessionSearchResultIds,
@@ -15,6 +17,7 @@ import {
   sessions,
   setSessions,
 } from "./session-state.ts"
+import { reloadWorktrees } from "./worktrees.ts"
 
 function deferred<T>() {
   let resolve!: (value: T) => void
@@ -41,6 +44,19 @@ function apiMessage(id: string, sessionId: string) {
       time: { created: 1 },
     },
     parts: [],
+  }
+}
+
+async function loadTestWorktree(instanceId: string): Promise<void> {
+  const original = serverApi.fetchWorktrees
+  serverApi.fetchWorktrees = async () => ({
+    worktrees: [{ slug: "branch", directory: "/worktree" }],
+    isGitRepo: true,
+  } as any)
+  try {
+    await reloadWorktrees(instanceId)
+  } finally {
+    serverApi.fetchWorktrees = original
   }
 }
 
@@ -163,8 +179,12 @@ describe("session request authority", () => {
     setSessions((prev) => new Map(prev).set(instanceId, new Map([[sessionId, session(instanceId, sessionId)]])))
 
     try {
-      const oldRequest = loadMessages(instanceId, sessionId)
+      let invalidateOld = () => {}
+      const oldRequest = loadMessages(instanceId, sessionId, {
+        registerInvalidation: (invalidate) => { invalidateOld = invalidate },
+      })
       const newRequest = loadMessages(instanceId, sessionId, { force: true })
+      invalidateOld()
       newResponse.resolve({ data: [apiMessage("new-message", sessionId)] })
       await newRequest
       oldResponse.resolve({ data: [apiMessage("old-message", sessionId)] })
@@ -172,6 +192,96 @@ describe("session request authority", () => {
 
       assert.deepEqual(messageStoreBus.getOrCreate(instanceId).getSessionMessageIds(sessionId), ["new-message"])
       assert.equal(loading().loadingMessages.get(instanceId)?.has(sessionId) ?? false, false)
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("does not let an older timeout invalidate a newer session-list request", async () => {
+    const instanceId = "newer-session-list"
+    const { client, cleanup } = setup(instanceId)
+    const oldResponse = deferred<any>()
+    const newResponse = deferred<any>()
+    let calls = 0
+    ;(client.session as any).list = () => (++calls === 1 ? oldResponse.promise : newResponse.promise)
+    ;(client.session as any).status = async () => ({ data: {} })
+    ;(client.session as any).get = async ({ sessionID }: { sessionID: string }) => ({ data: apiSession(sessionID) })
+
+    try {
+      let invalidateOld = () => {}
+      const oldRequest = fetchSessions(instanceId, {
+        registerInvalidation: (invalidate) => { invalidateOld = invalidate },
+      })
+      const newRequest = fetchSessions(instanceId)
+      invalidateOld()
+      newResponse.resolve({ data: [apiSession("new-session")] })
+      await newRequest
+      oldResponse.resolve({ data: [apiSession("old-session")] })
+      await oldRequest
+
+      assert.equal(sessions().get(instanceId)?.has("new-session"), true)
+      assert.equal(sessions().get(instanceId)?.has("old-session"), false)
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("treats sessions omitted from an authoritative status response as idle", async () => {
+    const instanceId = "authoritative-idle"
+    const { client, cleanup } = setup(instanceId)
+    const working = { ...session(instanceId, "working"), status: "working" as const }
+    const compacting = { ...session(instanceId, "compacting"), status: "compacting" as const }
+    await loadTestWorktree(instanceId)
+    setSessions((prev) => new Map(prev).set(instanceId, new Map<string, Session>([
+      [working.id, working],
+      [compacting.id, compacting],
+    ])))
+    const statusOptions: unknown[] = []
+    let messageOptions: unknown
+    ;(client.session as any).list = async () => ({ data: [
+      apiSession("working"),
+      { ...apiSession("compacting"), directory: "/worktree", workspaceID: "workspace-1" },
+    ] })
+    ;(client.session as any).status = async (options: unknown) => {
+      statusOptions.push(options)
+      return { data: {} }
+    }
+    ;(client.session as any).messages = async (options: unknown) => {
+      messageOptions = options
+      return { data: [] }
+    }
+    ;(client.session as any).get = async ({ sessionID }: { sessionID: string }) => ({ data: apiSession(sessionID) })
+
+    try {
+      await fetchSessions(instanceId)
+
+      assert.equal(sessions().get(instanceId)?.get("working")?.status, "idle")
+      assert.equal(sessions().get(instanceId)?.get("compacting")?.status, "idle")
+      assert.deepEqual(
+        statusOptions.map((value) => JSON.stringify(value)).sort(),
+        [JSON.stringify({ directory: "/work" }), JSON.stringify({ directory: "/work", workspace: "workspace-1" })].sort(),
+      )
+      await loadMessages(instanceId, "compacting", { force: true })
+      assert.deepEqual(messageOptions, { sessionID: "compacting", workspace: "workspace-1" })
+      assert.equal(await getOpenCodeWorkspaceIdForSession(instanceId, "compacting"), "workspace-1")
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("rejects strict status refresh when a worktree location is unresolved", async () => {
+    const instanceId = "unresolved-worktree-status"
+    const { client, cleanup } = setup(instanceId)
+    const existing = { ...session(instanceId, "worktree-session"), status: "working" as const }
+    await loadTestWorktree(instanceId)
+    setSessions((prev) => new Map(prev).set(instanceId, new Map([[existing.id, existing]])))
+    ;(client.session as any).list = async () => ({ data: [
+      { ...apiSession(existing.id), directory: "/worktree" },
+    ] })
+
+    try {
+      await assert.rejects(() => fetchSessions(instanceId, { strictStatus: true }), /resolve OpenCode workspace/)
+      assert.equal(sessions().get(instanceId)?.get(existing.id)?.status, "working")
     } finally {
       cleanup()
     }

--- a/packages/ui/src/stores/session-send-lifecycle.test.ts
+++ b/packages/ui/src/stores/session-send-lifecycle.test.ts
@@ -1,0 +1,190 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { sdkManager } from "../lib/sdk-manager.ts"
+import type { Session } from "../types/session.ts"
+import { addInstance, removeInstance } from "./instances.ts"
+import { messageStoreBus } from "./message-v2/bus.ts"
+import { sendMessage } from "./session-actions.ts"
+import { handleMessageUpdate, handleSessionError } from "./session-events.ts"
+import { clearInstanceDeletedSessionAuthority, setSessions } from "./session-state.ts"
+
+const tick = () => new Promise<void>((resolve) => setImmediate(resolve))
+
+function session(instanceId: string, id: string): Session {
+  return {
+    id,
+    instanceId,
+    parentId: null,
+    title: id,
+    agent: "build",
+    model: { providerId: "provider", modelId: "model" },
+    status: "idle",
+    retry: null,
+    idleSince: null,
+    generationRecovery: null,
+    runtimeStatusKnown: true,
+    version: "1",
+    time: { created: 1, updated: 1 },
+  }
+}
+
+function setup(instanceId: string, sessionId: string, promptAsync: (input: any) => Promise<any>) {
+  const client = { session: { promptAsync } } as any
+  ;(sdkManager as any).clients.set(`${instanceId}:/workspaces/${instanceId}/instance`, client)
+  addInstance({ id: instanceId, folder: "/work", port: 0, pid: 0, proxyPath: "", status: "ready", client })
+  setSessions((prev) => new Map(prev).set(instanceId, new Map([[sessionId, session(instanceId, sessionId)]])))
+
+  return () => {
+    messageStoreBus.unregisterInstance(instanceId)
+    setSessions((prev) => {
+      const next = new Map(prev)
+      next.delete(instanceId)
+      return next
+    })
+    clearInstanceDeletedSessionAuthority(instanceId)
+    removeInstance(instanceId, { authoritative: false })
+    sdkManager.destroyClientsForInstance(instanceId)
+  }
+}
+
+describe("optimistic send lifecycle", () => {
+  it("marks the optimistic message sent when promptAsync accepts it", async () => {
+    const instanceId = "send-accepted"
+    const sessionId = "session"
+    let request: any
+    const cleanup = setup(instanceId, sessionId, async (input) => {
+      request = input
+      return { data: undefined }
+    })
+
+    try {
+      await sendMessage(instanceId, sessionId, "hello")
+      const store = messageStoreBus.getOrCreate(instanceId)
+      assert.equal(typeof request.messageID, "string")
+      assert.equal(store.getMessage(request.messageID)?.status, "sent")
+      assert.equal(store.getMessage(request.messageID)?.isEphemeral, false)
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("marks a rejected prompt failed so authoritative hydration can remove it", async () => {
+    const instanceId = "send-rejected"
+    const sessionId = "session"
+    let request: any
+    const cleanup = setup(instanceId, sessionId, async (input) => {
+      request = input
+      return { error: { message: "rejected" } }
+    })
+
+    try {
+      await assert.rejects(() => sendMessage(instanceId, sessionId, "hello"))
+      const store = messageStoreBus.getOrCreate(instanceId)
+      assert.equal(store.getMessage(request.messageID)?.status, "error")
+
+      store.reconcileEmptyAuthoritativeSnapshot(sessionId)
+      assert.equal(store.getMessage(request.messageID), undefined)
+      assert.deepEqual(store.getSessionMessageIds(sessionId), [])
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("keeps same-id SSE confirmation authoritative when the request later rejects", async () => {
+    const instanceId = "send-sse-first"
+    const sessionId = "session"
+    let request: any
+    let resolvePrompt!: (value: any) => void
+    const prompt = new Promise<any>((resolve) => {
+      resolvePrompt = resolve
+    })
+    const cleanup = setup(instanceId, sessionId, async (input) => {
+      request = input
+      return prompt
+    })
+
+    try {
+      const sending = sendMessage(instanceId, sessionId, "hello")
+      await tick()
+      assert.equal(typeof request.messageID, "string")
+
+      handleMessageUpdate(instanceId, {
+        type: "message.updated",
+        properties: {
+          info: { id: request.messageID, sessionID: sessionId, role: "user", time: { created: 1 } },
+        },
+      } as any)
+      handleMessageUpdate(instanceId, {
+        type: "message.part.updated",
+        properties: {
+          part: { id: "server-part", sessionID: sessionId, messageID: request.messageID, type: "text", text: "hello" },
+        },
+      } as any)
+      resolvePrompt({ error: { message: "response lost" } })
+      await assert.rejects(sending)
+
+      const record = messageStoreBus.getOrCreate(instanceId).getMessage(request.messageID)
+      assert.equal(record?.isEphemeral, false)
+      assert.equal(record?.status, "complete")
+      assert.deepEqual(record?.partIds, ["server-part"])
+      assert.equal((record?.parts["server-part"]?.data as any)?.text, "hello")
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("reconciles exact optimistic parts when rejection arrives before same-id SSE", async () => {
+    const instanceId = "send-rejected-before-sse"
+    const sessionId = "session"
+    let request: any
+    const cleanup = setup(instanceId, sessionId, async (input) => {
+      request = input
+      return { error: { message: "response lost" } }
+    })
+
+    try {
+      await assert.rejects(() => sendMessage(instanceId, sessionId, "hello"))
+      handleMessageUpdate(instanceId, {
+        type: "message.updated",
+        properties: { info: { id: request.messageID, sessionID: sessionId, role: "user", time: { created: 1 } } },
+      } as any)
+      handleMessageUpdate(instanceId, {
+        type: "message.part.updated",
+        properties: {
+          part: { id: "server-part", sessionID: sessionId, messageID: request.messageID, type: "text", text: "hello" },
+        },
+      } as any)
+
+      const record = messageStoreBus.getOrCreate(instanceId).getMessage(request.messageID)
+      assert.deepEqual(record?.partIds, ["server-part"])
+    } finally {
+      cleanup()
+    }
+  })
+
+  it("retires an accepted send after an asynchronous session error", async () => {
+    const instanceId = "send-session-error"
+    const sessionId = "session"
+    let request: any
+    const cleanup = setup(instanceId, sessionId, async (input) => {
+      request = input
+      return { data: undefined }
+    })
+
+    try {
+      await sendMessage(instanceId, sessionId, "hello")
+      const store = messageStoreBus.getOrCreate(instanceId)
+      handleSessionError(instanceId, {
+        type: "session.error",
+        properties: { sessionID: sessionId, error: { message: "generation failed" } },
+      } as any)
+      assert.equal(store.getMessage(request.messageID)?.status, "error")
+
+      store.reconcileEmptyAuthoritativeSnapshot(sessionId)
+      assert.equal(store.getMessage(request.messageID), undefined)
+    } finally {
+      cleanup()
+    }
+  })
+})


### PR DESCRIPTION
## Problem

On mobile, backgrounding CodeNomad while the AI is working suspends JS execution. The SSE connection eventually times out (~45s), and any events that arrived while suspended (a tool call finishing, a message completing) are lost. Returning to the app could leave the UI permanently stuck showing "running" even though the work had actually finished on the server — the only way out was aborting the request.

## Fix

**1. `useForegroundRefresh` hook** (`packages/ui/src/lib/hooks/use-foreground-refresh.ts`)

Subscribes to the SSE transport's `disconnected -> connected` transition (not `visibilitychange`) and re-fetches session status + force-reloads messages only when a reconnect follows a real disconnect. An earlier attempt triggered on `visibilitychange` after a fixed delay, but that force-reloaded even when the connection had stayed alive the whole time, clearing in-flight "sending" state and making it look like the AI never responded to a message the user had just sent.

Also fixes a latent bug in `server-events.ts`: `onPing` could fire for a stale SSE generation after a reconnect, sending a pong tied to the wrong connection. Guarded with the existing `connectGeneration` counter.

**2. Two `hydrateMessages` bugs** found while testing the hook against real mobile background/foreground cycles (`packages/ui/src/stores/message-v2/instance-store.ts`):

- **Unnecessary full re-render on every reload.** The force-reload path always bumped every message's revision regardless of whether the server returned identical content, invalidating render caches and re-rendering the entire visible session on every reconnect. Several reconnects in a row produced perceptible lag. Fixed by only bumping revision when a message's parts or status actually changed — reload time dropped from ~280-320ms to ~10ms for unchanged content.
- **Duplicated message bubble on a race.** If the user sends a message right as a reconnect happens, the optimistic "sending" bubble (client-side temp id) isn't in the REST snapshot yet and was silently dropped from the visible list — without being deleted from the store. When the real SSE echo for it later arrived, the code could no longer find it to swap cleanly, so it created a new record instead, and a subsequent reload could leave both the orphaned bubble and the new one visible at once. Fixed by preserving pending "sending" messages across a reload until they're actually confirmed.

## Validation

- `npm run typecheck` (workspace `@codenomad/ui`): clean
- `node --test src/stores/message-v2/instance-store.test.ts`: 4/4 pass (2 new tests covering the duplicate-message race)
- Full UI test suite run file-by-file: 57/66 pass; the 9 that don't fail identically on a pristine `upstream/dev` checkout with none of this PR's changes applied (pre-existing solid-toast SSR issue in the test environment, unrelated to this change)
- `npm run build` (workspace `@codenomad/ui`): succeeds
- Manually verified over ~1.7 hours of real mobile background/foreground cycles (14s glances up to two 40+ minute backgrounds) — refresh fires only on genuine reconnects, completes in ~200-450ms, no stuck "running" state and no duplicated messages on return
