### PR TITLE
ci: add the OpenCode V2 prerelease channel

### DIFF
--- a/.github/workflows/dev-v2-release.yml
+++ b/.github/workflows/dev-v2-release.yml
@@ -1,0 +1,75 @@
+name: OpenCode V2 Pre-Release
+
+on:
+  schedule:
+    # Nightly build of DEV-v2 (only if its current commit has not been released).
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: write
+
+concurrency:
+  group: dev-v2-prerelease
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.gate.outputs.run }}
+      dev_v2_sha: ${{ steps.gate.outputs.dev_v2_sha }}
+      version_suffix: ${{ steps.gate.outputs.version_suffix }}
+    steps:
+      - name: Decide whether to run
+        id: gate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          api() {
+            curl -sS \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "$1"
+          }
+
+          DEV_V2_SHA=$(api "https://api.github.com/repos/${GITHUB_REPOSITORY}/git/ref/heads/DEV-v2" | jq -r '.object.sha')
+          if [ -z "$DEV_V2_SHA" ] || [ "$DEV_V2_SHA" = "null" ]; then
+            echo "Failed to resolve DEV-v2 head SHA" >&2
+            exit 1
+          fi
+
+          DATE=$(date -u +%Y%m%d)
+          SHA8="${DEV_V2_SHA::8}"
+          VERSION_SUFFIX="-dev-v2-${DATE}-${SHA8}"
+          SHOULD_RUN="true"
+
+          if [ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" ]; then
+            RELEASED=$(api "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases?per_page=100" | jq --arg suffix "-${SHA8}" '[.[] | select(.prerelease == true and (.tag_name | startswith("v0.20.0-dev-v2-")) and (.tag_name | endswith($suffix)))] | length')
+            if [ "$RELEASED" -gt 0 ]; then
+              SHOULD_RUN="false"
+            fi
+          fi
+
+          echo "run=${SHOULD_RUN}" >> "$GITHUB_OUTPUT"
+          echo "dev_v2_sha=${DEV_V2_SHA}" >> "$GITHUB_OUTPUT"
+          echo "version_suffix=${VERSION_SUFFIX}" >> "$GITHUB_OUTPUT"
+
+  prerelease:
+    needs: gate
+    if: ${{ needs.gate.outputs.run == 'true' }}
+    uses: ./.github/workflows/reusable-release.yml
+    with:
+      ref: ${{ needs.gate.outputs.dev_v2_sha }}
+      base_version: 0.20.0
+      version_suffix: ${{ needs.gate.outputs.version_suffix }}
+      npm_package_name: "@neuralnomads/codenomad-dev"
+      dist_tag: v2
+      prerelease: true
+      release_ui: false
+    secrets: inherit

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -13,6 +13,11 @@ on:
         required: false
         default: ""
         type: string
+      base_version:
+        description: "Base version override (defaults to package.json version)"
+        required: false
+        default: ""
+        type: string
       dist_tag:
         description: "npm dist-tag to publish under"
         required: false
@@ -62,9 +67,10 @@ jobs:
       - name: Compute release versions
         id: versions
         env:
+          BASE_VERSION_INPUT: ${{ inputs.base_version }}
           VERSION_SUFFIX: ${{ inputs.version_suffix }}
         run: |
-          BASE_VERSION=$(node -p "require('./package.json').version")
+          BASE_VERSION=${BASE_VERSION_INPUT:-$(node -p "require('./package.json').version")}
           VERSION="${BASE_VERSION}${VERSION_SUFFIX}"
           TAG="v${VERSION}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/packages/server/src/releases/dev-release-monitor.test.ts
+++ b/packages/server/src/releases/dev-release-monitor.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { matchesDevReleaseChannel } from "./dev-release-monitor"
+
+test("dev prereleases stay within their V1 or V2 channel", () => {
+  const v1 = "v0.19.0-dev-20260825-12345678"
+  const v2 = "v0.20.0-dev-v2-20260825-abcdef12"
+
+  assert.equal(matchesDevReleaseChannel(v1, v1), true)
+  assert.equal(matchesDevReleaseChannel(v2, v1), false)
+  assert.equal(matchesDevReleaseChannel(v2, v2), true)
+  assert.equal(matchesDevReleaseChannel(v1, v2), false)
+})

--- a/packages/server/src/releases/dev-release-monitor.ts
+++ b/packages/server/src/releases/dev-release-monitor.ts
@@ -30,6 +30,11 @@ export interface DevReleaseMonitor {
 
 const DEFAULT_POLL_INTERVAL_MS = 15 * 60 * 1000
 
+export function matchesDevReleaseChannel(tag: string, currentVersion: string): boolean {
+  const v2 = "-dev-v2-"
+  return currentVersion.includes(v2) ? tag.includes(v2) : tag.includes("-dev-") && !tag.includes(v2)
+}
+
 export function startDevReleaseMonitor(options: DevReleaseMonitorOptions): DevReleaseMonitor {
   let stopped = false
   let timer: ReturnType<typeof setInterval> | null = null
@@ -88,7 +93,10 @@ async function fetchLatestPrerelease(args: {
   }
 
   const list = (await response.json()) as GithubReleaseListItem[]
-  const latest = list.find((r) => r && r.prerelease === true && r.draft !== true)
+  const latest = list.find((release) => {
+    const tag = release?.tag_name || release?.name || ""
+    return release?.prerelease === true && release.draft !== true && matchesDevReleaseChannel(tag, args.currentVersion)
+  })
   if (!latest) {
     return null
   }


### PR DESCRIPTION
## Summary

- build `DEV-v2` as `0.20.0-dev-v2-<date>-<sha>` through the existing release pipeline
- publish GitHub prereleases and `@neuralnomads/codenomad-dev` under the isolated npm `v2` dist-tag
- keep stable remote UI and Winget publication disabled
- prevent V1 and V2 development builds from advertising each other's prereleases

The workflow lives on `dev` because GitHub only runs scheduled workflows from the default branch, but it checks out and builds the exact `DEV-v2` SHA.

## Validation

- parsed both changed workflow files as YAML
- server TypeScript check passed
- targeted development release channel test passed
- `git diff --check` passed
