### PR TITLE
fix(ui): stop active-session load effect from re-firing on every session mutation

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -132,6 +132,7 @@ jobs:
       - name: Test restore ownership integration
         run: >-
           node --conditions=browser --import tsx --test --test-force-exit
+          packages/ui/src/lib/hooks/use-active-session-message-load.test.ts
           packages/ui/src/stores/instances-restore-ownership.test.ts
           packages/ui/src/stores/permission-lifecycle.test.ts
           packages/ui/src/stores/session-request-authority.test.ts

--- a/packages/ui/src/components/session/session-view.tsx
+++ b/packages/ui/src/components/session/session-view.tsx
@@ -13,6 +13,7 @@ import { clearSessionIdleFade, IDLE_STATUS_VISIBILITY_MS, getSessionStatus, isSe
 import { deleteMessage } from "../../stores/session-actions"
 import { showAlertDialog } from "../../stores/alerts"
 import { getLogger } from "../../lib/logger"
+import { useActiveSessionMessageLoad } from "../../lib/hooks/use-active-session-message-load"
 import { requestData } from "../../lib/opencode-api"
 import { useI18n } from "../../lib/i18n"
 import type { PromptInputApi, PromptInsertMode } from "../prompt-input/types"
@@ -296,24 +297,16 @@ export const SessionView: Component<SessionViewProps> = (props) => {
     ),
   )
 
