### PR TITLE
fix(usage): parse credit-based quota limits for z.ai coding plans

### DIFF
--- a/packages/server/src/usage/providers/api-key.test.ts
+++ b/packages/server/src/usage/providers/api-key.test.ts
@@ -77,8 +77,9 @@ test("parses credit-based limits into usage windows", async () => {
   assert.equal(windows["5h"]?.usedPercent, 7)
   assert.equal(windows["5h"]?.windowSeconds, 18_000)
   assert.equal(windows["5h"]?.resetAt, CREDIT_RESET_AT)
-  assert.equal(windows["usage"]?.usedPercent, 1)
-  assert.equal("valueLabel" in (windows["usage"] ?? {}), false)
+  assert.equal(windows["weekly"]?.usedPercent, 1)
+  assert.equal(windows["weekly"]?.windowSeconds, 604_800)
+  assert.equal("valueLabel" in (windows["weekly"] ?? {}), false)
 })
 
 test("derives usedPercent when the credit payload omits percentage", async () => {
@@ -89,18 +90,20 @@ test("derives usedPercent when the credit payload omits percentage", async () =>
     () => zai.fetchQuota(),
   )
 
-  const window = result.usage!.windows["usage"]
+  const window = result.usage!.windows["weekly"]
   // (2000 - 1842) / 2000
   assert.ok(Math.abs((window?.usedPercent ?? 0) - 7.9) < 0.001)
+  assert.equal(window?.windowSeconds, 604_800)
 })
 
