### PR TITLE
fix(ui): preserve nested scroll gesture ownership

### DIFF
--- a/packages/ui/src/components/virtual-follow-list.tsx
+++ b/packages/ui/src/components/virtual-follow-list.tsx
@@ -1,5 +1,6 @@
 import { Show, createEffect, createMemo, createSignal, type Accessor, type JSX, on, onCleanup } from "solid-js"
 import { Virtualizer, type VirtualizerHandle } from "virtua/solid"
+import { attachScrollGestureRouting } from "../lib/scroll-gesture-routing"
 import { remapVirtualMeasurements } from "./virtual-follow-measurements"
 import { createVirtualReaderSettlement } from "./virtual-reader-settlement"
 import { advanceBottomPinSettlement, AnchorRestoreStabilizer, BOTTOM_FOLLOW_EPSILON_PX, canScrollInDirection, classifyVirtualItemKeyChange, getBottomAnchoredViewportOffset, getFollowSnapshotState, getKeyboardScrollIntent, getPrimaryPointerDragDirection, isAtBottom, isAutoFollowing, isMiddleButtonScrollIntent, isScrollRestoreMeasurementReady, resolveAutoPinHoldElement, restoreFollowModeFromSnapshot, ScrollRestoreTokenGuard, selectTopViewportAnchor, shouldAdvanceBottomPin, shouldNavigateAtBoundary, VirtualScrollController, type FollowEffect, type FollowEvent, type FollowMode, type HoldTargetElementResolver, type ScrollControllerMetrics, type ScrollControllerResult } from "./virtual-follow-behavior.ts"
@@ -157,6 +158,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
   let explicitBottomPinResolver: ((settlement: VirtualBottomSettlement) => void) | null = null
   let localBottomPinSequence = 0
   let programmaticScrollUntil = 0
+  let pendingVirtuaScroll = false
   let virtualItemKeys = virtualItems().map((item, index) => props.getKey(item, index))
   let plannedItems = virtualItems().slice()
   let plannedKeys = virtualItemKeys.slice()
@@ -230,10 +232,10 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
       dispatchFollowEvent({ type: "user-scroll", direction: "down", atBottom: true })
     }
     const element = scrollElement()
-    if (element) {
-      // Publish intent before notifying scroll listeners: otherwise old follow
-      // state can arm a programmatic pin and suppress user boundary navigation.
-      // Synchronize the live offset before replacing Virtua's pending operation.
+    if (element && pendingVirtuaScroll) {
+      // Replace an outstanding imperative operation once, not on every wheel
+      // or key repeat: scrollBy(0) itself creates a new measurement-time pin.
+      pendingVirtuaScroll = false
       element.dispatchEvent(new Event("scroll"))
       virtuaHandle()?.scrollBy(0)
     }
@@ -286,6 +288,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
     const nextOffset = Math.min(Math.max(offset, 0), maxOffset)
     markProgrammaticScroll()
     if (handle) {
+      pendingVirtuaScroll = true
       handle.scrollTo(nextOffset)
     } else {
       element.scrollTop = nextOffset
@@ -333,6 +336,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
     }
     if (!handle) return
     markProgrammaticScroll()
+    pendingVirtuaScroll = true
     handle.scrollToIndex(0, { align: "start", smooth: true })
   }
 
@@ -342,6 +346,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
     markProgrammaticScroll()
     // Large smooth jumps over dynamically measured items can leave Virtua's
     // mounted range behind the viewport. Semantic navigation must land first.
+    pendingVirtuaScroll = true
     virtuaHandle()?.scrollToIndex(index, { align: opts.block, smooth: false })
   }
 
@@ -653,6 +658,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
         const index = virtualItems().findIndex((item, i) => props.getKey(item, i) === snapshot.anchorKey)
         if (index !== -1) {
           markProgrammaticScroll()
+          pendingVirtuaScroll = true
           virtuaHandle()?.scrollToIndex(index, { align: "start", smooth: opts?.behavior === "smooth" })
           const stabilizer = new AnchorRestoreStabilizer()
           restartAnchorRestore = () => {
@@ -680,6 +686,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
     const index = virtualItems().findIndex((item, i) => props.getKey(item, i) === key)
     if (index === -1) return false
     markProgrammaticScroll()
+    pendingVirtuaScroll = true
     virtuaHandle()?.scrollToIndex(index, { align: "start", smooth: false })
     return true
   }
@@ -801,7 +808,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
       lastTouchY = null
     }
     const handleKeyIntent = (event: KeyboardEvent) => {
-      if (!isActive()) return
+      if (!isActive() || event.defaultPrevented) return
       if (!SCROLL_INTENT_KEYS.has(event.key)) return
       const target = event.target as HTMLElement | null
       const intent = getKeyboardScrollIntent({
@@ -811,6 +818,8 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
         textEditing: Boolean(target?.closest(TEXT_EDITING_KEY_TARGET_SELECTOR)),
       })
       if (!intent) return
+      const direction = intent.type === "top" ? "up" : intent.type === "bottom" ? "down" : intent.direction
+      if (nestedScrollerConsumes(event.target, direction)) return
       if (intent.type === "bottom") {
         event.preventDefault()
         jumpToBottom(true)
@@ -823,6 +832,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
       }
       markUserScrollIntent(intent.direction)
     }
