### PR TITLE
fix(ui): restore migrated global subsessions

### DIFF
--- a/packages/ui/src/stores/session-api.ts
+++ b/packages/ui/src/stores/session-api.ts
@@ -287,7 +287,7 @@ function getV2SessionItems(response: ProjectSessionListResponse): SDKSession[] {
   return response.data
 }
 
-async function fetchCompleteProjectSessionInventory(
+async function fetchCompleteSessionInventory(
   instanceId: string,
   signal?: AbortSignal,
   isCurrent: () => boolean = () => true,
@@ -295,15 +295,22 @@ async function fetchCompleteProjectSessionInventory(
   const project = getInstanceMetadata(instanceId)?.project?.id
   if (!project) return []
   const inventory = new Map<string, SDKSession>()
-  const seenCursors = new Set<string>()
-  let response = await fetchV2Sessions(instanceId, { project, order: "desc" }, signal)
-  while (true) {
-    if (!isCurrent()) return []
-    for (const session of response.data) inventory.set(session.id, session)
-    if (!response.nextCursor) break
-    if (seenCursors.has(response.nextCursor)) throw new Error(`Repeated session cursor: ${response.nextCursor}`)
-    seenCursors.add(response.nextCursor)
-    response = await fetchV2Sessions(instanceId, { cursor: response.nextCursor }, signal)
+  const directory = instances().get(instanceId)?.folder
+  const scopes: V2SessionListOptions[] = [{ project, order: "desc" }]
+  // V1 sessions can remain in the global project after migration while sharing this directory.
+  if (project !== "global" && directory) scopes.push({ directory, order: "desc" })
+
+  for (const scope of scopes) {
+    const seenCursors = new Set<string>()
+    let response = await fetchV2Sessions(instanceId, scope, signal)
+    while (true) {
+      if (!isCurrent()) return []
+      for (const session of response.data) inventory.set(session.id, session)
+      if (!response.nextCursor) break
+      if (seenCursors.has(response.nextCursor)) throw new Error(`Repeated session cursor: ${response.nextCursor}`)
+      seenCursors.add(response.nextCursor)
+      response = await fetchV2Sessions(instanceId, { cursor: response.nextCursor }, signal)
+    }
   }
   return Array.from(inventory.values())
 }
@@ -500,7 +507,7 @@ async function fetchSessions(instanceId: string, options?: {
     let inventory: SDKSession[] = []
     let inventoryComplete = false
     try {
-      inventory = await fetchCompleteProjectSessionInventory(instanceId, options?.signal, isCurrent)
+      inventory = await fetchCompleteSessionInventory(instanceId, options?.signal, isCurrent)
       inventoryComplete = hasProjectInventory && response.complete
     } catch (error) {
       if (options?.signal?.aborted) throw error

--- a/packages/ui/src/stores/session-request-authority.test.ts
+++ b/packages/ui/src/stores/session-request-authority.test.ts
@@ -1501,7 +1501,7 @@ describe("session request authority", () => {
     }
   })
 
-  it("loads root, child, and grandchild from a flat project inventory with cursor-only continuations", async () => {
+  it("loads current and migrated descendants from complete project and directory inventories", async () => {
     const instanceId = "project-descendants"
     const { client, cleanup } = setup(instanceId)
     const requests: any[] = []
@@ -1513,16 +1513,23 @@ describe("session request authority", () => {
       if (input.cursor === "root-page-2") {
         return { data: [apiSession("later")], cursor: {} }
       }
-      if (input.cursor === "inventory-page-2") {
+      if (input.cursor === "project-inventory-page-2") {
         return { data: [apiSession("grandchild", "child")], cursor: {} }
+      }
+      if (input.cursor === "directory-inventory-page-2") {
+        return { data: [{ ...apiSession("legacy-child", "root"), projectID: "global" }], cursor: {} }
       }
       if (input.parentID === null) return {
         data: [apiSession("root")],
         cursor: { next: "root-page-2" },
       }
+      if (input.project === "project") return {
+        data: [apiSession("root"), apiSession("child", "root")],
+        cursor: { next: "project-inventory-page-2" },
+      }
       return {
         data: [apiSession("root"), apiSession("child", "root")],
-        cursor: { next: "inventory-page-2" },
+        cursor: { next: "directory-inventory-page-2" },
       }
     }
 
@@ -1531,18 +1538,22 @@ describe("session request authority", () => {
       assert.equal(sessions().get(instanceId)?.has("root"), true)
       assert.equal(sessions().get(instanceId)?.has("child"), true)
       assert.equal(sessions().get(instanceId)?.has("grandchild"), true)
+      assert.equal(sessions().get(instanceId)?.get("legacy-child")?.projectID, "global")
       assert.equal(requests[0].directory, "/work")
       assert.equal("project" in requests[0], false)
       assert.equal(requests[0].parentID, null)
       assert.equal(requests[1].project, "project")
       assert.equal("directory" in requests[1], false)
+      assert.deepEqual(requests[2], { cursor: "project-inventory-page-2", limit: 200 })
+      assert.equal(requests[3].directory, "/work")
+      assert.equal("project" in requests[3], false)
+      assert.deepEqual(requests[4], { cursor: "directory-inventory-page-2", limit: 200 })
       assert.equal(requests.some((request) => typeof request.parentID === "string"), false)
-      assert.deepEqual(requests[2], { cursor: "inventory-page-2", limit: 200 })
 
       await loadMoreSessions(instanceId)
-      assert.deepEqual(requests[3], { cursor: "root-page-2", limit: 200 })
+      assert.deepEqual(requests[5], { cursor: "root-page-2", limit: 200 })
       assert.equal(requests.filter((request) => request.cursor).every((request) => Object.keys(request).sort().join(",") === "cursor,limit"), true)
-      assert.equal(requests.length, 4)
+      assert.equal(requests.length, 6)
       assert.equal(sessions().get(instanceId)?.get("later")?.status, "working")
       assert.equal(sessions().get(instanceId)?.get("later")?.runtimeStatusKnown, true)
     } finally {


### PR DESCRIPTION
## Summary

- merge the complete directory-scoped session inventory with the native V2 project inventory
- restore descendants that remain assigned to `projectID: "global"` after a V1 database migration
- deduplicate sessions by ID and keep cursor-cycle detection independent for each inventory
- skip the extra directory drain when the resolved project is already `global`

## Root cause

CodeNomad already lists root sessions by directory, so migrated global roots remain visible. Descendants were hydrated exclusively from the resolved V2 project inventory, however. OpenCode can retain migrated V1 sessions in the `global` project while `location.get` resolves a new project ID, which left valid child sessions outside CodeNomad's in-memory family graph and removed the expansion affordance.

This change treats the directory inventory as a compatibility union without rewriting OpenCode's database.

## Validation

- `node --conditions=browser --import tsx --test --test-force-exit packages/ui/src/stores/session-request-authority.test.ts` — 59/59 passed
- `npm run typecheck --workspace @codenomad/ui`
- `npm run build:ui`

The regression fixture independently paginates project and directory inventories and verifies that a legacy global child absent from the project response is restored.