### PR TITLE
fix(ui): contain provider card actions

### DIFF
--- a/packages/ui/src/styles/components/provider-model-visibility.css
+++ b/packages/ui/src/styles/components/provider-model-visibility.css
@@ -71,6 +71,10 @@
   gap: 0.5rem;
 }
 
+.provider-model-card-actions .selector-button {
+  width: auto;
+}
+
 @media (max-width: 700px) {
   .provider-model-visibility-toolbar {
     grid-template-columns: 1fr;
@@ -82,7 +86,8 @@
     flex-direction: column;
   }
 
-  .provider-model-visibility-toolbar .selector-button {
+  .provider-model-visibility-toolbar .selector-button,
+  .provider-model-card-actions .selector-button {
     width: 100%;
     justify-content: center;
   }


### PR DESCRIPTION
## Summary
- size provider card actions to their content on desktop
- prevent the global full-width selector button rule from overflowing the Provider Authentication dialog
- retain full-width stacked actions in the existing narrow/mobile layout

## Validation
- `npm run typecheck --workspace @codenomad/ui`
- `npm run build --workspace @codenomad/ui`
- `git diff --check`

Follow-up to #637.

Closes #650.