+    const detachGestureRouting = attachScrollGestureRouting(element)
     element.addEventListener("wheel", handleWheelIntent, { passive: true })
     element.addEventListener("pointerdown", handlePointerIntent)
     element.addEventListener("pointermove", handlePointerMove)
@@ -834,6 +844,7 @@ export default function VirtualFollowList<T>(props: VirtualFollowListProps<T>) {
     element.addEventListener("touchcancel", handleTouchEnd, { passive: true })
     element.addEventListener("keydown", handleKeyIntent)
     detachScrollIntentListeners = () => {
+      detachGestureRouting()
       element.removeEventListener("wheel", handleWheelIntent)
       element.removeEventListener("pointerdown", handlePointerIntent)
       element.removeEventListener("pointermove", handlePointerMove)

--- a/packages/ui/src/lib/scroll-gesture-routing.ts
+++ b/packages/ui/src/lib/scroll-gesture-routing.ts
@@ -1,0 +1,137 @@
+const WHEEL_GESTURE_IDLE_MS = 180
+const MIDDLE_DEAD_ZONE_PX = 8
+
+function scrollAxes(node: HTMLElement) {
+  const style = getComputedStyle(node)
+  const scrolls = (overflow: string) => /^(auto|scroll|overlay)$/.test(overflow)
+  return {
+    x: scrolls(style.overflowX) && node.scrollWidth > node.clientWidth + 1,
+    y: scrolls(style.overflowY) && node.scrollHeight > node.clientHeight + 1,
+  }
+}
+
+function wheelTarget(root: HTMLElement, target: EventTarget | null, dy: number): HTMLElement {
+  let node = target instanceof Element ? target : null
+  while (node && node !== root) {
+    if (node instanceof HTMLElement) {
+      if (scrollAxes(node).y && (dy < 0 ? node.scrollTop > 0 : node.scrollTop + node.clientHeight < node.scrollHeight - 1)) return node
+    }
+    node = node.parentElement
+  }
+  return root
+}
+
+function middleTargets(root: HTMLElement, target: EventTarget | null) {
+  const owners: { x?: HTMLElement; y?: HTMLElement } = {}
+  for (let node = target instanceof Element ? target : null; node; node = node.parentElement) {
+    if (node instanceof HTMLElement) {
+      const axes = scrollAxes(node)
+      if (axes.x) owners.x ??= node
+      if (axes.y) owners.y ??= node
+    }
+    if (node === root) break
+  }
+  return owners
+}
+
+/** Keep an in-progress gesture on its starting scroller, not whatever row
+ * virtualization or pointer movement happens to place under the cursor next. */
+export function attachScrollGestureRouting(root: HTMLElement): () => void {
+  let wheelOwner: HTMLElement | undefined
+  let wheelAt = -Infinity
+  let middle: { owners: ReturnType<typeof middleTargets>; pointerId: number; x: number; y: number; dx: number; dy: number; time: number } | undefined
+  let frame: number | undefined
+
+  const wheel = (event: WheelEvent) => {
+    // Redispatched intent below is only for the existing follow controllers.
+    if (!event.isTrusted) return
+    // Leave zoom, native horizontal/Shift-wheel and uncancellable input alone.
+    if (event.ctrlKey || event.shiftKey || event.deltaX !== 0 || !event.deltaY || !event.cancelable || event.defaultPrevented) {
+      wheelOwner = undefined
+      return
+    }
+    const now = performance.now()
+    const target = wheelTarget(root, event.target, event.deltaY)
+    if (!wheelOwner?.isConnected || !root.contains(wheelOwner) || now - wheelAt > WHEEL_GESTURE_IDLE_MS) wheelOwner = target
+    // At an edge, chain only to an ancestor of the owner, never a new shell
+    // passing under the cursor during the same gesture.
+    wheelOwner = wheelTarget(root, wheelOwner, event.deltaY)
+    wheelAt = now
+    const owner = wheelOwner
+    if (owner === target) return
+    event.preventDefault()
+    event.stopPropagation()
+    owner.dispatchEvent(new WheelEvent("wheel", { deltaX: event.deltaX, deltaY: event.deltaY, deltaMode: event.deltaMode, bubbles: true }))
+    const unit = event.deltaMode === WheelEvent.DOM_DELTA_PAGE ? owner.clientHeight
+      : event.deltaMode === WheelEvent.DOM_DELTA_LINE ? parseFloat(getComputedStyle(owner).lineHeight) || 16 : 1
+    owner.scrollBy({ left: event.deltaX * unit, top: event.deltaY * unit, behavior: "instant" })
+  }
+
+  const stopMiddle = () => {
+    const active = middle
+    middle = undefined
+    if (frame !== undefined) cancelAnimationFrame(frame)
+    frame = undefined
+    if (active && root.hasPointerCapture(active.pointerId)) root.releasePointerCapture(active.pointerId)
+    if (active) root.style.cursor = previousCursor
+  }
+  let previousCursor = ""
+  const tick = (time: number) => {
+    frame = undefined
+    const active = middle
+    if (!active) return
+    if (Object.values(active.owners).some(owner => !root.contains(owner) || !owner.getClientRects().length)) return stopMiddle()
+    const elapsed = Math.min(time - active.time, 32) / 16.67
+    active.time = time
+    const speed = (distance: number) => Math.sign(distance) * Math.max(0, Math.abs(distance) - MIDDLE_DEAD_ZONE_PX) / 6
+    active.owners.x?.scrollBy({ left: speed(active.dx) * elapsed, behavior: "instant" })
+    active.owners.y?.scrollBy({ top: speed(active.dy) * elapsed, behavior: "instant" })
+    frame = requestAnimationFrame(tick)
+  }
+  const down = (event: PointerEvent) => {
+    if (!event.isTrusted || event.button !== 1 || event.defaultPrevented) return
+    // Preserve middle-click link opening and editable/control behavior.
+    if (event.target instanceof Element && event.target.closest("a[href],button,input,textarea,select,[contenteditable]:not([contenteditable='false']),[role='button'],[role='textbox']")) return
+    stopMiddle()
+    wheelOwner = undefined
+    const owners = middleTargets(root, event.target)
+    if (!owners.x && !owners.y) return
+    event.preventDefault()
+    middle = { owners, pointerId: event.pointerId, x: event.clientX, y: event.clientY, dx: 0, dy: 0, time: performance.now() }
+    previousCursor = root.style.cursor
+    root.style.cursor = "all-scroll"
+    root.setPointerCapture(event.pointerId)
+    frame = requestAnimationFrame(tick)
+    // Do not stop propagation: both nested and transcript follow controllers
+    // must relinquish automatic writes before the first drag frame.
+  }
+  const move = (event: PointerEvent) => {
+    if (!middle || event.pointerId !== middle.pointerId) return
+    if ((event.buttons & 4) === 0) return stopMiddle()
+    middle.dx = event.clientX - middle.x
+    middle.dy = event.clientY - middle.y
+  }
+  const end = (event: PointerEvent) => {
+    if (middle && event.pointerId === middle.pointerId) stopMiddle()
+  }
+  const visibility = () => { if (document.hidden) stopMiddle() }
+  root.addEventListener("wheel", wheel, { capture: true, passive: false })
+  root.addEventListener("pointerdown", down, true)
+  root.addEventListener("pointermove", move)
+  root.addEventListener("pointerup", end)
+  root.addEventListener("pointercancel", end)
+  root.addEventListener("lostpointercapture", end)
+  window.addEventListener("blur", stopMiddle)
+  document.addEventListener("visibilitychange", visibility)
+  return () => {
+    stopMiddle()
+    root.removeEventListener("wheel", wheel, true)
+    root.removeEventListener("pointerdown", down, true)
+    root.removeEventListener("pointermove", move)
+    root.removeEventListener("pointerup", end)
+    root.removeEventListener("pointercancel", end)
+    root.removeEventListener("lostpointercapture", end)
+    window.removeEventListener("blur", stopMiddle)
+    document.removeEventListener("visibilitychange", visibility)
+  }
+}

--- a/packages/ui/tests/browser/fixtures/scroll-input.tsx
+++ b/packages/ui/tests/browser/fixtures/scroll-input.tsx
@@ -1,0 +1,33 @@
+import { createSignal } from "solid-js"
+import { render } from "solid-js/web"
+import ToolCall from "../../../src/components/tool-call"
+import VirtualFollowList, { type VirtualFollowListApi } from "../../../src/components/virtual-follow-list"
+import { ConfigProvider } from "../../../src/stores/preferences"
+import { I18nProvider } from "../../../src/lib/i18n"
+import { ThemeProvider } from "../../../src/lib/theme"
+import type { ToolCallPart } from "../../../src/components/tool-call/types"
+import "../../../src/index.css"
+
+const output = Array.from({ length: 160 }, (_, i) => `Shell output line ${i}`).join("\n")
+const [items, setItems] = createSignal(Array.from({ length: 30 }, (_, i): ToolCallPart => ({
+  id: `tool-${i}`, type: "tool", callID: `call-${i}`, tool: "shell",
+  state: { status: "completed", input: {}, output },
+})))
+let api: VirtualFollowListApi | undefined
+function Transcript() {
+  return <VirtualFollowList items={items} getKey={item => item.id}
+    registerApi={value => { api = value }}
+    renderItem={item => <div style={{ width: "650px", padding: "30px 0" }}>
+      <ToolCall toolCall={item} messageId={`message-${item.id}`} instanceId="scroll-fixture"
+        sessionId="session-fixture" onContentRendered={() => api?.notifyContentRendered()} />
+    </div>} />
+}
+render(() => <ConfigProvider><I18nProvider><ThemeProvider>
+  <Transcript />
+</ThemeProvider></I18nProvider></ConfigProvider>, document.getElementById("root")!)
+;(window as any).fixture = {
+  bottom: () => api?.scrollToBottom({ immediate: true }),
+  top: () => api?.scrollToTop({ immediate: true }),
+  append: () => setItems(items => [...items, { ...items[0], id: `tool-${items.length}`, callID: `call-${items.length}` }]),
+  snapshot: () => ({ outerFollow: api?.getAutoScroll(), outerTop: api?.getScrollElement()?.scrollTop }),
+}

--- a/packages/ui/tests/browser/session-rendering.test.ts
+++ b/packages/ui/tests/browser/session-rendering.test.ts
@@ -13,7 +13,7 @@ before(async () => {
       name: "browser-fixture",
       configureServer(server) {
         server.middlewares.use("/fixture", async (req, res) => {
-          const name = ["tall-append", "nested-scroll", "navigation", "undo", "tool-reprojection"].find(name => req.url?.includes(name)) ?? "session"
+          const name = ["tall-append", "nested-scroll", "navigation", "undo", "tool-reprojection", "scroll-input"].find(name => req.url?.includes(name)) ?? "session"
           res.setHeader("Content-Type", "text/html")
           res.end(await server.transformIndexHtml("/fixture", `<html><body><div id="root" style="display:flex;height:700px;width:1100px"></div><script type="module" src="/tests/browser/fixtures/${name}.tsx"></script></body></html>`))
         })
@@ -514,13 +514,12 @@ for (const operation of ["append", "roll"]) test(`middle-button scrolling owns n
     assert.equal(await output.locator("..").getAttribute("data-item-index"), operation === "roll" ? "28" : "29",
       "Keeping the keyed child must not freeze its shifted index")
     try {
-      // Native middle autoscroll can begin well after pointerdown, then continue
-      // outside the child. Simulate its scroll ticks, not a wheel event: this
-      // exercises the real nested/outer follow controllers and renderer writes.
+      // Delay motion beyond the intent deadline, then drive the actual drag.
+      // Do not write scrollTop: controller-only simulation hid the old MMB bug.
       const started = await page.evaluate(() => performance.now())
       await page.waitForFunction(start => performance.now() - start > 800, started)
       await page.mouse.move(bounds.x + 650, bounds.y + 30)
-      await output.evaluate(el => { el.scrollTop = 900 })
+      await page.waitForFunction(() => document.querySelector("[data-nested-output]")!.scrollTop < 1200)
       await page.evaluate(`new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))`)
       let before = await output.evaluate(el => el.scrollTop)
       for (let i = 0; i < 5; i++) {
@@ -534,6 +533,173 @@ for (const operation of ["append", "roll"]) test(`middle-button scrolling owns n
       assert.equal(state.innerFollow, false)
       assert.equal(state.outerFollow, false)
     } finally { await page.mouse.up({ button: "middle" }) }
+  })
+})
+
+test("native MMB drag started inside output keeps scrolling output outside its bounds", async () => {
+  await open("nested-scroll", async page => {
+    await page.evaluate(() => (window as any).fixture.bottom())
+    const output = page.locator("[data-nested-output]")
+    await output.waitFor({ state: "visible" })
+    await page.evaluate(() => (window as any).fixture.renderOutput())
+    await page.waitForFunction(() => (document.querySelector("[data-nested-output]")?.scrollTop ?? 0) > 1000)
+    await page.evaluate(`new Promise(resolve => { let n = 30; const frame = () => --n ? requestAnimationFrame(frame) : resolve(); requestAnimationFrame(frame) })`)
+    const box = (await output.boundingBox())!
+    const before = await page.evaluate(() => (window as any).fixture.snapshot())
+    await page.mouse.move(box.x + 100, box.y + 140)
+    await page.mouse.down({ button: "middle" })
+    try {
+      await page.mouse.move(box.x + box.width + 60, box.y + 40, { steps: 10 })
+      await page.waitForFunction(() => (document.querySelector("[data-nested-output]")?.scrollTop ?? Infinity) < 1000, undefined, { timeout: 3000 })
+      const after = await page.evaluate(() => (window as any).fixture.snapshot())
+      assert.ok(Math.abs(after.outerTop - before.outerTop) < 2, "A child-owned drag must not move the transcript")
+    } finally { await page.mouse.up({ button: "middle" }) }
+  })
+})
+
+for (const key of ["ArrowUp", "PageUp"]) test(`native repeated ${key} keeps moving the transcript`, async () => {
+  await open("nested-scroll", async page => {
+    await page.evaluate(() => (window as any).fixture.bottom())
+    const stream = page.locator(".message-stream")
+    await stream.focus()
+    const before = await stream.evaluate(el => el.scrollTop)
+    for (let i = 0; i < 12; i++) {
+      await page.keyboard.down(key)
+      await page.evaluate(`new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))`)
+    }
+    await page.keyboard.up(key)
+    await page.evaluate(`new Promise(resolve => { let n = 30; const frame = () => --n ? requestAnimationFrame(frame) : resolve(); requestAnimationFrame(frame) })`)
+    const after = await stream.evaluate(el => el.scrollTop)
+    assert.ok(before - after > (key === "ArrowUp" ? 200 : 1500), `${key} did not progress: ${before} -> ${after}`)
+  })
+})
+
+test("real shell output accepts native MMB drag without moving its transcript", async () => {
+  await open("scroll-input", async page => {
+    await page.evaluate(() => (window as any).fixture.bottom())
+    await page.locator('[data-virtual-follow-key="tool-29"] .tool-call-header').click()
+    const output = page.locator('[data-virtual-follow-key="tool-29"] .tool-call-markdown')
+    await output.waitFor({ state: "visible" })
+    await page.evaluate(`new Promise(resolve => { let n = 60; const frame = () => --n ? requestAnimationFrame(frame) : resolve(); requestAnimationFrame(frame) })`)
+    const box = (await output.boundingBox())!
+    const before = await page.evaluate(() => (window as any).fixture.snapshot())
+    await page.mouse.move(box.x + 100, Math.max(box.y + 50, 50))
+    await page.mouse.down({ button: "middle" })
+    try {
+      await page.mouse.move(box.x + box.width + 60, Math.min(box.y + 200, 650), { steps: 10 })
+      await page.waitForFunction(() => (document.querySelector('[data-virtual-follow-key="tool-29"] .tool-call-markdown')?.scrollTop ?? 0) > 100, undefined, { timeout: 3000 })
+      const after = await page.evaluate(() => (window as any).fixture.snapshot())
+      assert.ok(Math.abs(after.outerTop - before.outerTop) < 2, "Child drag moved transcript")
+    } finally { await page.mouse.up({ button: "middle" }) }
+  })
+})
+
+for (const key of ["ArrowUp", "PageUp"]) test(`real shell transcript repeated ${key} keeps progressing`, async () => {
+  await open("scroll-input", async page => {
+    await page.evaluate(() => (window as any).fixture.bottom())
+    await page.locator('[data-virtual-follow-key="tool-29"] .tool-call-header').click()
+    await page.locator('[data-virtual-follow-key="tool-29"] .tool-call-markdown').waitFor({ state: "visible" })
+    await page.evaluate(`new Promise(resolve => { let n = 60; const frame = () => --n ? requestAnimationFrame(frame) : resolve(); requestAnimationFrame(frame) })`)
+    const stream = page.locator(".message-stream")
+    await stream.focus()
+    const before = await stream.evaluate(el => el.scrollTop)
+    for (let i = 0; i < 24; i++) {
+      await page.keyboard.down(key)
+      await page.evaluate(`new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))`)
+    }
+    await page.keyboard.up(key)
+    await page.evaluate(`new Promise(resolve => { let n = 30; const frame = () => --n ? requestAnimationFrame(frame) : resolve(); requestAnimationFrame(frame) })`)
+    const after = await stream.evaluate(el => el.scrollTop)
+    assert.ok(before - after > (key === "ArrowUp" ? 500 : 1500), `${key} did not progress: ${before} -> ${after}`)
+  })
+})
+
+test("a wheel gesture started in the transcript is not stolen by a passing shell", async () => {
+  await open("scroll-input", async page => {
+    await page.evaluate(() => (window as any).fixture.bottom())
+    await page.locator('[data-virtual-follow-key="tool-29"] .tool-call-header').click()
+    const output = page.locator('[data-virtual-follow-key="tool-29"] .tool-call-markdown')
+    await output.waitFor({ state: "visible" })
+    await page.evaluate(`new Promise(resolve => { let n = 60; const frame = () => --n ? requestAnimationFrame(frame) : resolve(); requestAnimationFrame(frame) })`)
+    await output.evaluate(el => { el.scrollTop = 1000 })
+    const stream = page.locator(".message-stream")
+    const box = (await output.boundingBox())!
+    const before = await stream.evaluate(el => el.scrollTop)
+    // Keep the cursor stationary below the output: scrolling upward brings
+    // that output under it, just as in the reported regression.
+    await page.mouse.move(box.x + 100, box.y + box.height + 20)
+    await page.mouse.wheel(0,-80)
+    await page.evaluate(`new Promise(resolve => requestAnimationFrame(resolve))`)
+    for (let i = 0; i < 5; i++) {
+      await page.mouse.wheel(0, -80)
+      await page.evaluate(`new Promise(resolve => requestAnimationFrame(resolve))`)
+    }
+    await page.evaluate(`new Promise(resolve => { let n = 30; const frame = () => --n ? requestAnimationFrame(frame) : resolve(); requestAnimationFrame(frame) })`)
+    const after = await stream.evaluate(el => el.scrollTop)
+    assert.ok(before - after > 350, `Shell stole the ongoing wheel gesture: ${before} -> ${after}`)
+  })
+})
+
+test("MMB started in the transcript stays there over a shell and stops on release", async () => {
+  await open("nested-scroll", async page => {
+    await page.evaluate(() => (window as any).fixture.bottom())
+    const output = page.locator("[data-nested-output]")
+    await output.waitFor({ state: "visible" })
+    await page.evaluate(() => (window as any).fixture.renderOutput())
+    await page.evaluate(`new Promise(resolve => { let n = 30; const frame = () => --n ? requestAnimationFrame(frame) : resolve(); requestAnimationFrame(frame) })`)
+    const box = (await output.boundingBox())!
+    const before = await page.evaluate(() => (window as any).fixture.snapshot())
+    await page.mouse.move(box.x + 100, box.y + box.height + 25)
+    await page.mouse.down({ button: "middle" })
+    try {
+      await page.mouse.move(box.x + 100, box.y + 120, { steps: 10 })
+      await page.waitForFunction(before => (window as any).fixture.snapshot().outerTop < before - 80, before.outerTop)
+      assert.equal(await output.evaluate(el => el.scrollTop), before.savedTop, "The shell must not steal a transcript drag")
+    } finally { await page.mouse.up({ button: "middle" }) }
+    const stopped = await page.evaluate(() => (window as any).fixture.snapshot().outerTop)
+    await page.evaluate(`new Promise(resolve => { let n = 20; const frame = () => --n ? requestAnimationFrame(frame) : resolve(); requestAnimationFrame(frame) })`)
+    assert.equal(await page.evaluate(() => (window as any).fixture.snapshot().outerTop), stopped)
+  })
+})
+
+for (const key of ["ArrowUp", "ArrowDown", "PageUp", "PageDown", "Home", "End"]) test(`focused shell owns ${key} without moving the transcript`, async () => {
+  await open("nested-scroll", async page => {
+    await page.evaluate(() => (window as any).fixture.bottom())
+    const output = page.locator("[data-nested-output]")
+    await output.waitFor({ state: "visible" })
+    await page.evaluate(() => (window as any).fixture.renderOutput())
+    await page.evaluate(`new Promise(resolve => { let n = 30; const frame = () => --n ? requestAnimationFrame(frame) : resolve(); requestAnimationFrame(frame) })`)
+    await output.evaluate(el => { el.tabIndex = 0; el.scrollTop = 700; el.focus() })
+    const before = await page.evaluate(() => (window as any).fixture.snapshot().outerTop)
+    await page.keyboard.press(key)
+    const up = ["ArrowUp", "PageUp", "Home"].includes(key)
+    await page.waitForFunction(up => {
+      const top = document.querySelector("[data-nested-output]")!.scrollTop
+      return up ? top < 695 : top > 705
+    }, up)
+    await page.evaluate(`new Promise(resolve => { let n = 20; const frame = () => --n ? requestAnimationFrame(frame) : resolve(); requestAnimationFrame(frame) })`)
+    assert.equal(await page.evaluate(() => (window as any).fixture.snapshot().outerTop), before)
+  })
+})
+
+test("a new wheel gesture can select the shell, then chain to its ancestor at the edge", async () => {
+  await open("nested-scroll", async page => {
+    await page.evaluate(() => (window as any).fixture.bottom())
+    const output = page.locator("[data-nested-output]")
+    await output.waitFor({ state: "visible" })
+    await page.evaluate(() => (window as any).fixture.renderOutput())
+    await page.evaluate(`new Promise(resolve => { let n = 30; const frame = () => --n ? requestAnimationFrame(frame) : resolve(); requestAnimationFrame(frame) })`)
+    await output.evaluate(el => { el.scrollTop = 120 })
+    const box = (await output.boundingBox())!
+    const before = await page.evaluate(() => (window as any).fixture.snapshot().outerTop)
+    await page.mouse.move(box.x + 100, box.y + 100)
+    await page.mouse.wheel(0, -80)
+    await page.waitForFunction(() => document.querySelector("[data-nested-output]")!.scrollTop < 100)
+    assert.equal(await page.evaluate(() => (window as any).fixture.snapshot().outerTop), before)
+    await page.mouse.wheel(0, -80)
+    await page.waitForFunction(() => document.querySelector("[data-nested-output]")!.scrollTop === 0)
+    await page.mouse.wheel(0, -160)
+    await page.waitForFunction(before => (window as any).fixture.snapshot().outerTop < before - 80, before)
   })
 })
 