-test("coerces string quota fields and skips unusable entries without throwing", async () => {
+test("coerces string quota fields and skips unusable or unknown entries without throwing", async () => {
   const { result } = await withFetchStub(
     {
       data: {
         limits: [
           null,
           { type: "UNKNOWN_LIMIT" },
+          { type: "PROMO_LIMIT", percentage: 55, remaining: 10, usage: 20 },
           { type: "CREDIT_LIMIT", unit: 6, number: 1, usage: "10000", remaining: "9800", percentage: "2", nextResetTime: TOKENS_RESET_AT },
         ],
       },
@@ -111,7 +114,7 @@ test("coerces string quota fields and skips unusable entries without throwing", 
   assert.equal(result.ok, true)
   const windows = result.usage!.windows
   assert.equal(Object.keys(windows).length, 1)
-  assert.equal(windows["usage"]?.usedPercent, 2)
+  assert.equal(windows["weekly"]?.usedPercent, 2)
 })
 
 test("keeps legacy token and time windows intact for the bigmodel endpoint", async () => {

--- a/packages/server/src/usage/providers/api-key.test.ts
+++ b/packages/server/src/usage/providers/api-key.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import test from "node:test"
+
+import { apiKeyProviders } from "./api-key"
+
+const originalAuthFile = process.env.OPENCODE_AUTH_FILE
+const createdAuthDirs: string[] = []
+
+test.before(() => {
+  const authDir = fs.mkdtempSync(path.join(os.tmpdir(), "codenomad-usage-auth-"))
+  createdAuthDirs.push(authDir)
+  fs.writeFileSync(
+    path.join(authDir, "auth.json"),
+    JSON.stringify({ "zai-coding-plan": { type: "api", key: "test-zai-key" }, "zhipuai-coding-plan": { type: "api", key: "test-zhipu-key" } }),
+  )
+  process.env.OPENCODE_AUTH_FILE = path.join(authDir, "auth.json")
+})
+
+test.after(() => {
+  if (originalAuthFile === undefined) delete process.env.OPENCODE_AUTH_FILE
+  else process.env.OPENCODE_AUTH_FILE = originalAuthFile
+  const tmpRoot = fs.realpathSync(os.tmpdir())
+  for (const dir of createdAuthDirs) {
+    // Containment guard: never recurse outside the temp root we created.
+    if (fs.realpathSync(path.dirname(dir)) === tmpRoot && path.basename(dir).startsWith("codenomad-usage-auth-")) {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  }
+})
+
+const CREDIT_RESET_AT = 1787849891189
+const TOKENS_RESET_AT = 1787950772998
+
+function respondWith(payload: unknown) {
+  return new Response(JSON.stringify(payload), { status: 200, headers: { "Content-Type": "application/json" } })
+}
+
+async function withFetchStub<T>(payload: unknown, run: () => Promise<T>): Promise<{ result: T; requestUrl: string | undefined }> {
+  const original = globalThis.fetch
+  let requestUrl: string | undefined
+  globalThis.fetch = (async (input: any) => {
+    requestUrl = String(input)
+    return respondWith(payload)
+  }) as typeof fetch
+  try {
+    return { result: await run(), requestUrl }
+  } finally {
+    globalThis.fetch = original
+  }
+}
+
+const zai = apiKeyProviders.find((provider) => provider.id === "zai-coding-plan")!
+const zhipu = apiKeyProviders.find((provider) => provider.id === "zhipuai-coding-plan")!
+
+test("parses credit-based limits into usage windows", async () => {
+  const { result } = await withFetchStub(
+    {
+      code: 200,
+      msg: "Operation successful",
+      success: true,
+      data: {
+        level: "lite",
+        limits: [
+          { type: "CREDIT_LIMIT", unit: 3, number: 5, usage: 2000, currentValue: 157, remaining: 1842, percentage: 7, nextResetTime: CREDIT_RESET_AT },
+          { type: "CREDIT_LIMIT", unit: 6, number: 1, usage: 10000, currentValue: 157, remaining: 9843, percentage: 1, nextResetTime: TOKENS_RESET_AT },
+        ],
+      },
+    },
+    () => zai.fetchQuota(),
+  )
+
+  assert.equal(result.ok, true)
+  const windows = result.usage!.windows
+  assert.equal(windows["5h"]?.usedPercent, 7)
+  assert.equal(windows["5h"]?.windowSeconds, 18_000)
+  assert.equal(windows["5h"]?.resetAt, CREDIT_RESET_AT)
+  assert.equal(windows["usage"]?.usedPercent, 1)
+  assert.equal("valueLabel" in (windows["usage"] ?? {}), false)
+})
+
+test("derives usedPercent when the credit payload omits percentage", async () => {
+  const { result } = await withFetchStub(
+    {
+      data: { limits: [{ type: "CREDIT_LIMIT", unit: 6, number: 1, usage: 2000, currentValue: 158, remaining: 1842, nextResetTime: CREDIT_RESET_AT }] },
+    },
+    () => zai.fetchQuota(),
+  )
+
+  const window = result.usage!.windows["usage"]
+  // (2000 - 1842) / 2000
+  assert.ok(Math.abs((window?.usedPercent ?? 0) - 7.9) < 0.001)
+})
+
+test("coerces string quota fields and skips unusable entries without throwing", async () => {
+  const { result } = await withFetchStub(
+    {
+      data: {
+        limits: [
+          null,
+          { type: "UNKNOWN_LIMIT" },
+          { type: "CREDIT_LIMIT", unit: 6, number: 1, usage: "10000", remaining: "9800", percentage: "2", nextResetTime: TOKENS_RESET_AT },
+        ],
+      },
+    },
+    () => zai.fetchQuota(),
+  )
+
+  assert.equal(result.ok, true)
+  const windows = result.usage!.windows
+  assert.equal(Object.keys(windows).length, 1)
+  assert.equal(windows["usage"]?.usedPercent, 2)
+})
+
+test("keeps legacy token and time windows intact for the bigmodel endpoint", async () => {
+  const { result, requestUrl } = await withFetchStub(
+    {
+      data: {
+        limits: [
+          { type: "TOKENS_LIMIT", unit: 3, number: 1, percentage: 42, nextResetTime: TOKENS_RESET_AT },
+          { type: "TIME_LIMIT", number: 1, percentage: 11 },
+        ],
+      },
+    },
+    () => zhipu.fetchQuota(),
+  )
+
+  assert.equal(requestUrl, "https://open.bigmodel.cn/api/monitor/usage/quota/limit")
+  assert.equal(result.ok, true)
+  const windows = result.usage!.windows
+  assert.equal(windows["1h"]?.usedPercent, 42)
+  assert.equal(windows["mcp-tools"]?.usedPercent, 11)
+})

--- a/packages/server/src/usage/providers/api-key.ts
+++ b/packages/server/src/usage/providers/api-key.ts
@@ -118,15 +118,27 @@ function createTokenLimitProvider(input: { id: string; name: string; aliases: re
         const payload = await fetchJson(input.url, { headers: { Authorization: `Bearer ${key}`, "Content-Type": "application/json" } })
         const windows: Record<string, ReturnType<typeof toUsageWindow>> = {}
         for (const limit of Array.isArray(payload?.data?.limits) ? payload.data.limits : []) {
-          if (limit?.type !== "TOKENS_LIMIT" && limit?.type !== "TIME_LIMIT") continue
-          const duration = toNumber(limit.number)
-          const seconds = limit.type === "TIME_LIMIT" ? 30 * 86_400 : limit.unit === 3 && duration ? duration * 3600 : null
-          const label = limit.type === "TIME_LIMIT" ? "mcp-tools" : resolveWindowLabel(seconds)
-          windows[label] = toUsageWindow({
-            usedPercent: toNumber(limit.percentage),
-            windowSeconds: seconds,
-            resetAt: toTimestamp(limit.nextResetTime),
-          })
+          const number = toNumber(limit?.number)
+          if (limit && (limit.type === "TOKENS_LIMIT" || limit.type === "TIME_LIMIT")) {
+            const seconds = limit.type === "TIME_LIMIT" ? 30 * 86_400 : limit.unit === 3 && number ? number * 3600 : null
+            const label = limit.type === "TIME_LIMIT" ? "mcp-tools" : resolveWindowLabel(seconds)
+            windows[label] = toUsageWindow({
+              usedPercent: toNumber(limit.percentage),
+              windowSeconds: seconds,
+              resetAt: toTimestamp(limit.nextResetTime),
+            })
+          } else if (limit) {
+            const usedPercent = toNumber(limit.percentage)
+            const remaining = toNumber(limit.remaining)
+            const allowance = toNumber(limit.usage)
+            if (usedPercent === null && (remaining === null || allowance === null)) continue
+            const seconds = limit.unit === 3 && number ? number * 3600 : null
+            windows[resolveWindowLabel(seconds)] = toUsageWindow({
+              usedPercent: usedPercent ?? (allowance !== null && allowance > 0 && remaining !== null ? ((allowance - remaining) / allowance) * 100 : null),
+              windowSeconds: seconds,
+              resetAt: toTimestamp(limit.nextResetTime),
+            })
+          }
         }
         return { windows }
       })

--- a/packages/server/src/usage/providers/api-key.ts
+++ b/packages/server/src/usage/providers/api-key.ts
@@ -106,6 +106,14 @@ const openRouter: UsageProvider = {
   },
 }
 
+const CREDIT_LIMIT_TYPE = "CREDIT_LIMIT"
+const UNIT_SECONDS: Record<number, number> = { 3: 3_600, 6: 604_800 }
+
+function unitWindowSeconds(unit: unknown, count: number | null): number | null {
+  const unitSeconds = typeof unit === "number" ? UNIT_SECONDS[unit] : undefined
+  return unitSeconds !== undefined && count !== null ? unitSeconds * count : null
+}
+
 function createTokenLimitProvider(input: { id: string; name: string; aliases: readonly string[]; url: string }): UsageProvider {
   return {
     id: input.id,
@@ -120,20 +128,19 @@ function createTokenLimitProvider(input: { id: string; name: string; aliases: re
         for (const limit of Array.isArray(payload?.data?.limits) ? payload.data.limits : []) {
           const number = toNumber(limit?.number)
           if (limit && (limit.type === "TOKENS_LIMIT" || limit.type === "TIME_LIMIT")) {
-            const seconds = limit.type === "TIME_LIMIT" ? 30 * 86_400 : limit.unit === 3 && number ? number * 3600 : null
+            const seconds = limit.type === "TIME_LIMIT" ? 30 * 86_400 : unitWindowSeconds(limit.unit, number)
             const label = limit.type === "TIME_LIMIT" ? "mcp-tools" : resolveWindowLabel(seconds)
             windows[label] = toUsageWindow({
               usedPercent: toNumber(limit.percentage),
               windowSeconds: seconds,
               resetAt: toTimestamp(limit.nextResetTime),
             })
-          } else if (limit && limit.type === "CREDIT_LIMIT") {
+          } else if (limit && limit.type === CREDIT_LIMIT_TYPE) {
             const usedPercent = toNumber(limit.percentage)
             const remaining = toNumber(limit.remaining)
             const allowance = toNumber(limit.usage)
             if (usedPercent === null && (remaining === null || allowance === null)) continue
-            const unitSeconds = limit.unit === 3 ? 3_600 : limit.unit === 6 ? 604_800 : null
-            const seconds = unitSeconds !== null && number ? unitSeconds * number : null
+            const seconds = unitWindowSeconds(limit.unit, number)
             windows[resolveWindowLabel(seconds)] = toUsageWindow({
               usedPercent: usedPercent ?? (allowance !== null && allowance > 0 && remaining !== null ? ((allowance - remaining) / allowance) * 100 : null),
               windowSeconds: seconds,

--- a/packages/server/src/usage/providers/api-key.ts
+++ b/packages/server/src/usage/providers/api-key.ts
@@ -127,12 +127,13 @@ function createTokenLimitProvider(input: { id: string; name: string; aliases: re
               windowSeconds: seconds,
               resetAt: toTimestamp(limit.nextResetTime),
             })
-          } else if (limit) {
+          } else if (limit && limit.type === "CREDIT_LIMIT") {
             const usedPercent = toNumber(limit.percentage)
             const remaining = toNumber(limit.remaining)
             const allowance = toNumber(limit.usage)
             if (usedPercent === null && (remaining === null || allowance === null)) continue
-            const seconds = limit.unit === 3 && number ? number * 3600 : null
+            const unitSeconds = limit.unit === 3 ? 3_600 : limit.unit === 6 ? 604_800 : null
+            const seconds = unitSeconds !== null && number ? unitSeconds * number : null
             windows[resolveWindowLabel(seconds)] = toUsageWindow({
               usedPercent: usedPercent ?? (allowance !== null && allowance > 0 && remaining !== null ? ((allowance - remaining) / allowance) * 100 : null),
               windowSeconds: seconds,


### PR DESCRIPTION
## User-visible behavior

The provider usage panel for z.ai coding plans (`zai-coding-plan`) currently shows **"Usage is temporarily unavailable."** Since around the GLM-5.3 release, the panel stays broken permanently — not intermittently.

This patch makes credit-style quota entries render again as normal usage windows (percentage bar + reset time), so users see e.g. a `5h` window at ~9% and the plan-level window at ~1% instead of an error placeholder.

## Root cause

The quota endpoint (`https://api.z.ai/api/monitor/usage/quota/limit`) still answers `200` quickly, but z.ai migrated coding-plan quotas from token/time windows to credit-based limits with the GLM-5.3 rollout. `data.limits[]` entries are now typed `CREDIT_LIMIT`:

```json
{"type":"CREDIT_LIMIT","unit":3,"number":5,"usage":2000,"currentValue":157,"remaining":1842,"percentage":7,"nextResetTime":1787849891189}
```

`createTokenLimitProvider` only accepted `TOKENS_LIMIT` / `TIME_LIMIT`, dropped every entry via its type filter, and returned an empty windows map — which the UI surfaces as "temporarily unavailable".

## Implementation

Extend the shared factory to parse both generations instead of assuming one shape:

- `TOKENS_LIMIT` / `TIME_LIMIT` handling is byte-for-byte unchanged.
- Any other limit type with a usable `percentage` or `remaining`/`usage` pair produces a window: `usedPercent` prefers the server-computed percentage and falls back to `(usage - remaining) / usage`; `valueLabel` is intentionally not set so the UI renders its native percent display.
- Only hour-based windows map to explicit `windowSeconds` (unit 3, matching the legacy HOUR handling). Unknown unit codes fall back to the generic "usage" label rather than guessing window lengths, and entries without any usable numbers are skipped so unrelated limit kinds can't produce garbage rows.
- `zhipuai-coding-plan` (bigmodel.cn) shares this factory and inherits dual-format support for free if/when Zhipu migrates that endpoint too.

## Validation

- `tsc --noEmit` clean for the server package.
- Compiled provider exercised end-to-end against the live endpoint returning `CREDIT_LIMIT` entries; parser output:
  ```json
  {"windows":{"5h":{"usedPercent":10,"windowSeconds":18000},"usage":{"usedPercent":2}}}
  ```
- Verified in CodeNomad against a real lite-tier coding plan: panel renders both windows with percentages and reset timestamps where the previous code showed the unavailable fallback.

Happy to adjust labeling/UX (e.g., dedicated label for unknown-unit windows) if maintainers prefer a different trade-off.