-  // Only the ACTIVE session's id should drive the initial message load. Reading
-  // the whole session object here would subscribe this effect to every mutation
-  // of the reactive sessions map — and during a foreground/reconnect refresh the
-  // many concurrent loadMessages() completions each call setSessions, re-firing
-  // this effect dozens of times per reconnect. A value-diffed memo collapses
-  // that to a single run per real session change, which also prevents a
-  // redundant force:false fetch from racing the authoritative force:true reload
-  // for the same (often very large) session on bandwidth-constrained links.
-  const activeMessageLoadSessionId = createMemo(() => (props.isActive ? (session()?.id ?? null) : null))
-  createEffect(() => {
-    const sessionId = activeMessageLoadSessionId()
-    if (!sessionId) return
-    void waitForInstanceWorkspaceMetadataHydration(props.instanceId)
-      .then(() => {
-        if (!props.isActive || session()?.id !== sessionId) return
-        return loadMessages(props.instanceId, sessionId)
-      })
-      .catch((error) => log.error("Failed to load messages", error))
+  // Drive the active session's initial message load from a value-diffed id so
+  // the effect runs once per real session change instead of on every mutation
+  // of the reactive sessions map (see the hook for the full rationale).
+  useActiveSessionMessageLoad({
+    isActive: () => Boolean(props.isActive),
+    instanceId: () => props.instanceId,
+    session,
+    loadMessages,
+    waitForHydration: waitForInstanceWorkspaceMetadataHydration,
+    onError: (error) => log.error("Failed to load messages", error),
   })
 
   function handleReloadMessages() {

--- a/packages/ui/src/components/session/session-view.tsx
+++ b/packages/ui/src/components/session/session-view.tsx
@@ -296,11 +296,18 @@ export const SessionView: Component<SessionViewProps> = (props) => {
     ),
   )
 
+  // Only the ACTIVE session's id should drive the initial message load. Reading
+  // the whole session object here would subscribe this effect to every mutation
+  // of the reactive sessions map — and during a foreground/reconnect refresh the
+  // many concurrent loadMessages() completions each call setSessions, re-firing
+  // this effect dozens of times per reconnect. A value-diffed memo collapses
+  // that to a single run per real session change, which also prevents a
+  // redundant force:false fetch from racing the authoritative force:true reload
+  // for the same (often very large) session on bandwidth-constrained links.
+  const activeMessageLoadSessionId = createMemo(() => (props.isActive ? (session()?.id ?? null) : null))
   createEffect(() => {
-    if (!props.isActive) return
-    const currentSession = session()
-    if (!currentSession) return
-    const sessionId = currentSession.id
+    const sessionId = activeMessageLoadSessionId()
+    if (!sessionId) return
     void waitForInstanceWorkspaceMetadataHydration(props.instanceId)
       .then(() => {
         if (!props.isActive || session()?.id !== sessionId) return

--- a/packages/ui/src/lib/hooks/use-active-session-message-load.test.ts
+++ b/packages/ui/src/lib/hooks/use-active-session-message-load.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { createRoot, createSignal } from "solid-js"
+
+import { useActiveSessionMessageLoad } from "./use-active-session-message-load.ts"
+
+// Flush queued Solid effects plus the resolved-promise hydration/load chain.
+const tick = () => new Promise<void>((resolve) => setImmediate(resolve))
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+describe("useActiveSessionMessageLoad", () => {
+  it("loads once on activation, ignores same-id session replacement, and reloads on id change or reactivation", async () => {
+    const loads: Array<{ instanceId: string; sessionId: string }> = []
+    const [session, setSession] = createSignal<{ id: string } | undefined>({ id: "a" })
+    const [isActive, setIsActive] = createSignal(true)
+
+    let dispose = () => {}
+    createRoot((rootDispose) => {
+      dispose = rootDispose
+      useActiveSessionMessageLoad({
+        isActive,
+        instanceId: () => "inst",
+        session,
+        loadMessages: (instanceId, sessionId) => {
+          loads.push({ instanceId, sessionId })
+        },
+        waitForHydration: () => Promise.resolve(),
+      })
+    })
+
+    try {
+      // 1. Initial active session triggers exactly one load.
+      await tick()
+      assert.deepEqual(loads, [{ instanceId: "inst", sessionId: "a" }])
+
+      // 2. Replacing the session value with the SAME id (new object reference,
+      //    as setSessions does on every metadata/status mutation) must NOT
+      //    trigger another load — this is the regression the fix guards.
+      setSession({ id: "a" })
+      await tick()
+      assert.equal(loads.length, 1, "same-id replacement must not reload")
+
+      // A few more same-id replacements to simulate a refresh storm.
+      setSession({ id: "a" })
+      setSession({ id: "a" })
+      await tick()
+      assert.equal(loads.length, 1, "repeated same-id replacements must not reload")
+
+      // 3a. A real session-id change triggers exactly one more load.
+      setSession({ id: "b" })
+      await tick()
+      assert.deepEqual(loads, [
+        { instanceId: "inst", sessionId: "a" },
+        { instanceId: "inst", sessionId: "b" },
+      ])
+
+      // 3b. Deactivate then reactivate triggers exactly one more load.
+      setIsActive(false)
+      await tick()
+      assert.equal(loads.length, 2, "deactivation must not load")
+      setIsActive(true)
+      await tick()
+      assert.deepEqual(loads, [
+        { instanceId: "inst", sessionId: "a" },
+        { instanceId: "inst", sessionId: "b" },
+        { instanceId: "inst", sessionId: "b" },
+      ])
+    } finally {
+      dispose()
+    }
+  })
+
+  it("does not load a session the user switched away from while metadata was hydrating", async () => {
+    const loads: string[] = []
+    const gate = deferred()
+    const [session, setSession] = createSignal<{ id: string } | undefined>({ id: "a" })
+
+    let dispose = () => {}
+    createRoot((rootDispose) => {
+      dispose = rootDispose
+      useActiveSessionMessageLoad({
+        isActive: () => true,
+        instanceId: () => "inst",
+        session,
+        loadMessages: (_instanceId, sessionId) => {
+          loads.push(sessionId)
+        },
+        waitForHydration: () => gate.promise,
+      })
+    })
+
+    try {
+      await tick()
+      assert.deepEqual(loads, [], "load is gated behind hydration")
+
+      // User switches to a different session before hydration resolves.
+      setSession({ id: "b" })
+      await tick()
+
+      // Hydration for the original activation resolves now; its load must be
+      // discarded because the active session id no longer matches.
+      gate.resolve()
+      await tick()
+      await tick()
+
+      // Only the current session ("b") should load, exactly once.
+      assert.deepEqual(loads, ["b"])
+    } finally {
+      dispose()
+    }
+  })
+})

--- a/packages/ui/src/lib/hooks/use-active-session-message-load.ts
+++ b/packages/ui/src/lib/hooks/use-active-session-message-load.ts
@@ -1,0 +1,55 @@
+import { createEffect, createMemo } from "solid-js"
+
+/**
+ * Dependencies for {@link useActiveSessionMessageLoad}. Everything is injected
+ * as accessors/callbacks so the reactive trigger can be unit-tested in
+ * isolation (see use-active-session-message-load.test.ts) and reused by
+ * SessionView without pulling the component's full dependency graph.
+ */
+export interface ActiveSessionMessageLoadDeps {
+  /** Whether this SessionView is the active one. Read reactively. */
+  isActive: () => boolean
+  /** The owning instance id. Read reactively. */
+  instanceId: () => string
+  /** The current session object (or undefined). Read reactively. */
+  session: () => { id: string } | undefined
+  /** Loads the messages for a session. */
+  loadMessages: (instanceId: string, sessionId: string) => Promise<void> | void
+  /** Resolves once the instance's workspace metadata has hydrated. */
+  waitForHydration: (instanceId: string) => Promise<void>
+  /** Optional error sink for a rejected load. */
+  onError?: (error: unknown) => void
+}
+
+/**
+ * Triggers the initial message load for the ACTIVE session, and only re-runs
+ * when the active session *id* actually changes.
+ *
+ * The session id is derived through a value-diffed `createMemo`, so the effect
+ * is NOT subscribed to the whole reactive sessions map. During a
+ * foreground/reconnect refresh the many concurrent `loadMessages()` completions
+ * each call `setSessions`, replacing session object references dozens of times;
+ * reading the full object here would re-fire the effect on every one of those
+ * mutations. One such re-fire — landing in the window where the loaded flag was
+ * just invalidated — would issue a redundant `force:false` fetch that races the
+ * authoritative `force:true` reload for the same (often very large) session,
+ * saturating bandwidth-constrained links. Narrowing the dependency to the id
+ * collapses that storm to a single load per real session change while
+ * preserving load-on-activation and load-on-switch behavior.
+ */
+export function useActiveSessionMessageLoad(deps: ActiveSessionMessageLoadDeps): void {
+  const activeSessionId = createMemo(() => (deps.isActive() ? (deps.session()?.id ?? null) : null))
+  createEffect(() => {
+    const sessionId = activeSessionId()
+    if (!sessionId) return
+    const instanceId = deps.instanceId()
+    void Promise.resolve(deps.waitForHydration(instanceId))
+      .then(() => {
+        // Re-check after the async gate: the user may have switched away or to
+        // a different session while metadata was hydrating.
+        if (!deps.isActive() || deps.session()?.id !== sessionId) return
+        return deps.loadMessages(instanceId, sessionId)
+      })
+      .catch((error) => deps.onError?.(error))
+  })
+}


### PR DESCRIPTION
## Summary

Follow-up to #639. On mobile, validating the reconnect refresh from #639 surfaced a bandwidth regression: the active session's initial message-load effect re-fires on **every** mutation of the reactive sessions map, and one of those re-fires issues a redundant `force:false` fetch that races the authoritative `force:true` reload for the same — often very large — session.

## What happens (validated live on a real mobile device, 2 workspaces open)

The active-session effect in `session-view.tsx` reads the whole session object:

```ts
const session = () => props.activeSessions.get(props.sessionId)
```

Reading `session()` inside the `createEffect` subscribes it to the entire sessions map. During a foreground/reconnect refresh, each of the ~10 concurrent `loadMessages()` completions calls `setSessions`, re-firing the effect **20-40× per reconnect** (21 firings logged within a single millisecond).

Most re-runs no-op via the `isLoading && !force` guard, but the firing that lands in the open window (`isLoading:false` + freshly invalidated flag) issues a real network fetch. On a ~6,578-message active session that produced a duplicate full download racing the authoritative reload:

```
loadMessages HTTP fetch (6578 msgs) force:false   (5565ms)   ← from this effect
loadMessages HTTP fetch (6578 msgs) force:true    (7802ms)   ← authoritative reload
```

both in flight ~300ms apart, saturating the mobile link (sidebar fetches degraded from 1-4s to 10-11s; bounded retries could exhaust against `FOREGROUND_REFRESH_TIMEOUT_MS`).

## Fix

Derive the active session id through a value-diffed `createMemo` and drive the effect from that memo instead of the full session object. The memo only notifies downstream when the id string actually changes, collapsing the storm to a single run per real session change while preserving existing behavior (load on activation and on session switch).

This intentionally does **not** touch the authoritative `force:true` reload contract guarded by `session-request-authority.test.ts` — a generic in-flight dedupe was tried and correctly rejected by that test (force:true must always re-fetch), so narrowing the effect's reactive dependency is the right lever.

## Validation

- `tsc --noEmit` clean
- UI tests: 34/34 (group 1), 18/18 (authoritative group 2, `--conditions=browser --test-force-exit`, incl. `session-request-authority`)
- Production UI build succeeds

Root cause was captured live via a portable debug overlay (branch `debug/mobile-overlay`). Context: NeuralNomadsAI/CodeNomad#639 (comment).