@@ -559,5 +725,94 @@ test("nested scroll ownership cancels an already queued bottom write and can exp
       el.dispatchEvent(new Event("scroll"))
     })
     assert.equal((await page.evaluate(() => (window as any).fixture.snapshot())).innerFollow, true)
+  })
+})
+
+async function openScrollableOutput(run: (page: Page) => Promise<void>) {
+  await open("nested-scroll", async page => {
+    await page.evaluate(() => (window as any).fixture.bottom())
+    await page.locator("[data-nested-output]").waitFor({ state: "visible" })
+    await page.evaluate(() => (window as any).fixture.renderOutput())
+    await page.waitForFunction(() => document.querySelector("[data-nested-output]")!.scrollTop > 1000)
+    await page.evaluate(`new Promise(resolve => { let n = 30; const frame = () => --n ? requestAnimationFrame(frame) : resolve(); requestAnimationFrame(frame) })`)
+    await run(page)
+  })
+}
+
+async function makeHorizontalCode(page: Page) {
+  await page.locator("[data-nested-output] pre").evaluate(el => {
+    el.style.overflow = "auto"
+    const code = el.querySelector("code")!
+    code.style.display = "block"
+    code.style.width = "1800px"
+    code.style.height = "1600px"
+  })
+}
+
+test("MMB selects independent axes when horizontal code is inside a vertical shell", async () => {
+  await openScrollableOutput(async page => {
+    await makeHorizontalCode(page)
+    const output = page.locator("[data-nested-output]")
+    const box = (await output.boundingBox())!
+    const before = await page.locator(".message-stream").evaluate(el => el.scrollTop)
+    await page.mouse.move(box.x + 100, box.y + 140)
+    await page.mouse.down({ button: "middle" })
+    try {
+      await page.mouse.move(box.x + 250, box.y + 40, { steps: 10 })
+      await page.waitForFunction(() => document.querySelector("[data-nested-output]")!.scrollTop < 1100, undefined, { timeout: 3000 })
+      assert.ok(await output.locator("pre").evaluate(el => el.scrollLeft) > 50, "Code must still pan horizontally")
+      assert.equal(await page.locator(".message-stream").evaluate(el => el.scrollTop), before)
+    } finally { await page.mouse.up({ button: "middle" }) }
+  })
+})
+
+test("hiding a session cancels its captured MMB gesture instead of resuming it on return", async () => {
+  await openScrollableOutput(async page => {
+    const stream = page.locator(".message-stream")
+    const output = page.locator("[data-nested-output]")
+    const box = (await output.boundingBox())!
+    await page.mouse.move(box.x + 100, box.y + 140)
+    await page.mouse.down({ button: "middle" })
+    try {
+      await page.mouse.move(box.x + 100, box.y + 40)
+      await page.waitForFunction(() => document.querySelector("[data-nested-output]")!.scrollTop < 1300)
+      await stream.evaluate(el => { el.style.display = "none" })
+      await page.evaluate(`new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))`)
+      assert.equal(await stream.evaluate(el => el.style.cursor), "", "Hidden pane retained its active gesture")
+      await stream.evaluate(el => { el.style.display = "" })
+      const stopped = await output.evaluate(el => el.scrollTop)
+      await page.evaluate(`new Promise(resolve => { let n = 20; const frame = () => --n ? requestAnimationFrame(frame) : resolve(); requestAnimationFrame(frame) })`)
+      assert.equal(await output.evaluate(el => el.scrollTop), stopped)
+    } finally { await page.mouse.up({ button: "middle" }) }
+  })
+})
+
+test("a descendant's prevented Home cannot trigger transcript navigation", async () => {
+  await openScrollableOutput(async page => {
+    const output = page.locator("[data-nested-output]")
+    await output.evaluate(el => {
+      el.scrollTop = 0
+      el.tabIndex = 0
+      el.addEventListener("keydown", event => event.preventDefault())
+      el.focus()
+    })
+    const before = await page.locator(".message-stream").evaluate(el => el.scrollTop)
+    await page.keyboard.press("Home")
+    await page.evaluate(`new Promise(resolve => { let n = 30; const frame = () => --n ? requestAnimationFrame(frame) : resolve(); requestAnimationFrame(frame) })`)
+    assert.equal(await page.locator(".message-stream").evaluate(el => el.scrollTop), before)
+  })
+})
+
+test("Shift-wheel remains horizontal after a transcript wheel gesture", async () => {
+  await openScrollableOutput(async page => {
+    await makeHorizontalCode(page)
+    const output = page.locator("[data-nested-output]")
+    const box = (await output.boundingBox())!
+    await page.mouse.move(box.x + 100, box.y + box.height + 20)
+    await page.mouse.wheel(0, -80)
+    await page.mouse.move(box.x + 100, box.y + 120)
+    await page.keyboard.down("Shift")
+    try { await page.mouse.wheel(0, 200) } finally { await page.keyboard.up("Shift") }
+    await page.waitForFunction(() => document.querySelector("[data-nested-output] pre")!.scrollLeft > 50, undefined, { timeout: 3000 })
   })
 })


