### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ See full workaround in the original README.
 
 ## Community
 
-[![Star History](https://api.star-history.com/svg?repos=NeuralNomadsAI/CodeNomad&type=Date)](https://star-history.com/#NeuralNomadsAI/CodeNomad&Date)
+[![Star History](https://star-history.dera.page/svg?repos=NeuralNomadsAI/CodeNomad&type=Date)](https://star-history.dera.page/#NeuralNomadsAI/CodeNomad&Date)
 
 ---
 


### PR DESCRIPTION
The Star History chart was broken because it depended on the GitHub stargazer API. Switch it to an alternative provider using the same data source so the community chart renders correctly. No API token required.