### PR TITLE
fix(ui): preserve history on an empty older message page

### DIFF
--- a/packages/ui/src/components/message-history-pagination.test.ts
+++ b/packages/ui/src/components/message-history-pagination.test.ts
@@ -81,6 +81,21 @@ describe("message history pagination", () => {
     assert.ok(paging.indexOf('api.setAutoScroll(direction === "latest")', position) > position)
   })
 
+  it("does not reposition the retained page after an exhausted older-cursor probe", () => {
+    const window = { kind: "latest", olderCursor: "past-oldest", newerCursors: [] }
+    const exhausted = { ...window, olderCursor: undefined }
+    assert.equal(getMessageWindowPageKey(window), getMessageWindowPageKey(exhausted))
+    const source = fs.readFileSync(new URL("./message-section.tsx", import.meta.url), "utf8")
+    const start = source.indexOf("async function pageWindow(")
+    const paging = source.slice(start, source.indexOf("function messageWindowPageKey", start))
+    const capture = paging.indexOf("const previousPage = messageWindowPageKey()")
+    const load = paging.indexOf("await load(controller.signal)")
+    const stop = paging.indexOf('if (direction === "older" && messageWindowPageKey() === previousPage) return')
+    const follow = paging.indexOf('api.setAutoScroll(direction === "latest")')
+    assert.ok(capture >= 0 && capture < load)
+    assert.ok(stop > load && stop < follow)
+  })
+
   it("keeps native inbox prompts after delivered transcript messages", () => {
     const source = fs.readFileSync(new URL("./message-section.tsx", import.meta.url), "utf8")
     const start = source.indexOf("const visibleMessageIds")

--- a/packages/ui/src/components/message-section.tsx
+++ b/packages/ui/src/components/message-section.tsx
@@ -861,8 +861,12 @@ export default function MessageSection(props: MessageSectionProps) {
     pagingWindow = true
     try {
       if (!isCurrent()) return
+      const previousPage = messageWindowPageKey()
       await load(controller.signal)
       if (!isCurrent()) return
+      // An empty boundary probe retires the older cursor without changing the
+      // resident page. Do not jump from its top back to its bottom in that case.
+      if (direction === "older" && messageWindowPageKey() === previousPage) return
       api.setAutoScroll(direction === "latest")
       api.notifyContentRendered()
       await waitTwoFrames()

--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -1375,7 +1375,13 @@ async function loadMessages(
       && getOpenCodeMessageRevision(instanceId, sessionId) !== liveMessageRevision
     const apiMessages = responseAscending ? [...response.data] : [...response.data].reverse()
     if (apiMessages.length === 0) {
-      if (hasLatestRevisionConflict() || (intent === "open" && planned.cursor)) {
+      if (intent === "older") {
+        // V2 boundary cursors do not guarantee another page. An exhausted
+        // history request says nothing about the messages already resident.
+        // Keep their window identity (including live/latest authority) and
+        // scroll anchor; only retire the cursor that reached the boundary.
+        commitMessageWindow(instanceId, sessionId, withOlderCursor(currentWindow, undefined), "open")
+      } else if (hasLatestRevisionConflict() || (intent === "open" && planned.cursor)) {
         retryAfterRevisionConflict = true
       } else if (store.getSessionRevision(sessionId) !== messageRevision) {
         retryAfterRevisionConflict = true

--- a/packages/ui/src/stores/session-request-authority.test.ts
+++ b/packages/ui/src/stores/session-request-authority.test.ts
@@ -9,7 +9,7 @@ import { getCommands } from "./commands.ts"
 import { beginMessageHistoryTraversal, fetchAgents, fetchProviders, fetchSessions, hasMoreMessages, hydrateRestoredSessionChain, invalidateMessageHistoryTraversal, isLatestMessageWindow, loadLatestMessageWindow, loadMessages, loadMoreMessages, loadMoreSessions, loadNewerMessageWindow, loadOldestMessageWindow, removeSessionRuntimeState, searchSessions } from "./session-api.ts"
 import { getInstanceMetadata, setInstanceMetadata } from "./instance-metadata.ts"
 import { loadInstanceMetadata } from "../lib/hooks/use-instance-metadata.ts"
-import { applyOpenCodeDataEvent, destroyOpenCodeData, getOpenCodeMessageRevision } from "./opencode-data.ts"
+import { applyOpenCodeDataEvent, destroyOpenCodeData, getOpenCodeMessageRevision, projectOpenCodeMessages } from "./opencode-data.ts"
 import {
   clearInstanceDeletedSessionAuthority,
   agents,
@@ -265,6 +265,120 @@ describe("session request authority", () => {
       assert.deepEqual(messageStoreBus.getOrCreate(instanceId).getSessionMessageIds(sessionId), ["old-1", "old-2"])
       assert.deepEqual(requests.at(-1), { sessionID: sessionId, limit: 200, cursor: "page-2" })
       assert.equal(hasMoreMessages(instanceId, sessionId), false)
+    } finally {
+      cleanup()
+    }
+  })
+
+  for (const kind of ["latest", "history"] as const) {
+    for (const count of [10, 200]) {
+      it(`preserves the ${kind} window of ${count} messages when the older cursor returns an empty terminal page`, async () => {
+        const instanceId = `empty-older-${kind}-${count}`, sessionId = "session"
+        const { client, cleanup } = setup(instanceId)
+        const page = Array.from({ length: count }, (_, index) => ({
+          ...apiMessage(`message-${count - index}`),
+          time: { created: count - index },
+          tokens: { input: 1, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+          cost: 1,
+        }))
+        const requests: any[] = []
+        ;(client as any).message = { list: async (input: any) => {
+          requests.push(input)
+          if (input.cursor === "past-oldest") return { data: [], cursor: {} }
+          if (kind === "history" && !input.cursor) return { data: [apiMessage("latest")], cursor: { next: "history" } }
+          // Native V2 supplies boundary cursors even for a short final page.
+          return { data: page, cursor: { next: "past-oldest", previous: "toward-latest" } }
+        } }
+        setSessions((previous) => new Map(previous).set(instanceId, new Map([[sessionId, session(instanceId, sessionId)]])))
+        try {
+          await loadMessages(instanceId, sessionId)
+          if (kind === "history") await loadMoreMessages(instanceId, sessionId)
+          const store = messageStoreBus.getOrCreate(instanceId)
+          const ids = [...store.getSessionMessageIds(sessionId)]
+          const infos = ids.map((id) => store.getMessageInfo(id))
+          const usage = JSON.parse(JSON.stringify(store.getSessionUsage(sessionId)))
+          const revision = store.getSessionRevision(sessionId)
+          const window = { ...store.getMessageWindow(sessionId)!, newerCursors: [...store.getMessageWindow(sessionId)!.newerCursors] }
+          store.setScrollSnapshot(sessionId, "message-stream", {
+            scrollTop: 0, atBottom: false, scrollRatio: 0, maxScrollTop: 900,
+            anchorKey: ids[0], anchorOffset: -5, followModeType: "escaped",
+            windowIsLatest: kind === "latest", windowCursor: window.resumeCursor, newerCursors: window.newerCursors,
+          })
+          const { updatedAt: _before, ...snapshot } = store.getScrollSnapshot(sessionId, "message-stream")!
+
+          await loadMoreMessages(instanceId, sessionId)
+
+          assert.deepEqual(store.getSessionMessageIds(sessionId), ids)
+          ids.forEach((id, index) => assert.strictEqual(store.getMessageInfo(id), infos[index]))
+          assert.deepEqual(store.getSessionUsage(sessionId), usage)
+          assert.equal(store.getSessionRevision(sessionId), revision)
+          const { olderCursor: _exhausted, ...retainedWindow } = window
+          assert.deepEqual(store.getMessageWindow(sessionId), retainedWindow)
+          const { updatedAt: _after, ...retainedSnapshot } = store.getScrollSnapshot(sessionId, "message-stream")!
+          assert.deepEqual(retainedSnapshot, snapshot)
+          assert.equal(isLatestMessageWindow(instanceId, sessionId), kind === "latest")
+          assert.equal(hasMoreMessages(instanceId, sessionId), false)
+          assert.equal(getSessionMessagesLoadError(instanceId, sessionId), undefined)
+          await loadMoreMessages(instanceId, sessionId)
+          assert.equal(requests.filter((input) => input.cursor === "past-oldest").length, 1)
+          if (kind === "history") {
+            await loadNewerMessageWindow(instanceId, sessionId)
+            assert.deepEqual(store.getSessionMessageIds(sessionId), ["latest"])
+            assert.equal(isLatestMessageWindow(instanceId, sessionId), true)
+          }
+        } finally {
+          cleanup()
+        }
+      })
+    }
+  }
+
+  it("keeps live events authoritative during and after an empty older-page probe", async () => {
+    const instanceId = "empty-older-live-events", sessionId = "session"
+    const { client, cleanup } = setup(instanceId)
+    const terminal = deferred<any>()
+    let calls = 0
+    ;(client as any).message = { list: (input: any) => {
+      calls += 1
+      return input.cursor ? terminal.promise : Promise.resolve({ data: [apiMessage("initial")], cursor: { next: "past-oldest" } })
+    } }
+    setSessions((previous) => new Map(previous).set(instanceId, new Map([[sessionId, session(instanceId, sessionId)]])))
+    const addLiveMessage = (id: string) => {
+      const data = applyOpenCodeDataEvent(instanceId, "/work", {
+        id: `event-${id}`, type: "session.step.started", created: 2,
+        data: { sessionID: sessionId, assistantMessageID: id, agent: "build", model: { providerID: "provider", id: "model" } },
+      } as any)
+      projectOpenCodeMessages(instanceId, sessionId, data)
+    }
+    try {
+      await loadMessages(instanceId, sessionId)
+      const request = loadMoreMessages(instanceId, sessionId)
+      addLiveMessage("during")
+      terminal.resolve({ data: [], cursor: {} })
+      await request
+      addLiveMessage("after")
+      assert.deepEqual(messageStoreBus.getOrCreate(instanceId).getSessionMessageIds(sessionId), ["initial", "during", "after"])
+      assert.equal(isLatestMessageWindow(instanceId, sessionId), true)
+      assert.equal(hasMoreMessages(instanceId, sessionId), false)
+      assert.equal(calls, 2)
+    } finally {
+      destroyOpenCodeData(instanceId)
+      cleanup()
+    }
+  })
+
+  it("still clears a genuinely empty authoritative latest snapshot", async () => {
+    const instanceId = "empty-authoritative-latest", sessionId = "session"
+    const { client, cleanup } = setup(instanceId)
+    let empty = false
+    ;(client as any).message = { list: async () => ({ data: empty ? [] : [apiMessage("removed")], cursor: {} }) }
+    setSessions((previous) => new Map(previous).set(instanceId, new Map([[sessionId, session(instanceId, sessionId)]])))
+    try {
+      await loadMessages(instanceId, sessionId)
+      empty = true
+      await loadLatestMessageWindow(instanceId, sessionId)
+      assert.deepEqual(messageStoreBus.getOrCreate(instanceId).getSessionMessageIds(sessionId), [])
+      assert.equal(isLatestMessageWindow(instanceId, sessionId), true)
     } finally {
       cleanup()
     }


### PR DESCRIPTION
## Scope: issue #678 only

Fixes #678.

An older OpenCode V2 boundary cursor can return an empty page. That response
must exhaust only the cursor, not erase the conversation or move the reader.

### Changes

- Keep resident messages, usage, latest/history window identity and saved scroll
  position when the older-page response is empty.
- Do not reposition the reader when that terminal probe did not change the page.
- Seven targeted regressions: latest/history windows with 10/200 records,
  metadata/usage/anchor stability, one terminal request, live events during the
  probe, return to newer pages, and genuinely empty latest snapshots.

Only **four files** change: two production files and their two existing tests
(141 insertions, 2 deletions). No virtualizer, undo, fork, server, desktop,
dependency, styling or workflow changes belong to this PR anymore.

The former consolidated history is preserved on `fix/transcript-rendering-followup`.
All other corrections and ongoing prompt-disappearance/middle-scroll work are
being tracked separately; this PR does not claim to resolve those symptoms.

## Validation of the minimal branch

- Fresh `npm ci` against the unchanged lockfile.
- **302 runnable UI tests + 151 browser-conditioned Node/Solid tests = 453 passed.**
- UI and Electron TypeScript checks passed.
- UI production build passed (existing bundle/Browserslist warnings).
- Chromium comparison with the actual MessageSection, VirtualFollowList and store:
  original: 10 -> 0 messages; store-only: messages kept but jumps down;
  minimal fix: 10 messages kept at scrollTop 0, one terminal request, no page errors.
- Review of the narrowed diff: no outstanding code finding for #678.

This is shared UI behavior for Electron and Tauri, not a new interactive native
validation. The installed Tauri application remains the earlier consolidated
`817fd2c4` artifact; it has not been replaced by this minimal branch.

## Merge gate

Fresh GitHub checks and required review must pass on this new head before merge.
The prior consolidated run failed two Windows cross-host ownership tests in
`client_state/cross_host.rs`; no Rust file changes are included here. That prior
failure is not being hidden or counted as a successful validation of this head.
No branch protection changes or administrative merge bypasses are requested.

## Maintenance note

Existing large files touched: `packages/ui/src/components/message-section.tsx`
(~1507 lines), `packages/ui/src/stores/session-api.ts` (~1618 lines), and
`packages/ui/src/stores/session-request-authority.test.ts` (~1600 lines).
No unrelated size-only refactoring.
