### PR TITLE
Add Build Remote Agent phone pairing (gbr/1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,28 @@ Add SideCar as:
 
 </details>
 
+<details>
+<summary><strong>Build Remote Agent (phone spectator)</strong></summary>
+
+Pair a phone running [Build Remote Agent](https://grokbuildremote.com/) to this machine. Protocol `gbr/1`. The phone spectates (and can veto); CodeNomad stays the cockpit. Independent product; not affiliated with xAI or SpaceX.
+
+```bash
+curl -fsSL https://grokbuildremote.com/install.sh | bash
+gbr-agent version    # need v0.6.0+
+gbr-agent pair && gbr-agent run
+```
+
+Add SideCar as:
+
+- **Name**: `Build Remote Agent`
+- **Port**: `http://127.0.0.1:8788`
+- **Base path**: `/sidecars/gbr`
+- **Prefix mode**: `Strip prefix`
+
+Bot API after `gbr-agent run`: `http://127.0.0.1:8788/health` and `/v1/sessions`. MCP stdio: `gbr-mcp` from [GrokBuildRemote-Agents](https://github.com/LinespottingOrg/GrokBuildRemote-Agents). Never put mailbox keys in git.
+
+</details>
+
 ---
 
 ## Requirements


### PR DESCRIPTION
Add **Build Remote Agent** as an optional phone pairing device for a desktop session of this project.

Independent product by Linespotting AB. **Not affiliated with xAI or SpaceX.** Protocol `gbr/1` (existing pair flow only — no new pair protocol).

## Pair

```bash
# macOS / Linux
curl -fsSL https://grokbuildremote.com/install.sh | bash
gbr-agent version          # need v0.6.0+
gbr-agent pair             # browser QR + printed 8-char code
gbr-agent run              # leave running
```

Phone: open [Build Remote Agent](https://grokbuildremote.com/) → scan QR or type the 8-char code. Unpair in Settings before changing PCs.

## Attach (only these)

- HTTP Bot API: `http://127.0.0.1:8788` after `gbr-agent run`
- MCP stdio: `node …/GrokBuildRemote-Agents/mcp/gbr-mcp/bin/gbr-mcp.js`

```bash
curl -sS http://127.0.0.1:8788/health
curl -sS http://127.0.0.1:8788/v1/sessions
```

Phone is **spectator + veto**, not orchestrator. Never commit mailbox keys.

Agent (MIT): https://github.com/LinespottingOrg/GrokBuildRemote-Agents
