### PR TITLE
test(server): isolate automation registry on Linux

### DIFF
--- a/packages/server/src/opencode/automation-plugin.test.ts
+++ b/packages/server/src/opencode/automation-plugin.test.ts
@@ -229,7 +229,11 @@ test("pins parallel sessions to their independently inspected bridges", async ()
 test("prunes stale registry pressure before limiting discovery", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "codenomad-automation-stale-"))
   const previousLocalAppData = process.env.LOCALAPPDATA
+  const previousXdgRuntimeDir = process.env.XDG_RUNTIME_DIR
+  const previousWslDistroName = process.env.WSL_DISTRO_NAME
   process.env.LOCALAPPDATA = root
+  process.env.XDG_RUNTIME_DIR = root
+  delete process.env.WSL_DISTRO_NAME
   let removeBridge: (() => Promise<void>) | undefined
   let server: http.Server | undefined
   try {
@@ -238,7 +242,8 @@ test("prunes stale registry pressure before limiting discovery", async () => {
       : { result: { target: { id: "live", title: "Live", url: "http://app.test" }, nodes: [], diagnostics: [] } })
     server = bridge.server
     removeBridge = await publishAutomationBridge(createAutomationBridgeRegistration(bridge.url))
-    const directory = path.join(root, "CodeNomad", "automation-bridges")
+    const directory = automationBridgeDirectories()[0]
+    assert.equal(path.dirname(path.dirname(directory)), root)
     const base = Date.now() + 10_000
     for (let index = 0; index < 70; index += 1) {
       const startedAt = base + index
@@ -259,6 +264,10 @@ test("prunes stale registry pressure before limiting discovery", async () => {
     await closeServer(server)
     if (previousLocalAppData === undefined) delete process.env.LOCALAPPDATA
     else process.env.LOCALAPPDATA = previousLocalAppData
+    if (previousXdgRuntimeDir === undefined) delete process.env.XDG_RUNTIME_DIR
+    else process.env.XDG_RUNTIME_DIR = previousXdgRuntimeDir
+    if (previousWslDistroName === undefined) delete process.env.WSL_DISTRO_NAME
+    else process.env.WSL_DISTRO_NAME = previousWslDistroName
     await rm(root, { recursive: true, force: true })
   }
 })


### PR DESCRIPTION
## Summary

- isolate the Developer Mode automation registry test on Linux as well as Windows
- derive the seeded registry path through the production resolver
- restore `LOCALAPPDATA`, `XDG_RUNTIME_DIR`, and `WSL_DISTRO_NAME` after the test

## Root cause

Both final CI runs for #647 failed in `prunes stale registry pressure before limiting discovery`. The test redirected only `LOCALAPPDATA`, which Linux ignores, then wrote fixtures into a hard-coded Windows registry path that did not exist.

## Validation

- `node --import tsx --test packages/server/src/opencode/automation-plugin.test.ts`
- 20 repeated targeted runs
- `npm run typecheck --workspace @neuralnomads/codenomad`
- `git diff --check`

This fixes the deterministic Linux failure from PR Build Validation runs 33862538051 and 33863984160.