### PR DESCRIPTION
## Summary

Follow up on the MMB, wheel and keyboard scrolling regressions reported after #683.

- Keep middle-button drags on the scrollers selected at pointerdown until release, even when the pointer leaves their bounds. Resolve horizontal and vertical owners independently for wide code nested inside a vertically scrolling shell.
- Keep a continuous vertical wheel gesture on its starting scroller so a shell passing under a stationary pointer cannot steal it. Allow ancestor chaining at an edge; leave horizontal/Shift-wheel, zoom and uncancellable events to the browser.
- Replace an outstanding Virtua imperative scroll only once on user intent instead of issuing `scrollBy(0)` on every wheel/key event and creating another measurement-time pin.
- Leave navigation keys with a nested scroller that can consume them, and respect events already prevented by descendant controls.
- End captured MMB gestures on release, cancellation, lost capture, blur, hidden/detached content or cleanup. Preserve normal link, editor and control behavior.

## Review and regressions

Review identified three additional defects, each reproduced by a failing browser test before correction:

1. Horizontal code could swallow vertical MMB movement intended for the containing shell.
2. Hiding a session did not terminate its captured MMB gesture.
3. A prevented `Home` event could still navigate the transcript.

The subsequent scoped review identified no remaining actionable findings. Existing MMB tests now drive actual mouse movement rather than writing `scrollTop` to simulate the drag. Tests exercise the real Solid virtual list/follow controllers and a real `ToolCall` fixture.

