### PR TITLE
fix(ui): stop reasoning output scroll jitter

### DIFF
--- a/packages/ui/src/lib/follow-scroll.tsx
+++ b/packages/ui/src/lib/follow-scroll.tsx
@@ -104,7 +104,7 @@ export function createFollowScroll(options: FollowScrollOptions): FollowScrollHe
       const containerRect = container.getBoundingClientRect()
       const sentinelRect = sentinel.getBoundingClientRect()
       const delta = sentinelRect.bottom - containerRect.bottom
-      if (Math.abs(delta) > 1) {
+      if (delta > 1) {
         suppressNextScrollHandling = true
         container.scrollBy({ top: delta, behavior: immediate ? "auto" : "smooth" })
       }


### PR DESCRIPTION
## Summary

- Keep follow-scroll anchor correction directional.
- Avoid scrolling upward when the bottom sentinel is already visible above container padding.
- Preserve downward correction as streamed reasoning content grows.

## Root cause

Streaming first pins the reasoning output to its bottom. The follow-scroll anchor pass then measures the sentinel slightly above the container edge because of bottom padding. The previous absolute-delta check treated that negative offset as actionable and scrolled upward; the next streamed update pinned back to the bottom, producing visible oscillation.

## Validation

- `npm exec --no -- tsx --test packages/ui/src/components/virtual-follow-behavior.test.ts`
- `npm run typecheck --workspace @codenomad/ui`
- `npm run build --workspace @codenomad/ui`
- `git diff --check`

Fixes #652