## Validation

Validated source: `5b1926cf8e9464a8828ff68ec33852ca94567950`.

- 43/43 Chromium browser tests, in two complete runs.
- 57/57 focused virtual-scroll behavior, measurement and reader-settlement tests.
- UI and Electron typechecks.
- Windows Tauri release build (`--no-bundle`).
- 14 targeted checks in the rebuilt Tauri/WebView2 application: both MMB starting zones, release, stationary-cursor wheel routing across a passing shell, six navigation keys in a focused shell, and repeated transcript Arrow/Page keys.
- Verified that the loaded source maps match the reviewed source files; captured native screenshot evidence.
- `git diff --check`.

Native release executable SHA-256: `BC2EDF02138440691008DD1E1F4B28EF12E5C76555F681D299D6ED8827013735`.

These are targeted checks, not a claim of exhaustive desktop or cross-platform coverage. An initial native test run lost its target DOM element; the completed-shell-targeted rerun passed all 14 checks. The user's separate UI #667 executable was restored unchanged after validation; no UI-worktree changes are included here. GitHub CI remains separate from these local checks.

## Scope / maintenance

Only four files change. No preferences, translations, dependencies or native-host implementation changes. `packages/ui/src/components/virtual-follow-list.tsx` is an existing oversized file (~1,188 lines); the gesture routing is isolated in a focused helper rather than adding a general refactor.
